### PR TITLE
Fix spelling of 'query'

### DIFF
--- a/model/model-impl/src/test/resources/sync/action/account/group-change.xml
+++ b/model/model-impl/src/test/resources/sync/action/account/group-change.xml
@@ -456,7 +456,7 @@
 			<i:correlation> <!-- Correlation rule is a search query -->
 				<!-- The clause <c:type uri="http://midpoint.evolveum.com/xml/ns/public/common/common-3#UserType"/> 
 					is implicit in correlation rules -->
-				<!-- Following search queury will look for users that have "name" equal 
+				<!-- Following search query will look for users that have "name" equal 
 					to the "uid" attribute of the account. Simply speaking, it will look for 
 					match in usernames in the IDM and the resource. -->
 				<c:equal>

--- a/model/model-impl/src/test/resources/sync/action/user/existing-user-change.xml
+++ b/model/model-impl/src/test/resources/sync/action/user/existing-user-change.xml
@@ -457,7 +457,7 @@
 			<i:correlation> <!-- Correlation rule is a search query -->
 				<!-- The clause <c:type uri="http://midpoint.evolveum.com/xml/ns/public/common/common-3#UserType"/> 
 					is implicit in correlation rules -->
-				<!-- Following search queury will look for users that have "name" equal 
+				<!-- Following search query will look for users that have "name" equal 
 					to the "uid" attribute of the account. Simply speaking, it will look for 
 					match in usernames in the IDM and the resource. -->
 				<c:equal>

--- a/model/model-impl/src/test/resources/sync/change-correct.xml
+++ b/model/model-impl/src/test/resources/sync/change-correct.xml
@@ -437,7 +437,7 @@
             <i:correlation> <!-- Correlation rule is a search query -->
                 <!-- The clause <c:type uri="http://midpoint.evolveum.com/xml/ns/public/common/common-3#UserType"/> is implicit in
                         correlation rules -->
-                <!-- Following search queury will look for users that have "name" equal to the "uid" attribute of the account. Simply
+                <!-- Following search query will look for users that have "name" equal to the "uid" attribute of the account. Simply
                         speaking, it will look for match in usernames in the IDM and the resource. -->
                 <c:equal>
                     <c:path>.</c:path>

--- a/model/model-impl/src/test/resources/sync/change-without-object.xml
+++ b/model/model-impl/src/test/resources/sync/change-without-object.xml
@@ -405,7 +405,7 @@
 			<i:correlation> <!-- Correlation rule is a search query -->
 				<!-- The clause <c:type uri="http://midpoint.evolveum.com/xml/ns/public/common/common-3#UserType"/> is implicit in 
 					correlation rules -->
-				<!-- Following search queury will look for users that have "name" equal to the "uid" attribute of the account. Simply 
+				<!-- Following search query will look for users that have "name" equal to the "uid" attribute of the account. Simply 
 					speaking, it will look for match in usernames in the IDM and the resource. -->
 				<c:equal>
 					<c:path>.</c:path>

