### PR TITLE
Run admin-gui web pp with an embedded jetty

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 .settings
 .idea
 *.iml
+*.log
 *.versionsBackup
 target
 rebel.xml

--- a/build-system/pom.xml
+++ b/build-system/pom.xml
@@ -1171,18 +1171,6 @@
 			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-jar-plugin</artifactId>
-				<executions>
-					<execution>
-						<goals>
-							<goal>test-jar</goal>
-						</goals>
-					</execution>
-				</executions>
-				<version>2.4</version>
-			</plugin>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-source-plugin</artifactId>
 				<version>2.2.1</version>
 				<executions>
@@ -1229,11 +1217,18 @@
 						</manifestEntries>
 					</archive>
 				</configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>test-jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
 			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-war-plugin</artifactId>
-				<version>2.4</version>
+				<version>2.6</version>
 				<configuration>
 					<archive>
 						<manifestEntries>
@@ -1253,11 +1248,27 @@
 				<version>2.4</version> <configuration> <configLocation>http:///svn/coding-rules/CheckStyle-rules.xml</configLocation> 
 				<includeTestSourceDirectory>false</includeTestSourceDirectory> </configuration> 
 				</plugin -->
-			<plugin>
-				<groupId>org.mortbay.jetty</groupId>
-				<artifactId>jetty-maven-plugin</artifactId>
-				<version>7.0.1.v20091125</version>
-			</plugin>
+            <plugin>
+                <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-maven-plugin</artifactId>
+                <version>9.3.10.v20160621</version>
+                <configuration>
+                    <systemProperties>
+                        <systemProperty>
+                            <name>org.eclipse.jetty.annotations.maxWait</name>
+                            <value>240</value>
+                        </systemProperty>
+                    </systemProperties>
+                    <webApp>
+                        <contextPath>/midpoint</contextPath>
+                        <!-- <overrideDescriptor>${basedir}/etc/jetty/web.xml</overrideDescriptor> -->
+                    </webApp>
+                    <webAppConfig>
+                        <allowDuplicateFragmentNames>true</allowDuplicateFragmentNames>
+                    </webAppConfig>
+                    <jvmArgs>-Xdebug -Xrunjdwp:transport=dt_socket,address=5000,server=y,suspend=n</jvmArgs>
+                </configuration>
+            </plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>

--- a/gui/admin-gui/pom.xml
+++ b/gui/admin-gui/pom.xml
@@ -784,22 +784,22 @@
                 <activeByDefault>true</activeByDefault>
             </activation>
 
-	    <dependencies>
-		<dependency>
-                        <artifactId>jaxb-impl</artifactId>
-                        <groupId>com.sun.xml.bind</groupId>
-                        <scope>runtime</scope>
+            <dependencies>
+                <dependency>
+                    <artifactId>jaxb-impl</artifactId>
+                    <groupId>com.sun.xml.bind</groupId>
+                    <scope>runtime</scope>
                 </dependency>
                 <dependency>
-                        <artifactId>jaxb-api</artifactId>
-                        <groupId>javax.xml.bind</groupId>
+                    <artifactId>jaxb-api</artifactId>
+                    <groupId>javax.xml.bind</groupId>
                 </dependency>
                 <dependency>
-                        <artifactId>jaxb-core</artifactId>
-                        <groupId>com.sun.xml.bind</groupId>
-                        <scope>runtime</scope>
-		</dependency>
-	    </dependencies>
+                    <artifactId>jaxb-core</artifactId>
+                    <groupId>com.sun.xml.bind</groupId>
+                    <scope>runtime</scope>
+                </dependency>
+            </dependencies>
 
         </profile>
 


### PR DESCRIPTION
- Fix minor formatting issues in the pom
- Let the admin gui (i.e midpoint.war) to be deployed via an embedded jetty instance. (Would have done the same for Tomcat, except tomcat plugins are terrible)

Basically, you'd do this:

```
cd midpoint/gui/admin-gui
mvn jetty:run-forked
```

Then go to `localhost:8080/midpoint` and login. 

Don't ask developers to download a separate tomcat instance to test. More work for them :) 