--- a/repo/audit-api/src/main/java/com/evolveum/midpoint/audit/api/AuditEventType.java
+++ b/repo/audit-api/src/main/java/com/evolveum/midpoint/audit/api/AuditEventType.java
@@ -24,25 +24,25 @@ import com.evolveum.midpoint.xml.ns._public.common.audit_3.AuditEventTypeType;
  *
  */
 public enum AuditEventType {
-	
+
 	GET_OBJECT,
-	
+
 	ADD_OBJECT,
-	
+
 	MODIFY_OBJECT,
-	
+
 	DELETE_OBJECT,
-	
+
 	EXECUTE_CHANGES_RAW,
-	
+
 	SYNCHRONIZATION,
 	//  ....
-		
+
 	/**
 	 * E.g. login
 	 */
 	CREATE_SESSION,
-	
+
 	/**
 	 * E.g. logout
 	 */
@@ -54,28 +54,28 @@ public enum AuditEventType {
     WORK_ITEM,
 
     WORKFLOW_PROCESS_INSTANCE,
-    
+
     RECONCILIATION;
 
     /**
-     * Queury session, modify session
+     * Query session, modify session
      */
-	
+
 	/**
-	 * Task states??? 
+	 * Task states???
 	 */
 
 	/**
 	 * Startup, shutdown, critical failure (whole system)
 	 */
-	
+
 	// backup, restores
-    
+
     public static AuditEventType toAuditEventType(AuditEventTypeType event){
     	if (event == null){
     		return null;
     	}
-    	
+
     	switch (event){
 			case ADD_OBJECT:
 				return AuditEventType.ADD_OBJECT;
@@ -101,16 +101,16 @@ public enum AuditEventType {
 				return AuditEventType.WORKFLOW_PROCESS_INSTANCE;
 			default:
 				throw new IllegalArgumentException("Unknown audit event type: " + event);
-					
+
     	}
-    	
+
     }
-    
+
     public static AuditEventTypeType fromAuditEventType(AuditEventType event){
     	if (event == null){
     		return null;
     	}
-    	
+
     	switch (event){
 			case ADD_OBJECT:
 				return AuditEventTypeType.ADD_OBJECT;
@@ -136,9 +136,9 @@ public enum AuditEventType {
 				return AuditEventTypeType.WORKFLOW_PROCESS_INSTANCE;
 			default:
 				throw new IllegalArgumentException("Unknown audit event type: " + event);
-					
+
     	}
-    	
+
     }
 
 }

--- a/repo/repo-sql-impl-test/src/test/resources/basic/objects.xml
+++ b/repo/repo-sql-impl-test/src/test/resources/basic/objects.xml
@@ -540,7 +540,7 @@
             <correlation>
                 <q:description>
                     Correlation expression is a search query.
-                    Following search queury will look for users that have "name"
+                    Following search query will look for users that have "name"
                     equal to the "uid" attribute of the account. Simply speaking,
                     it will look for match in usernames in the IDM and the resource.
                     The correlation rule always looks for users, so it will not match

--- a/repo/repo-sql-impl-test/src/test/resources/modify/resource-csv.xml
+++ b/repo/repo-sql-impl-test/src/test/resources/modify/resource-csv.xml
@@ -239,7 +239,7 @@ object.
 	            <correlation>
 	                <q:description>
 	                    Correlation expression is a search query.
-	                    Following search queury will look for users that have "name"
+	                    Following search query will look for users that have "name"
 	                    equal to the "name" attribute of the account. Simply speaking,
 	                    it will look for match in usernames in the IDM and the resource.
 	                    The correlation rule always looks for users, so it will not match

--- a/repo/repo-sql-impl-test/src/test/resources/modify/resource-opendj.xml
+++ b/repo/repo-sql-impl-test/src/test/resources/modify/resource-opendj.xml
@@ -466,7 +466,7 @@ object.
 	            <correlation>
 	                <q:description>
 	                    Correlation expression is a search query.
-	                    Following search queury will look for users that have "name"
+	                    Following search query will look for users that have "name"
 	                    equal to the "uid" attribute of the account. Simply speaking,
 	                    it will look for match in usernames in the IDM and the resource.
 	                    The correlation rule always looks for users, so it will not match

--- a/samples/demo-generic synchronization/resource-GenSync-OpenDJ.xml
+++ b/samples/demo-generic synchronization/resource-GenSync-OpenDJ.xml
@@ -13431,7 +13431,7 @@
 				<correlation>
 						<q:description>
 							Correlation expression is a search query.
-							Following search queury will look for users that have "name"
+							Following search query will look for users that have "name"
 							equal to the "uid" attribute of the account. Simply speaking,
 							it will look for match in usernames in the IDM and the resource.
 							The correlation rule always looks for users, so it will not match

--- a/samples/demo-rs/resource-csv-source.xml
+++ b/samples/demo-rs/resource-csv-source.xml
@@ -210,7 +210,7 @@ object.
 				<correlation>
 					<q:description>
 	                    Correlation expression is a search query.
-	                    Following search queury will look for users that have "name"
+	                    Following search query will look for users that have "name"
 	                    equal to the "name" attribute of the account. Simply speaking,
 	                    it will look for match in usernames in the IDM and the resource.
 	                    The correlation rule always looks for users, so it will not match

--- a/samples/demo-rs/resource-csv-xxx.xml
+++ b/samples/demo-rs/resource-csv-xxx.xml
@@ -237,7 +237,7 @@ object.
 				<correlation>
 					<q:description>
 	                    Correlation expression is a search query.
-	                    Following search queury will look for users that have "name"
+	                    Following search query will look for users that have "name"
 	                    equal to the "name" attribute of the account. Simply speaking,
 	                    it will look for match in usernames in the IDM and the resource.
 	                    The correlation rule always looks for users, so it will not match

--- a/samples/demo-rs/resource-ldap-openldap.xml
+++ b/samples/demo-rs/resource-ldap-openldap.xml
@@ -498,7 +498,7 @@ It also contains inbound mappings and definition to enable synchronization.
 	            <correlation>
 	                <q:description>
 	                    Correlation expression is a search query.
-	                    Following search queury will look for users that have "name"
+	                    Following search query will look for users that have "name"
 	                    equal to the "uid" attribute of the account. Simply speaking,
 	                    it will look for match in usernames in the IDM and the resource.
 	                    The correlation rule always looks for users, so it will not match

--- a/samples/demo/hr.xml
+++ b/samples/demo/hr.xml
@@ -185,7 +185,7 @@
 	            <correlation>
 	                <q:description>
 	                    Correlation expression is a search query.
-	                    Following search queury will look for users that have "name"
+	                    Following search query will look for users that have "name"
 	                    equal to the "name" attribute of the account. Simply speaking,
 	                    it will look for match in usernames in the IDM and the resource.
 	                    The correlation rule always looks for users, so it will not match

--- a/samples/demo/opendj.xml
+++ b/samples/demo/opendj.xml
@@ -469,7 +469,7 @@
             <correlation>
                 <q:description>
                     Correlation expression is a search query.
-                    Following search queury will look for users that have "name"
+                    Following search query will look for users that have "name"
                     equal to the "uid" attribute of the account. Simply speaking,
                     it will look for match in usernames in the IDM and the resource.
                     The correlation rule always looks for users, so it will not match
@@ -523,7 +523,7 @@
             <correlation>
                 <q:description>
                     Correlation expression is a search query.
-                    Following search queury will look for users that have "name"
+                    Following search query will look for users that have "name"
                     equal to the "uid" attribute of the account. Simply speaking,
                     it will look for match in usernames in the IDM and the resource.
                     The correlation rule always looks for users, so it will not match

--- a/samples/demo/openldap.xml
+++ b/samples/demo/openldap.xml
@@ -444,7 +444,7 @@
             <correlation>
                 <q:description>
                     Correlation expression is a search query.
-                    Following search queury will look for users that have "name"
+                    Following search query will look for users that have "name"
                     equal to the "uid" attribute of the account. Simply speaking,
                     it will look for match in usernames in the IDM and the resource.
                     The correlation rule always looks for users, so it will not match
@@ -498,7 +498,7 @@
             <correlation>
                 <q:description>
                     Correlation expression is a search query.
-                    Following search queury will look for users that have "name"
+                    Following search query will look for users that have "name"
                     equal to the "uid" attribute of the account. Simply speaking,
                     it will look for match in usernames in the IDM and the resource.
                     The correlation rule always looks for users, so it will not match

--- a/samples/resources/389ds/389ds-legacy-connector.xml
+++ b/samples/resources/389ds/389ds-legacy-connector.xml
@@ -392,7 +392,7 @@ It also contains inbound mappings and definition to enable synchronization.
 	            <correlation>
 	                <q:description>
 	                    Correlation expression is a search query.
-	                    Following search queury will look for users that have "name"
+	                    Following search query will look for users that have "name"
 	                    equal to the "uid" attribute of the account. Simply speaking,
 	                    it will look for match in usernames in the IDM and the resource.
 	                    The correlation rule always looks for users, so it will not match

--- a/samples/resources/ad/ad-resource-advanced-sync.xml
+++ b/samples/resources/ad/ad-resource-advanced-sync.xml
@@ -316,7 +316,7 @@ to "false". The only way of resetting the flag is to change user's password.
 		<correlation>
 			<q:description>
 	                    Correlation expression is a search query.
-	                    Following search queury will look for users that have "name"
+	                    Following search query will look for users that have "name"
 	                    equal to the "sAMAccountName" attribute of the account. Simply speaking,
 	                    it will look for match in usernames in the IDM and the resource.
 	                    The correlation rule always looks for users, so it will not match

--- a/samples/resources/csvfile/localhost-csvfile-medium.xml
+++ b/samples/resources/csvfile/localhost-csvfile-medium.xml
@@ -191,7 +191,7 @@ using an Identity Connector Framework connector.
 				<correlation>
 					<q:description>
 	                    Correlation expression is a search query.
-	                    Following search queury will look for users that have "name"
+	                    Following search query will look for users that have "name"
 	                    equal to the "name" attribute of the account. Simply speaking,
 	                    it will look for match in usernames in the IDM and the resource.
 	                    The correlation rule always looks for users, so it will not match

--- a/samples/resources/csvfile/localhost-csvfile-resource-advanced-sync-2.xml
+++ b/samples/resources/csvfile/localhost-csvfile-resource-advanced-sync-2.xml
@@ -221,7 +221,7 @@ object.
 				<correlation>
 					<q:description>
 	                    Correlation expression is a search query.
-	                    Following search queury will look for users that have "name"
+	                    Following search query will look for users that have "name"
 	                    equal to the "name" attribute of the account. Simply speaking,
 	                    it will look for match in usernames in the IDM and the resource.
 	                    The correlation rule always looks for users, so it will not match

--- a/samples/resources/csvfile/localhost-csvfile-resource-advanced-sync.xml
+++ b/samples/resources/csvfile/localhost-csvfile-resource-advanced-sync.xml
@@ -221,7 +221,7 @@ object.
 				<correlation>
 					<q:description>
 	                    Correlation expression is a search query.
-	                    Following search queury will look for users that have "name"
+	                    Following search query will look for users that have "name"
 	                    equal to the "name" attribute of the account. Simply speaking,
 	                    it will look for match in usernames in the IDM and the resource.
 	                    The correlation rule always looks for users, so it will not match

--- a/samples/resources/csvfile/localhost-csvfile-resource-bulk-action.xml
+++ b/samples/resources/csvfile/localhost-csvfile-resource-bulk-action.xml
@@ -221,7 +221,7 @@ object.
 				<correlation>
 					<q:description>
 	                    Correlation expression is a search query.
-	                    Following search queury will look for users that have "name"
+	                    Following search query will look for users that have "name"
 	                    equal to the "name" attribute of the account. Simply speaking,
 	                    it will look for match in usernames in the IDM and the resource.
 	                    The correlation rule always looks for users, so it will not match

--- a/samples/resources/dsee/odsee-localhost-advanced-nosync.xml
+++ b/samples/resources/dsee/odsee-localhost-advanced-nosync.xml
@@ -319,7 +319,7 @@ object.
 	            <correlation>
 	                <q:description>
 	                    Correlation expression is a search query.
-	                    Following search queury will look for users that have "name"
+	                    Following search query will look for users that have "name"
 	                    equal to the "uid" attribute of the account. Simply speaking,
 	                    it will look for match in usernames in the IDM and the resource.
 	                    The correlation rule always looks for users, so it will not match

--- a/samples/resources/office365/office365-federated.xml
+++ b/samples/resources/office365/office365-federated.xml
@@ -285,7 +285,7 @@ This contains configuration for a federated Office 365 domain
                 <correlation>
                     <q:description>
                         Correlation expression is a search query.
-                        Following search queury will look for users that have "name"
+                        Following search query will look for users that have "name"
                         equal to the "mailNickname" attribute of the account. Simply speaking,
                         it will look for match in usernames in the IDM and the resource.
                         The correlation rule always looks for users, so it will not match

--- a/samples/resources/office365/office365-managed.xml
+++ b/samples/resources/office365/office365-managed.xml
@@ -265,7 +265,7 @@ This contains configuration for a managed (non federated) Office 365 domain
                 <correlation>
                     <q:description>
                         Correlation expression is a search query.
-                        Following search queury will look for users that have "name"
+                        Following search query will look for users that have "name"
                         equal to the "mailNickname" attribute of the account. Simply speaking,
                         it will look for match in usernames in the IDM and the resource.
                         The correlation rule always looks for users, so it will not match

--- a/samples/resources/opendj/opendj-localhost-medium.xml
+++ b/samples/resources/opendj/opendj-localhost-medium.xml
@@ -339,7 +339,7 @@ It also contains inbound mappings and definition to enable synchronization.
 	            <correlation>
 	                <q:description>
 	                    Correlation expression is a search query.
-	                    Following search queury will look for users that have "name"
+	                    Following search query will look for users that have "name"
 	                    equal to the "uid" attribute of the account. Simply speaking,
 	                    it will look for match in usernames in the IDM and the resource.
 	                    The correlation rule always looks for users, so it will not match

--- a/samples/resources/opendj/opendj-localhost-resource-sync-advanced.xml
+++ b/samples/resources/opendj/opendj-localhost-resource-sync-advanced.xml
@@ -375,7 +375,7 @@ object.
 	            <correlation>
 	                <q:description>
 	                    Correlation expression is a search query.
-	                    Following search queury will look for users that have "name"
+	                    Following search query will look for users that have "name"
 	                    equal to the "uid" attribute of the account. Simply speaking,
 	                    it will look for match in usernames in the IDM and the resource.
 	                    The correlation rule always looks for users, so it will not match

--- a/samples/resources/opendj/opendj-localhost-resource-sync-no-extension-advanced-test.xml
+++ b/samples/resources/opendj/opendj-localhost-resource-sync-no-extension-advanced-test.xml
@@ -385,7 +385,7 @@ object.
 	            <correlation>
 	                <q:description>
 	                    Correlation expression is a search query.
-	                    Following search queury will look for users that have "name"
+	                    Following search query will look for users that have "name"
 	                    equal to the "uid" attribute of the account. Simply speaking,
 	                    it will look for match in usernames in the IDM and the resource.
 	                    The correlation rule always looks for users, so it will not match

--- a/samples/resources/opendj/opendj-localhost-resource-sync-no-extension-advanced.xml
+++ b/samples/resources/opendj/opendj-localhost-resource-sync-no-extension-advanced.xml
@@ -383,7 +383,7 @@ object.
 				<correlation>
 					<q:description>
 	                    Correlation expression is a search query.
-	                    Following search queury will look for users that have "name"
+	                    Following search query will look for users that have "name"
 	                    equal to the "uid" attribute of the account. Simply speaking,
 	                    it will look for match in usernames in the IDM and the resource.
 	                    The correlation rule always looks for users, so it will not match

--- a/samples/resources/opendj/piracy/opendj-localhost-resource-sync-extension-pirates.xml
+++ b/samples/resources/opendj/piracy/opendj-localhost-resource-sync-extension-pirates.xml
@@ -452,7 +452,7 @@ This resource definition contains also definition to enable synchronization.
 	            <correlation>
 	                <!-- Correlation rule is a search query -->
 	                <!-- The clause <type uri="http://midpoint.evolveum.com/xml/ns/public/common/common-3#UserType"/> is implicit in correlation rules -->
-	                <!-- Following search queury will look for users that have "name"
+	                <!-- Following search query will look for users that have "name"
 	                     equal to the "uid" attribute of the account. Simply speaking,
 	                     it will look for match in usernames in the IDM and the resource. -->
 	                <q:equal>

--- a/samples/resources/openldap/openldap-localhost-medium.xml
+++ b/samples/resources/openldap/openldap-localhost-medium.xml
@@ -425,7 +425,7 @@ It also contains inbound mappings and definition to enable synchronization.
 	            <correlation>
 	                <q:description>
 	                    Correlation expression is a search query.
-	                    Following search queury will look for users that have "name"
+	                    Following search query will look for users that have "name"
 	                    equal to the "uid" attribute of the account. Simply speaking,
 	                    it will look for match in usernames in the IDM and the resource.
 	                    The correlation rule always looks for users, so it will not match

--- a/samples/resources/scriptedsql/localhost-scriptedsql-advanced-nosync.xml
+++ b/samples/resources/scriptedsql/localhost-scriptedsql-advanced-nosync.xml
@@ -220,7 +220,7 @@
 				<correlation>
 					<q:description>
 	                    Correlation expression is a search query.
-	                    Following search queury will look for users that have "name"
+	                    Following search query will look for users that have "name"
 	                    equal to the "name" attribute of the account. Simply speaking,
 	                    it will look for match in usernames in the IDM and the resource.
 	                    The correlation rule always looks for users, so it will not match

--- a/samples/resources/scriptedsql/localhost-scriptedsql-advanced-sync.xml
+++ b/samples/resources/scriptedsql/localhost-scriptedsql-advanced-sync.xml
@@ -232,7 +232,7 @@
 				<correlation>
 					<q:description>
 	                    Correlation expression is a search query.
-	                    Following search queury will look for users that have "name"
+	                    Following search query will look for users that have "name"
 	                    equal to the "name" attribute of the account. Simply speaking,
 	                    it will look for match in usernames in the IDM and the resource.
 	                    The correlation rule always looks for users, so it will not match

--- a/samples/rest/opendj-resource-sync.xml
+++ b/samples/rest/opendj-resource-sync.xml
@@ -358,7 +358,7 @@ removed all objects other than the resource itself.
             <correlation>
                 <q:description>
                     Correlation expression is a search query.
-                    Following search queury will look for users that have "name"
+                    Following search query will look for users that have "name"
                     equal to the "uid" attribute of the account. Simply speaking,
                     it will look for match in usernames in the IDM and the resource.
                     The correlation rule always looks for users, so it will not match

--- a/samples/stories/multitenant-idm-saas/resources/crm-simulation-sync.xml
+++ b/samples/stories/multitenant-idm-saas/resources/crm-simulation-sync.xml
@@ -274,7 +274,7 @@ object.
 				<correlation>
 					<q:description>
 	                    Correlation expression is a search query.
-	                    Following search queury will look for users that have "name"
+	                    Following search query will look for users that have "name"
 	                    equal to the "name" attribute of the account. Simply speaking,
 	                    it will look for match in usernames in the IDM and the resource.
 	                    The correlation rule always looks for users, so it will not match

--- a/samples/stories/multitenant-idm-saas/resources/openldap-customers.xml
+++ b/samples/stories/multitenant-idm-saas/resources/openldap-customers.xml
@@ -674,7 +674,7 @@ It also contains inbound mappings and definition to enable synchronization.
 	            <correlation>
 	                <q:description>
 	                    Correlation expression is a search query.
-	                    Following search queury will look for users that have "name"
+	                    Following search query will look for users that have "name"
 	                    equal to the "uid" attribute of the account. Simply speaking,
 	                    it will look for match in usernames in the IDM and the resource.
 	                    The correlation rule always looks for users, so it will not match

--- a/samples/stories/unix-ldap-advanced/resources/resource-openLDAP.xml
+++ b/samples/stories/unix-ldap-advanced/resources/resource-openLDAP.xml
@@ -800,7 +800,7 @@
             <correlation>
                <q:description>
 	                    Correlation expression is a search query.
-	                    Following search queury will look for users that have "name"
+	                    Following search query will look for users that have "name"
 	                    equal to the "uid" attribute of the account. Simply speaking,
 	                    it will look for match in usernames in the IDM and the resource.
 	                    The correlation rule always looks for users, so it will not match
@@ -857,7 +857,7 @@
             <correlation>
                <q:description>
                         Correlation expression is a search query.
-	                    Following search queury will look for users that have "name"
+	                    Following search query will look for users that have "name"
 	                    equal to the "uid" attribute of the account. Simply speaking,
 	                    it will look for match in usernames in the IDM and the resource.
 	                    The correlation rule always looks for users, so it will not match
@@ -913,7 +913,7 @@
             <correlation>
                <q:description>
                         Correlation expression is a search query.
-	                    Following search queury will look for users that have "name"
+	                    Following search query will look for users that have "name"
 	                    equal to the "uid" attribute of the account. Simply speaking,
 	                    it will look for match in usernames in the IDM and the resource.
 	                    The correlation rule always looks for users, so it will not match
@@ -976,7 +976,7 @@
             <correlation>
                <q:description>
                         Correlation expression is a search query.
-	                    Following search queury will look for users that have "name"
+	                    Following search query will look for users that have "name"
 	                    equal to the "uid" attribute of the account. Simply speaking,
 	                    it will look for match in usernames in the IDM and the resource.
 	                    The correlation rule always looks for users, so it will not match
@@ -1038,7 +1038,7 @@
             <correlation>
                <q:description>
                         Correlation expression is a search query.
-	                    Following search queury will look for users that have "name"
+	                    Following search query will look for users that have "name"
 	                    equal to the "uid" attribute of the account. Simply speaking,
 	                    it will look for match in usernames in the IDM and the resource.
 	                    The correlation rule always looks for users, so it will not match

--- a/samples/stories/unix-ldap/resources/ldap-posix.xml
+++ b/samples/stories/unix-ldap/resources/ldap-posix.xml
@@ -400,7 +400,7 @@
 	            <correlation>
 	                <q:description>
 	                    Correlation expression is a search query.
-	                    Following search queury will look for users that have "name"
+	                    Following search query will look for users that have "name"
 	                    equal to the "uid" attribute of the account. Simply speaking,
 	                    it will look for match in usernames in the IDM and the resource.
 	                    The correlation rule always looks for users, so it will not match

--- a/testing/consistency-mechanism/src/test/resources/request/resource-modify-synchronization.xml
+++ b/testing/consistency-mechanism/src/test/resources/request/resource-modify-synchronization.xml
@@ -44,7 +44,7 @@
 	            <correlation>
 	                <q:description>
 	                    Correlation expression is a search query.
-	                    Following search queury will look for users that have "employeeNumber"
+	                    Following search query will look for users that have "employeeNumber"
 	                    equal to the "enumber" attribute of the account.
                             The condition will ensure that "enumber" is not
                             empty, otherwise it would match any midPoint user

--- a/testing/selenidetest/src/test/resources/mp-resources/localhost-csvfile-resource-advanced-sync.xml
+++ b/testing/selenidetest/src/test/resources/mp-resources/localhost-csvfile-resource-advanced-sync.xml
@@ -205,7 +205,7 @@ object.
 				<correlation>
 					<q:description>
 	                    Correlation expression is a search query.
-	                    Following search queury will look for users that have "name"
+	                    Following search query will look for users that have "name"
 	                    equal to the "name" attribute of the account. Simply speaking,
 	                    it will look for match in usernames in the IDM and the resource.
 	                    The correlation rule always looks for users, so it will not match

--- a/testing/story/src/test/resources/science/resource-dummy-stats.xml
+++ b/testing/story/src/test/resources/science/resource-dummy-stats.xml
@@ -120,7 +120,7 @@
          <correlation xmlns:q="http://prism.evolveum.com/xml/ns/public/query-3">
             <q:description>
 	                    Correlation expression is a search query.
-	                    Following search queury will look for users that have "name"
+	                    Following search query will look for users that have "name"
 	                    equal to the "uid" attribute of the account. Simply speaking,
 	                    it will look for match in usernames in the IDM and the resource.
 	                    The correlation rule always looks for users, so it will not match

--- a/testing/story/src/test/resources/science/resource-dummy-unix.xml
+++ b/testing/story/src/test/resources/science/resource-dummy-unix.xml
@@ -165,7 +165,7 @@
          <correlation xmlns:q="http://prism.evolveum.com/xml/ns/public/query-3">
             <q:description>
 	                    Correlation expression is a search query.
-	                    Following search queury will look for users that have "name"
+	                    Following search query will look for users that have "name"
 	                    equal to the "sAMAccountName" attribute of the account. Simply speaking,
 	                    it will look for match in usernames in the IDM and the resource.
 	                    The correlation rule always looks for users, so it will not match

--- a/testing/story/src/test/resources/science/resource-opendj-ad-simulation.xml
+++ b/testing/story/src/test/resources/science/resource-opendj-ad-simulation.xml
@@ -274,7 +274,7 @@
          <correlation xmlns:q="http://prism.evolveum.com/xml/ns/public/query-3">
             <q:description>
 	                    Correlation expression is a search query.
-	                    Following search queury will look for users that have "name"
+	                    Following search query will look for users that have "name"
 	                    equal to the "sAMAccountName" attribute of the account. Simply speaking,
 	                    it will look for match in usernames in the IDM and the resource.
 	                    The correlation rule always looks for users, so it will not match

--- a/tools/repo-ninja/src/test/resources/objects.xml
+++ b/tools/repo-ninja/src/test/resources/objects.xml
@@ -549,7 +549,7 @@
             <correlation>
                 <description>
                     Correlation expression is a search query.
-                    Following search queury will look for users that have "name"
+                    Following search query will look for users that have "name"
                     equal to the "uid" attribute of the account. Simply speaking,
                     it will look for match in usernames in the IDM and the resource.
                     The correlation rule always looks for users, so it will not match


### PR DESCRIPTION
"Query" was spelled "queury" and I think that error was copy/pasted all over. I noticed it in a log message, even though it seems to be mostly in comments, so I don't know where the log message got it from.

Also, my editor removed some unecessary whitespace it seems.