### PR TITLE
test dependencies

### DIFF
--- a/testing/story/src/test/java/com/evolveum/midpoint/testing/story/TestLdapDependency.java
+++ b/testing/story/src/test/java/com/evolveum/midpoint/testing/story/TestLdapDependency.java
@@ -1,0 +1,595 @@
+/*
+ * Copyright (c) 2016 Evolveum
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.evolveum.midpoint.testing.story;
+
+
+import static com.evolveum.midpoint.test.IntegrationTestTools.display;
+import static org.testng.AssertJUnit.assertNotNull;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Collection;
+
+import javax.xml.namespace.QName;
+
+import org.opends.server.types.DirectoryException;
+import org.opends.server.types.Entry;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.annotation.DirtiesContext.ClassMode;
+import org.springframework.test.context.ContextConfiguration;
+import org.testng.AssertJUnit;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.Test;
+
+import com.evolveum.midpoint.model.api.PolicyViolationException;
+import com.evolveum.midpoint.prism.PrismContainer;
+import com.evolveum.midpoint.prism.PrismObject;
+import com.evolveum.midpoint.prism.delta.ItemDelta;
+import com.evolveum.midpoint.prism.delta.ObjectDelta;
+import com.evolveum.midpoint.prism.util.PrismAsserts;
+import com.evolveum.midpoint.prism.util.PrismTestUtil;
+import com.evolveum.midpoint.schema.constants.MidPointConstants;
+import com.evolveum.midpoint.schema.result.OperationResult;
+import com.evolveum.midpoint.schema.util.MiscSchemaUtil;
+import com.evolveum.midpoint.task.api.Task;
+import com.evolveum.midpoint.test.util.MidPointTestConstants;
+import com.evolveum.midpoint.test.util.TestUtil;
+import com.evolveum.midpoint.util.exception.CommunicationException;
+import com.evolveum.midpoint.util.exception.ConfigurationException;
+import com.evolveum.midpoint.util.exception.ExpressionEvaluationException;
+import com.evolveum.midpoint.util.exception.ObjectAlreadyExistsException;
+import com.evolveum.midpoint.util.exception.ObjectNotFoundException;
+import com.evolveum.midpoint.util.exception.SchemaException;
+import com.evolveum.midpoint.util.exception.SecurityViolationException;
+import com.evolveum.midpoint.xml.ns._public.common.common_3.ActivationType;
+import com.evolveum.midpoint.xml.ns._public.common.common_3.AssignmentType;
+import com.evolveum.midpoint.xml.ns._public.common.common_3.FocusType;
+import com.evolveum.midpoint.xml.ns._public.common.common_3.ObjectReferenceType;
+import com.evolveum.midpoint.xml.ns._public.common.common_3.ObjectType;
+import com.evolveum.midpoint.xml.ns._public.common.common_3.OrgType;
+import com.evolveum.midpoint.xml.ns._public.common.common_3.ResourceType;
+import com.evolveum.midpoint.xml.ns._public.common.common_3.RoleType;
+import com.evolveum.midpoint.xml.ns._public.common.common_3.ShadowKindType;
+import com.evolveum.midpoint.xml.ns._public.common.common_3.ShadowType;
+import com.evolveum.prism.xml.ns._public.types_3.PolyStringType;
+
+/**
+ * Testing dependencies:
+ * There are two meta-roles for orgs.
+ * Org Metarole contains two inducements, one for creating organizationalUnit (intent=ou) and one for creating groupOfUniqueNames (intent=group) in ldap.
+ * group depends on ou (since it is created in ou)
+ * 
+ * Org Metarole VIP is very similar it also contains two inducements, one for creating (intent=ou-vip) and one for creating groupOfUniqueNames (intent=group-vip) in ldap.
+ * group-vip depends on ou-cip (since it is created in ou-vip)
+ * 
+ * @author michael gruber
+ *
+ */
+@ContextConfiguration(locations = {"classpath:ctx-story-test-main.xml"})
+@DirtiesContext(classMode = ClassMode.AFTER_CLASS)
+public  class TestLdapDependency extends AbstractStoryTest {
+	
+	public static final File TEST_DIR = new File(MidPointTestConstants.TEST_RESOURCES_DIR, "ldap-dependency");
+	
+	private static final String RESOURCE_OPENDJ_OID = "10000000-0000-0000-0000-000000000003";
+	private static final String RESOURCE_OPENDJ_NAMESPACE = MidPointConstants.NS_RI;
+	private static final QName OPENDJ_ASSOCIATION_GROUP_NAME = new QName(RESOURCE_OPENDJ_NAMESPACE, "group");
+
+	public static final String ORG_TOP_OID = "00000000-8888-6666-0000-100000000001";
+	
+	public static final String ROLE_META_ORG_OID = "10000000-0000-0000-0000-000000006601";
+	public static final String ROLE_META_ORG_VIP_OID = "10000000-0000-0000-0000-000000006602";
+	public static final String ROLE_META_ORG_SUPERVIP_OID = "10000000-0000-0000-0000-000000006603";
+
+	private static final String ORG_IT_NAME = "IT";
+	private static final String ORG_HR_NAME = "HR";
+	private static String orgItOid;
+	private static String orgHrOid;
+	
+
+	private static final String ORG_TYPE_FUNCTIONAL = "functional";
+
+	private static final String LDAP_GROUP_INTENT = "group";
+	private static final String LDAP_GROUP_VIP_INTENT = "group-vip";
+	private static final String LDAP_GROUP_SUPERVIP_INTENT = "group-supervip";
+		
+	private static final String LDAP_OU_INTENT = "ou";
+	private static final String LDAP_OU_VIP_INTENT = "ou-vip";
+
+	
+	private ResourceType resourceOpenDjType;
+	private PrismObject<ResourceType> resourceOpenDj;
+
+	
+	private File getTestDir() {
+		return TEST_DIR;
+	}
+	
+	private File getResourceOpenDjFile() {
+		return new File(getTestDir(), "resource-opendj.xml");
+	}
+	
+	private File getOrgTopFile() {
+		return new File(getTestDir(), "org-top.xml");
+	}
+	
+	private File getRoleMetaOrgFile() {
+		return new File(getTestDir(), "role-meta-org.xml");
+	}
+	
+	private File getRoleMetaOrgVipFile() {
+		return new File(getTestDir(), "role-meta-org-vip.xml");
+	}
+	
+	private File getRoleMetaOrgSuperVipFile() {
+		return new File(getTestDir(), "role-meta-org-supervip.xml");
+	}
+
+	@Override
+    protected void startResources() throws Exception {
+        openDJController.startCleanServerRI();
+    }
+
+    @AfterClass
+    public static void stopResources() throws Exception {
+        openDJController.stop();
+    }
+	
+	@Override
+	public void initSystem(Task initTask, OperationResult initResult) throws Exception {
+		super.initSystem(initTask, initResult);
+		
+		
+		// Resources	
+		resourceOpenDj = importAndGetObjectFromFile(ResourceType.class, getResourceOpenDjFile(), RESOURCE_OPENDJ_OID, initTask, initResult);
+		resourceOpenDjType = resourceOpenDj.asObjectable();
+		openDJController.setResource(resourceOpenDj);
+
+		// Org
+		importObjectFromFile(getOrgTopFile(), initResult);
+
+		// Roles
+		importObjectFromFile(getRoleMetaOrgFile(), initResult);
+		importObjectFromFile(getRoleMetaOrgVipFile(), initResult);
+		importObjectFromFile(getRoleMetaOrgSuperVipFile(), initResult);
+	}
+	
+	@Test
+    public void test000Sanity() throws Exception {
+		final String TEST_NAME = "test000Sanity";
+        TestUtil.displayTestTile(this, TEST_NAME);
+        Task task = taskManager.createTaskInstance(TestTrafo.class.getName() + "." + TEST_NAME);
+        
+        OperationResult testResultOpenDj = modelService.testResource(RESOURCE_OPENDJ_OID, task);
+        TestUtil.assertSuccess(testResultOpenDj);
+
+        dumpOrgTree();
+        dumpLdap();
+	}
+	
+	@Test
+    public void test100AddOrgIT() throws Exception {
+		final String TEST_NAME = "test100AddOrgIT";
+        TestUtil.displayTestTile(this, TEST_NAME);
+        Task task = taskManager.createTaskInstance(TestLdapDependency.class.getName() + "." + TEST_NAME);
+        OperationResult result = task.getResult();
+
+        PrismObject<OrgType> orgBefore = createOrg(ORG_IT_NAME, ORG_TOP_OID);
+        
+        // WHEN
+        TestUtil.displayWhen(TEST_NAME);
+        display("Adding org", orgBefore);
+        addObject(orgBefore, task, result);
+
+        // THEN
+        TestUtil.displayThen(TEST_NAME);
+        result.computeStatus();
+        TestUtil.assertSuccess(result);
+        
+        dumpOrgTree();
+		dumpLdap();
+        
+		PrismObject<OrgType> orgAfter = getOrg(ORG_IT_NAME);
+        orgItOid = orgAfter.getOid();
+
+		assertSubOrgs(orgAfter, 0);
+		assertSubOrgs(ORG_TOP_OID, 1);
+	}
+	
+	@Test
+    public void test150AssignFunctionalRoleToITOrg() throws Exception {
+		final String TEST_NAME = "test150AssignFunctionalRoleToITOrg";
+        TestUtil.displayTestTile(this, TEST_NAME);
+        Task task = taskManager.createTaskInstance(TestLdapDependency.class.getName() + "." + TEST_NAME);
+        OperationResult result = task.getResult();
+
+        PrismObject<OrgType> orgBefore = getOrg(ORG_IT_NAME);
+        
+        // WHEN
+        TestUtil.displayWhen(TEST_NAME);
+        display("orgBefore: ", orgBefore);
+        assignRoleToOrg(orgItOid, ROLE_META_ORG_OID, task, result);
+
+        // THEN
+        TestUtil.displayThen(TEST_NAME);
+        result.computeStatus();
+        TestUtil.assertSuccess(result);
+        
+        dumpOrgTree();
+		dumpLdap();
+        
+        PrismObject<OrgType> orgAfter = getOrg(ORG_IT_NAME);
+        display("AFTER Assigning functional role org", orgAfter);
+		assertSubOrgs(orgAfter, 0);
+		assertSubOrgs(ORG_TOP_OID, 1);
+		assertRoleMembershipRef(orgAfter, ROLE_META_ORG_OID, ORG_TOP_OID);
+		assertLdapObject(orgAfter, ShadowKindType.ENTITLEMENT, LDAP_GROUP_INTENT);
+		assertLdapObject(orgAfter, ShadowKindType.GENERIC, LDAP_OU_INTENT);
+	}
+	
+	@Test
+    public void test170UnassignFunctionalRoleFromITOrg() throws Exception {
+		final String TEST_NAME = "test170UnassignFunctionalRoleFromITOrg";
+        TestUtil.displayTestTile(this, TEST_NAME);
+        Task task = taskManager.createTaskInstance(TestLdapDependency.class.getName() + "." + TEST_NAME);
+        OperationResult result = task.getResult();
+
+        PrismObject<OrgType> orgBefore = getOrg(ORG_IT_NAME);
+        
+        // WHEN
+        TestUtil.displayWhen(TEST_NAME);
+        display("unassigning vip role org", orgBefore);
+        unassignRoleFromOrg(orgItOid, ROLE_META_ORG_OID, task, result);
+        
+        // THEN
+        TestUtil.displayThen(TEST_NAME);
+        result.computeStatus();
+        TestUtil.assertSuccess(result);
+        
+        dumpOrgTree();
+		dumpLdap();
+        
+        PrismObject<OrgType> orgAfter = getOrg(ORG_IT_NAME);
+        display("AFTER unassigning functional role org", orgAfter);
+		assertSubOrgs(orgAfter, 0);
+		assertSubOrgs(ORG_TOP_OID, 1);
+		assertRoleMembershipRef(orgAfter, ORG_TOP_OID);
+		assertNotAssignedRole(orgAfter, ROLE_META_ORG_OID);
+		//TODO: assert ldap objects deleted...
+	}
+	
+	
+	@Test
+    public void test200AddOrgHR() throws Exception {
+		final String TEST_NAME = "test200AddOrgHR";
+        TestUtil.displayTestTile(this, TEST_NAME);
+        Task task = taskManager.createTaskInstance(TestLdapDependency.class.getName() + "." + TEST_NAME);
+        OperationResult result = task.getResult();
+
+        PrismObject<OrgType> orgBefore = createOrg(ORG_HR_NAME, ORG_TOP_OID);
+        
+        // WHEN
+        TestUtil.displayWhen(TEST_NAME);
+        display("Adding org", orgBefore);
+        addObject(orgBefore, task, result);
+
+        // THEN
+        TestUtil.displayThen(TEST_NAME);
+        result.computeStatus();
+        TestUtil.assertSuccess(result);
+        
+        dumpOrgTree();
+		dumpLdap();
+        
+		PrismObject<OrgType> orgAfter = getOrg(ORG_HR_NAME);
+        orgHrOid = orgAfter.getOid();
+
+		assertSubOrgs(orgAfter, 0);
+		assertSubOrgs(ORG_TOP_OID, 2);
+	}
+	
+	@Test
+    public void test250AssignFunctionalAndVipRoleToHROrg() throws Exception {
+		final String TEST_NAME = "test250AssignFunctionalAndVipRoleToHROrg";
+        TestUtil.displayTestTile(this, TEST_NAME);
+        Task task = taskManager.createTaskInstance(TestLdapDependency.class.getName() + "." + TEST_NAME);
+        OperationResult result = task.getResult();
+
+        PrismObject<OrgType> orgBefore = getOrg(ORG_HR_NAME);
+        
+        // WHEN
+        TestUtil.displayWhen(TEST_NAME);
+        display("orgBefore: ", orgBefore);
+        assignRoleToOrg(orgHrOid, ROLE_META_ORG_OID, task, result);
+        assignRoleToOrg(orgHrOid, ROLE_META_ORG_VIP_OID, task, result);
+
+        // THEN
+        TestUtil.displayThen(TEST_NAME);
+        result.computeStatus();
+        TestUtil.assertSuccess(result);
+        
+        dumpOrgTree();
+		dumpLdap();
+        
+        PrismObject<OrgType> orgAfter = getOrg(ORG_HR_NAME);
+        display("AFTER Assigning functional and vip role org", orgAfter);
+		assertSubOrgs(orgAfter, 0);
+		assertSubOrgs(ORG_TOP_OID, 2);
+		assertRoleMembershipRef(orgAfter, ROLE_META_ORG_OID, ROLE_META_ORG_VIP_OID, ORG_TOP_OID);
+		assertLdapObject(orgAfter, ShadowKindType.ENTITLEMENT, LDAP_GROUP_INTENT);
+		assertLdapObject(orgAfter, ShadowKindType.GENERIC, LDAP_OU_INTENT);
+		assertLdapObject(orgAfter, ShadowKindType.ENTITLEMENT, LDAP_GROUP_VIP_INTENT);
+		assertLdapObject(orgAfter, ShadowKindType.GENERIC, LDAP_OU_VIP_INTENT);
+	}
+	
+	@Test
+    public void test270UnassignVipRoleFromHROrg() throws Exception {
+		final String TEST_NAME = "test270UnassignVipRoleFromHROrg";
+        TestUtil.displayTestTile(this, TEST_NAME);
+        Task task = taskManager.createTaskInstance(TestLdapDependency.class.getName() + "." + TEST_NAME);
+        OperationResult result = task.getResult();
+
+        PrismObject<OrgType> orgBefore = getOrg(ORG_HR_NAME);
+        
+        // WHEN
+        TestUtil.displayWhen(TEST_NAME);
+        display("unassigning vip role org", orgBefore);
+        unassignRoleFromOrg(orgHrOid, ROLE_META_ORG_VIP_OID, task, result);
+        
+        // THEN
+        TestUtil.displayThen(TEST_NAME);
+        result.computeStatus();
+        TestUtil.assertSuccess(result);
+        
+        dumpOrgTree();
+		dumpLdap();
+        
+        PrismObject<OrgType> orgAfter = getOrg(ORG_HR_NAME);
+        display("AFTER unassigning vip role org", orgAfter);
+		assertSubOrgs(orgAfter, 0);
+		assertSubOrgs(ORG_TOP_OID, 2);
+		assertRoleMembershipRef(orgAfter, ROLE_META_ORG_OID, ORG_TOP_OID);
+		assertNotAssignedRole(orgAfter, ROLE_META_ORG_VIP_OID);
+		assertLdapObject(orgAfter, ShadowKindType.ENTITLEMENT, LDAP_GROUP_INTENT);
+		assertLdapObject(orgAfter, ShadowKindType.GENERIC, LDAP_OU_INTENT);
+		//TODO: assert ldap vip objects deleted...
+	}
+	
+	//test280AssignVipAndSuperVipRoleToHROrg required for  test290UnassignVipRoleFromHROrg
+	//@Test
+    public void test280AssignVipAndSuperVipRoleToHROrg() throws Exception {
+		final String TEST_NAME = "test280AssignVipAndSuperVipRoleToHROrg";
+        TestUtil.displayTestTile(this, TEST_NAME);
+        Task task = taskManager.createTaskInstance(TestLdapDependency.class.getName() + "." + TEST_NAME);
+        OperationResult result = task.getResult();
+
+        PrismObject<OrgType> orgBefore = getOrg(ORG_HR_NAME);
+        
+        // WHEN
+        TestUtil.displayWhen(TEST_NAME);
+        display("orgBefore: ", orgBefore);
+        assignRoleToOrg(orgHrOid, ROLE_META_ORG_VIP_OID, task, result);
+        assignRoleToOrg(orgHrOid, ROLE_META_ORG_SUPERVIP_OID, task, result);
+
+        // THEN
+        TestUtil.displayThen(TEST_NAME);
+        result.computeStatus();
+        TestUtil.assertSuccess(result);
+        
+        dumpOrgTree();
+		dumpLdap();
+        
+        PrismObject<OrgType> orgAfter = getOrg(ORG_HR_NAME);
+        display("AFTER Assigning supervip role org", orgAfter);
+		assertSubOrgs(orgAfter, 0);
+		assertSubOrgs(ORG_TOP_OID, 2);
+		assertRoleMembershipRef(orgAfter, ROLE_META_ORG_OID, ROLE_META_ORG_VIP_OID, ROLE_META_ORG_SUPERVIP_OID, ORG_TOP_OID);
+		assertLdapObject(orgAfter, ShadowKindType.ENTITLEMENT, LDAP_GROUP_INTENT);
+		assertLdapObject(orgAfter, ShadowKindType.GENERIC, LDAP_OU_INTENT);
+		assertLdapObject(orgAfter, ShadowKindType.ENTITLEMENT, LDAP_GROUP_VIP_INTENT);
+		assertLdapObject(orgAfter, ShadowKindType.ENTITLEMENT, LDAP_GROUP_SUPERVIP_INTENT);
+		assertLdapObject(orgAfter, ShadowKindType.GENERIC, LDAP_OU_VIP_INTENT);
+	}
+
+	//should result in dependency exception but results in NullPointer
+	//TODO: correct assertions (assertException)
+	//@Test
+    public void test290UnassignVipRoleFromHROrg() throws Exception {
+		final String TEST_NAME = "test290UnassignVipRoleFromHROrg";
+        TestUtil.displayTestTile(this, TEST_NAME);
+        Task task = taskManager.createTaskInstance(TestLdapDependency.class.getName() + "." + TEST_NAME);
+        OperationResult result = task.getResult();
+
+        PrismObject<OrgType> orgBefore = getOrg(ORG_HR_NAME);
+        
+        // WHEN
+        TestUtil.displayWhen(TEST_NAME);
+        display("unassigning vip role org", orgBefore);
+        unassignRoleFromOrg(orgHrOid, ROLE_META_ORG_VIP_OID, task, result);
+        
+        // THEN
+        TestUtil.displayThen(TEST_NAME);
+        result.computeStatus();
+        TestUtil.assertSuccess(result);
+        
+        dumpOrgTree();
+		dumpLdap();
+        
+        PrismObject<OrgType> orgAfter = getOrg(ORG_HR_NAME);
+        display("AFTER unassigning vip role org", orgAfter);
+		assertSubOrgs(orgAfter, 0);
+		assertSubOrgs(ORG_TOP_OID, 2);
+		assertRoleMembershipRef(orgAfter, ROLE_META_ORG_OID, ORG_TOP_OID);
+		assertNotAssignedRole(orgAfter, ROLE_META_ORG_VIP_OID);
+		assertLdapObject(orgAfter, ShadowKindType.ENTITLEMENT, LDAP_GROUP_INTENT);
+		assertLdapObject(orgAfter, ShadowKindType.GENERIC, LDAP_OU_INTENT);
+		//TODO: assert ldap vip objects deleted...
+	}
+
+	private PrismObject<OrgType> createOrg(String name, String parentOrgOid) throws SchemaException {
+		PrismObject<OrgType> org = prismContext.getSchemaRegistry().findObjectDefinitionByCompileTimeClass(OrgType.class).instantiate();
+		OrgType orgType = org.asObjectable();
+		orgType.setName(new PolyStringType(name));
+		orgType.getOrgType().add(ORG_TYPE_FUNCTIONAL);
+		if (parentOrgOid != null) {
+			AssignmentType parentAssignment = new AssignmentType();
+			ObjectReferenceType parentAssignmentTargetRef = new ObjectReferenceType();
+			parentAssignmentTargetRef.setOid(parentOrgOid);
+			parentAssignmentTargetRef.setType(OrgType.COMPLEX_TYPE);
+			parentAssignment.setTargetRef(parentAssignmentTargetRef);
+			orgType.getAssignment().add(parentAssignment);
+		}
+		return org;
+	}
+
+	private void assertLdapObjectsFunctionalOrg(PrismObject<OrgType> org) throws SchemaException, ObjectNotFoundException, SecurityViolationException, CommunicationException, ConfigurationException, DirectoryException {
+		String orgName =  org.getName().toString();
+		display("assert org", org.getName());
+		
+		String groupOid = getLinkRefOid(org, RESOURCE_OPENDJ_OID, ShadowKindType.ENTITLEMENT, LDAP_GROUP_INTENT);
+		PrismObject<ShadowType> groupShadow = getShadowModel(groupOid);
+		display("Org "+orgName+" group shadow", groupShadow);
+		// TODO assert shadow content
+
+		Entry groupEntry = openDJController.searchSingle("cn="+orgName);
+		assertNotNull("No group LDAP entry for "+orgName, groupEntry);
+		display("OU GROUP entry", openDJController.toHumanReadableLdifoid(groupEntry));
+		openDJController.assertObjectClass(groupEntry, "groupOfUniqueNames");
+
+	}
+	
+	
+	private void assertLdapObject(PrismObject<OrgType> org, ShadowKindType kind, String intent) throws SchemaException, ObjectNotFoundException, SecurityViolationException, CommunicationException, ConfigurationException, DirectoryException {
+		String orgName =  org.getName().toString();
+		display("assert org", orgName);
+		
+		String objOid = getLinkRefOid(org, RESOURCE_OPENDJ_OID, kind, intent);
+		PrismObject<ShadowType> objShadow = getShadowModel(objOid);
+		display("Org "+orgName+" kind " +kind + " intent " + intent +" shadow", objShadow);
+		// TODO assert shadow content
+		
+		String search = "";
+		if (kind.equals(ShadowKindType.ENTITLEMENT)){
+			if (LDAP_GROUP_INTENT.equals(intent)) search = "cn="+orgName;
+			if (LDAP_GROUP_VIP_INTENT.equals(intent)) search = "cn="+orgName+"-vip";
+			if (LDAP_GROUP_SUPERVIP_INTENT.equals(intent)) search = "cn="+orgName+"-supervip";
+		}
+		if (kind.equals(ShadowKindType.GENERIC)){
+			if (LDAP_OU_INTENT.equals(intent)) search = "ou="+orgName;
+			if (LDAP_OU_VIP_INTENT.equals(intent)) search = "ou="+orgName+"-vip";
+		}
+		Entry objEntry = openDJController.searchSingle(search);
+		assertNotNull("No LDAP entry for "+orgName, objEntry);;
+		display("LDAP entry kind " +kind + " inten " + intent +" ldapObj", objEntry);
+		
+		if (kind.equals(ShadowKindType.ENTITLEMENT)){
+			openDJController.assertObjectClass(objEntry, "groupOfUniqueNames");
+		}
+		if (kind.equals(ShadowKindType.GENERIC)){
+			openDJController.assertObjectClass(objEntry, "organizationalUnit");
+		}
+		
+		
+
+	}
+
+	private PrismObject<OrgType> getOrg(String orgName) throws SchemaException, ObjectNotFoundException, SecurityViolationException, CommunicationException, ConfigurationException {
+		PrismObject<OrgType> org = findObjectByName(OrgType.class, orgName);
+		assertNotNull("The org "+orgName+" is missing!", org);
+		display("Org "+orgName, org);
+		PrismAsserts.assertPropertyValue(org, OrgType.F_NAME, PrismTestUtil.createPolyString(orgName));
+		return org;
+	}
+
+	private void dumpOrgTree() throws SchemaException, ObjectNotFoundException, SecurityViolationException, CommunicationException, ConfigurationException {
+		display("Org tree", dumpOrgTree(ORG_TOP_OID));
+	}
+	
+	private void dumpLdap() throws DirectoryException {
+		display("LDAP server tree", openDJController.dumpTree());
+		display("LDAP server content", openDJController.dumpEntries());
+	}
+	
+	////should be in AbstractModelIntegrationTest
+	
+	private void modifyOrgAssignment(String orgOid, String roleOid, QName refType, QName relation, Task task, 
+			PrismContainer<?> extension, ActivationType activationType, boolean add, OperationResult result) 
+			throws ObjectNotFoundException,
+			SchemaException, ExpressionEvaluationException, CommunicationException, ConfigurationException, ObjectAlreadyExistsException,
+			PolicyViolationException, SecurityViolationException {
+		ObjectDelta<OrgType> orgDelta = createAssignmentOrgDelta(orgOid, roleOid, refType, relation, extension, activationType, add);
+		Collection<ObjectDelta<? extends ObjectType>> deltas = MiscSchemaUtil.createCollection(orgDelta);
+		modelService.executeChanges(deltas, null, task, result);		
+	}
+	
+	private ObjectDelta<OrgType> createAssignmentOrgDelta(String orgOid, String roleOid, QName refType, QName relation, 
+			PrismContainer<?> extension, ActivationType activationType, boolean add) throws SchemaException {
+		Collection<ItemDelta<?,?>> modifications = new ArrayList<>();
+		modifications.add((createAssignmentModification(roleOid, refType, relation, extension, activationType, add)));
+		ObjectDelta<OrgType> userDelta = ObjectDelta.createModifyDelta(orgOid, modifications, OrgType.class, prismContext);
+		return userDelta;
+	}
+	
+	private void assignRoleToOrg(String orgOid, String roleOid, Task task, OperationResult result) throws ObjectNotFoundException,
+	SchemaException, ExpressionEvaluationException, CommunicationException, ConfigurationException, ObjectAlreadyExistsException,
+	PolicyViolationException, SecurityViolationException {
+	assignRoleToOrg(orgOid, roleOid, (ActivationType) null, task, result);
+	}
+	
+	private void assignRoleToOrg(String orgOid, String roleOid, ActivationType activationType, Task task, OperationResult result) throws ObjectNotFoundException,
+	SchemaException, ExpressionEvaluationException, CommunicationException, ConfigurationException, ObjectAlreadyExistsException,
+	PolicyViolationException, SecurityViolationException {
+	modifyOrgAssignment(orgOid, roleOid, RoleType.COMPLEX_TYPE, null, task, null, activationType, true, result);
+	}
+	
+	private void unassignRoleFromOrg(String orgOid, String roleOid, Task task, OperationResult result) throws ObjectNotFoundException,
+	SchemaException, ExpressionEvaluationException, CommunicationException, ConfigurationException, ObjectAlreadyExistsException,
+	PolicyViolationException, SecurityViolationException {
+	unassignRoleFromOrg(orgOid, roleOid, (ActivationType) null, task, result);
+	}
+	
+	private void unassignRoleFromOrg(String orgOid, String roleOid, ActivationType activationType, Task task, OperationResult result) throws ObjectNotFoundException,
+	SchemaException, ExpressionEvaluationException, CommunicationException, ConfigurationException, ObjectAlreadyExistsException,
+	PolicyViolationException, SecurityViolationException {
+	modifyOrgAssignment(orgOid, roleOid, RoleType.COMPLEX_TYPE, null, task, null, activationType, false, result);
+	}
+	
+	public static <F extends FocusType> void assertOrgNotAssignedRole(PrismObject<F> focus, String roleOid) {
+		assertNotAssigned(focus, roleOid, RoleType.COMPLEX_TYPE);
+		//assertNotAssigned(user, roleOid, RoleType.COMPLEX_TYPE);
+	}
+	
+	//TODO: maybe a replacement for MidpointAsserts.assertNotAssigned()
+	//it can be used not only for user
+	public static <F extends FocusType> void assertNotAssigned(PrismObject<F> focus, String targetOid, QName refType) {
+		F focusType = focus.asObjectable();
+		for (AssignmentType assignmentType: focusType.getAssignment()) {
+			ObjectReferenceType targetRef = assignmentType.getTargetRef();
+			if (targetRef != null) {
+				if (refType.equals(targetRef.getType())) {
+					if (targetOid.equals(targetRef.getOid())) {
+						AssertJUnit.fail(focus + " does have assigned "+refType.getLocalPart()+" "+targetOid+" while not expecting it");
+					}
+				}
+			}
+		}
+	}
+	
+
+	
+	
+}

--- a/testing/story/src/test/resources/ldap-dependency/org-top.xml
+++ b/testing/story/src/test/resources/ldap-dependency/org-top.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2010-2015 Evolveum
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+ 
+<org oid="00000000-8888-6666-0000-100000000001"
+	xmlns='http://midpoint.evolveum.com/xml/ns/public/common/common-3'
+       xmlns:org='http://midpoint.evolveum.com/xml/ns/public/common/org-3'>
+	<name>TOP</name>
+	<displayName>Top</displayName>
+	<identifier>0000</identifier>
+	<orgType>functional</orgType>
+</org>

--- a/testing/story/src/test/resources/ldap-dependency/resource-opendj.xml
+++ b/testing/story/src/test/resources/ldap-dependency/resource-opendj.xml
@@ -1,0 +1,549 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2010-2016 Evolveum
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<resource oid="10000000-0000-0000-0000-000000000003"
+          xmlns="http://midpoint.evolveum.com/xml/ns/public/common/common-3"
+          xmlns:c="http://midpoint.evolveum.com/xml/ns/public/common/common-3"
+          xmlns:t="http://prism.evolveum.com/xml/ns/public/types-3"
+          xmlns:q="http://prism.evolveum.com/xml/ns/public/query-3"
+          xmlns:mr="http://prism.evolveum.com/xml/ns/public/matching-rule-3"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xmlns:ri="http://midpoint.evolveum.com/xml/ns/public/resource/instance-3"
+          xmlns:icfs="http://midpoint.evolveum.com/xml/ns/public/connector/icf-1/resource-schema-3"
+          xmlns:icfc="http://midpoint.evolveum.com/xml/ns/public/connector/icf-1/connector-schema-3"
+          xmlns:func="http://midpoint.evolveum.com/xml/ns/public/function/basic-3"
+          xmlns:ext="http://midpoint.evolveum.com/xml/ns/story/orgsync/ext">
+
+    <name>Embedded Test OpenDJ</name>
+
+    <connectorRef type="ConnectorType">
+    	<description>Dummy description, just for the test</description>
+		<filter>
+            <q:equal>
+            	<q:path>c:connectorType</q:path>
+                <q:value>com.evolveum.polygon.connector.ldap.LdapConnector</q:value>
+            </q:equal>
+        </filter>
+    </connectorRef>
+
+    <connectorConfiguration xmlns:icfcldap="http://midpoint.evolveum.com/xml/ns/public/connector/icf-1/bundle/com.evolveum.polygon.connector-ldap/com.evolveum.polygon.connector.ldap.LdapConnector">
+					   
+		<icfc:configurationProperties>
+			<icfcldap:port>10389</icfcldap:port>
+			<icfcldap:host>localhost</icfcldap:host>
+			<icfcldap:baseContext>dc=example,dc=com</icfcldap:baseContext>
+			<icfcldap:bindDn>cn=directory manager</icfcldap:bindDn>
+			<icfcldap:bindPassword><t:clearValue>secret</t:clearValue></icfcldap:bindPassword>
+			<icfcldap:pagingStrategy>auto</icfcldap:pagingStrategy>
+			<icfcldap:vlvSortAttribute>entryUUID</icfcldap:vlvSortAttribute>
+ 			<icfcldap:operationalAttributes>ds-pwp-account-disabled</icfcldap:operationalAttributes>
+ 			<icfcldap:operationalAttributes>isMemberOf</icfcldap:operationalAttributes>
+		</icfc:configurationProperties>
+		
+		<icfc:resultsHandlerConfiguration>
+			<icfc:enableNormalizingResultsHandler>false</icfc:enableNormalizingResultsHandler>
+			<icfc:enableFilteredResultsHandler>false</icfc:enableFilteredResultsHandler>
+			<icfc:enableAttributesToGetSearchResultsHandler>false</icfc:enableAttributesToGetSearchResultsHandler>
+		</icfc:resultsHandlerConfiguration>
+		
+    </connectorConfiguration>
+
+	<schemaHandling>
+
+		<objectType>
+			<kind>account</kind>
+            <intent>default</intent>
+            <displayName>Default Account</displayName>
+            <default>true</default>
+            <objectClass>ri:inetOrgPerson</objectClass>
+            <attribute>
+                <ref>ri:dn</ref>
+                <displayName>Distinguished Name</displayName>
+                <outbound>
+                    <!-- Name cannot be weak. Changes in name trigger object rename. -->
+					<source>
+						<path>$user/name</path>
+					</source>
+                    <expression>
+                    	<script>
+	                        <code>
+	                        	basic.composeDnWithSuffix('uid', name, 'ou=people,dc=example,dc=com')
+	                        </code>
+                        </script>
+                    </expression>
+                </outbound>
+            </attribute>
+
+            <attribute>
+                <ref>ri:cn</ref>
+                <displayName>Common Name</displayName>
+                <outbound>
+                	<source>
+	                    <path>$user/fullName</path>
+                    </source>
+                </outbound>
+                <inbound>
+                	<strength>weak</strength>
+                	<target>
+	                    <path>$user/fullName</path>
+                    </target>
+                </inbound>
+            </attribute>
+
+            <attribute>
+                <ref>ri:sn</ref>                
+                <outbound>
+                	<source>
+                		<path>familyName</path>
+                	</source>
+                </outbound>
+                <inbound>
+                 	<strength>weak</strength>
+                	<target>
+	                    <path>$user/familyName</path>
+                    </target>
+                </inbound>
+            </attribute>
+
+            <attribute>
+                <ref>ri:givenName</ref>
+                <outbound>
+                	<source>
+                		<path>givenName</path>
+                	</source>
+                </outbound>
+                <inbound>
+                	<strength>weak</strength>
+                	<target>
+	                    <path>$user/givenName</path>
+                    </target>
+                </inbound>
+            </attribute>
+
+            <attribute>
+                <ref>ri:uid</ref>
+                <outbound>
+                	<!-- This MUST be weak in case of OpenDJ. If DN (name) is changed then the uid will be changed
+                	     as a side-effect as it is a naming attribute. -->
+                	<strength>weak</strength>
+                	<source>
+                		<path>$user/name</path>
+                	</source>
+                </outbound>
+                <inbound>
+                	<strength>weak</strength>
+                	<target>
+	                    <path>$user/name</path>
+                    </target>
+                </inbound>                
+            </attribute>
+
+            <association>
+            	<ref>ri:group</ref>
+            	<displayName>LDAP Group Membership</displayName>
+            	<kind>entitlement</kind>
+            	<intent>group</intent>
+            	<direction>objectToSubject</direction>
+            	<associationAttribute>ri:uniqueMember</associationAttribute>
+            	<valueAttribute>ri:dn</valueAttribute>
+            	<shortcutAssociationAttribute>ri:isMemberOf</shortcutAssociationAttribute>
+            	<shortcutValueAttribute>ri:dn</shortcutValueAttribute>
+            </association>
+            <association>
+            	<ref>ri:group</ref>
+            	<displayName>LDAP Group Membership VIP</displayName>
+            	<kind>entitlement</kind>
+            	<intent>group-vip</intent>
+            	<direction>objectToSubject</direction>
+            	<associationAttribute>ri:uniqueMember</associationAttribute>
+            	<valueAttribute>ri:dn</valueAttribute>
+            	<shortcutAssociationAttribute>ri:isMemberOf</shortcutAssociationAttribute>
+            	<shortcutValueAttribute>ri:dn</shortcutValueAttribute>
+            </association>
+
+			<protected>
+       			<filter>
+	       			<q:equal>
+	       				<q:matching>http://prism.evolveum.com/xml/ns/public/matching-rule-3#stringIgnoreCase</q:matching>
+		            	<q:path>attributes/ri:dn</q:path>
+		                <q:value>uid=idm,ou=Administrators,dc=example,dc=com</q:value>
+		            </q:equal>
+	            </filter>
+			</protected>
+            
+            <activation>
+                <administrativeStatus>
+                    <outbound/>
+                    <inbound/>
+                </administrativeStatus>
+            </activation>
+            			
+            <credentials>
+                <password>
+                    <outbound/>
+                    <inbound>
+                    	<strength>weak</strength>
+                    	<expression>
+                    		<generate/>
+                    	</expression>
+                    </inbound>
+                </password>
+            </credentials>
+
+        </objectType>
+        
+        <objectType>
+			<kind>generic</kind>
+			<intent>ou</intent>
+			<displayName>OU</displayName>
+			<objectClass>ri:organizationalUnit</objectClass>
+			<attribute>
+				<c:ref>ri:dn</c:ref>
+				<outbound>
+					<strength>strong</strength>
+					<source>
+						<c:path>$focus/name</c:path>
+					</source>
+					<expression>
+						<script>
+							<code>
+								import javax.naming.ldap.LdapName
+								import javax.naming.ldap.Rdn
+								
+								def rdns = []
+								rdns.add(new Rdn('ou', name.getOrig()))
+								
+								object = focus
+								while (true) {
+									parent = midpoint.getParentOrgByOrgType(object, 'functional')
+									if (parent == null) {
+										break;
+									}
+									if (parent.getName().getOrig() == 'TOP') {
+										break;
+									}
+									rdns.add(new Rdn('ou', parent.getName().getOrig()))
+									object = parent;
+								}
+								dn = new LdapName('dc=example,dc=com')
+								rdns.reverse().each { rdn -> dn.add(rdn) }
+								return dn.toString();
+							</code>
+						</script>
+					</expression>
+				</outbound>
+			</attribute>
+			<attribute>
+				<c:ref>ri:ou</c:ref>
+				<outbound>
+					<source>
+						<c:path>$focus/name</c:path>
+					</source>
+				</outbound>
+			</attribute>
+		</objectType>
+        <objectType>
+			<kind>generic</kind>
+			<intent>ou-vip</intent>
+			<displayName>OU</displayName>
+			<objectClass>ri:organizationalUnit</objectClass>
+			<attribute>
+				<c:ref>ri:dn</c:ref>
+				<outbound>
+					<strength>strong</strength>
+					<source>
+						<c:path>$focus/name</c:path>
+					</source>
+					<expression>
+						<script>
+							<code>
+								import javax.naming.ldap.LdapName
+								import javax.naming.ldap.Rdn
+								
+								def rdns = []
+								rdns.add(new Rdn('ou', name.getOrig()+'-vip'))
+								
+								object = focus
+								while (true) {
+									parent = midpoint.getParentOrgByOrgType(object, 'functional')
+									if (parent == null) {
+										break;
+									}
+									if (parent.getName().getOrig() == 'TOP') {
+										break;
+									}
+									rdns.add(new Rdn('ou', parent.getName().getOrig()))
+									object = parent;
+								}
+								dn = new LdapName('dc=example,dc=com')
+								rdns.reverse().each { rdn -> dn.add(rdn) }
+								return dn.toString();
+							</code>
+						</script>
+					</expression>
+				</outbound>
+			</attribute>
+			<attribute>
+				<c:ref>ri:ou</c:ref>
+				<outbound>
+					<source>
+						<c:path>$focus/name</c:path>
+					</source>
+					<expression>
+						<script>
+							<code>
+								name.getOrig()+'-vip'
+							</code>
+						</script>
+					</expression>
+				</outbound>
+			</attribute>
+		</objectType>
+
+		<objectType>
+			<kind>entitlement</kind>
+			<intent>group</intent>
+			<displayName>LDAP Group</displayName>
+			<objectClass>ri:groupOfUniqueNames</objectClass>
+			<attribute>
+				<c:ref>ri:dn</c:ref>
+				<displayName>Distinguished Name</displayName>
+				<outbound>
+					<strength>strong</strength>
+					<source>
+						<c:path>$focus/name</c:path>
+					</source>
+					<expression>
+						<script>
+							<code>
+								import javax.naming.ldap.LdapName
+								import javax.naming.ldap.Rdn
+								
+								def rdns = []
+								rdns.add(new Rdn('cn', name.getOrig()))
+								rdns.add(new Rdn('ou', name.getOrig()))
+								
+								object = focus
+								while (true) {
+									parent = midpoint.getParentOrgByOrgType(object, 'functional')
+									if (parent == null) {
+										break;
+									}
+									if (parent.getName().getOrig() == 'TOP') {
+										break;
+									}
+									rdns.add(new Rdn('ou', parent.getName().getOrig()))
+									object = parent;
+								}
+								dn = new LdapName('dc=example,dc=com')
+								rdns.reverse().each { rdn -> dn.add(rdn) }
+								return dn.toString();
+							</code>
+						</script>
+					</expression>
+				</outbound>
+			</attribute>
+			<attribute>
+				<c:ref>ri:cn</c:ref>
+				<displayName>Common Name</displayName>
+				<outbound>
+					<source>
+						<c:path>$focus/name</c:path>
+					</source>
+				</outbound>
+			</attribute>
+			<association>
+            	<ref>ri:group</ref>
+            	<displayName>LDAP Group Membership</displayName>
+            	<kind>entitlement</kind>
+            	<intent>group</intent>
+            	<direction>objectToSubject</direction>
+            	<associationAttribute>ri:uniqueMember</associationAttribute>
+            	<valueAttribute>ri:dn</valueAttribute>
+            	<shortcutAssociationAttribute>ri:isMemberOf</shortcutAssociationAttribute>
+            	<shortcutValueAttribute>ri:dn</shortcutValueAttribute>
+            </association>
+            <dependency>
+				<kind>generic</kind>
+				<intent>ou</intent>
+			</dependency>
+		</objectType>
+		<objectType>
+			<kind>entitlement</kind>
+			<intent>group-vip</intent>
+			<displayName>LDAP Group VIP</displayName>
+			<objectClass>ri:groupOfUniqueNames</objectClass>
+			<attribute>
+				<c:ref>ri:dn</c:ref>
+				<displayName>Distinguished Name</displayName>
+				<outbound>
+					<strength>strong</strength>
+					<source>
+						<c:path>$focus/name</c:path>
+					</source>
+					<expression>
+						<script>
+							<code>
+								import javax.naming.ldap.LdapName
+								import javax.naming.ldap.Rdn
+								
+								def rdns = []
+								rdns.add(new Rdn('cn', name.getOrig()+'-vip'))
+								rdns.add(new Rdn('ou', name.getOrig()+'-vip'))
+								
+								object = focus
+								while (true) {
+									parent = midpoint.getParentOrgByOrgType(object, 'functional')
+									if (parent == null) {
+										break;
+									}
+									if (parent.getName().getOrig() == 'TOP') {
+										break;
+									}
+									rdns.add(new Rdn('ou', parent.getName().getOrig()))
+									object = parent;
+								}
+								dn = new LdapName('dc=example,dc=com')
+								rdns.reverse().each { rdn -> dn.add(rdn) }
+								return dn.toString();
+							</code>
+						</script>
+					</expression>
+				</outbound>
+			</attribute>
+			<attribute>
+				<c:ref>ri:cn</c:ref>
+				<displayName>Common Name</displayName>
+				<outbound>
+					<source>
+						<c:path>$focus/name</c:path>
+					</source>
+					<expression>
+						<script>
+							<code>
+								name.getOrig()+'-vip'
+							</code>
+						</script>
+					</expression>
+				</outbound>
+			</attribute>
+			<association>
+            	<ref>ri:group</ref>
+            	<displayName>LDAP Group Membership</displayName>
+            	<kind>entitlement</kind>
+            	<intent>group-vip</intent>
+            	<direction>objectToSubject</direction>
+            	<associationAttribute>ri:uniqueMember</associationAttribute>
+            	<valueAttribute>ri:dn</valueAttribute>
+            	<shortcutAssociationAttribute>ri:isMemberOf</shortcutAssociationAttribute>
+            	<shortcutValueAttribute>ri:dn</shortcutValueAttribute>
+            </association>
+            <dependency>
+				<kind>generic</kind>
+				<intent>ou-vip</intent>
+			</dependency>
+		</objectType>
+		<objectType>
+			<kind>entitlement</kind>
+			<intent>group-supervip</intent>
+			<displayName>LDAP Group SUPERVIP</displayName>
+			<objectClass>ri:groupOfUniqueNames</objectClass>
+			<attribute>
+				<c:ref>ri:dn</c:ref>
+				<displayName>Distinguished Name</displayName>
+				<outbound>
+					<strength>strong</strength>
+					<source>
+						<c:path>$focus/name</c:path>
+					</source>
+					<expression>
+						<script>
+							<code>
+								import javax.naming.ldap.LdapName
+								import javax.naming.ldap.Rdn
+								
+								def rdns = []
+								rdns.add(new Rdn('cn', name.getOrig()+'-supervip'))
+								rdns.add(new Rdn('ou', name.getOrig()+'-vip'))
+								
+								object = focus
+								while (true) {
+									parent = midpoint.getParentOrgByOrgType(object, 'functional')
+									if (parent == null) {
+										break;
+									}
+									if (parent.getName().getOrig() == 'TOP') {
+										break;
+									}
+									rdns.add(new Rdn('ou', parent.getName().getOrig()))
+									object = parent;
+								}
+								dn = new LdapName('dc=example,dc=com')
+								rdns.reverse().each { rdn -> dn.add(rdn) }
+								return dn.toString();
+							</code>
+						</script>
+					</expression>
+				</outbound>
+			</attribute>
+			<attribute>
+				<c:ref>ri:cn</c:ref>
+				<displayName>Common Name</displayName>
+				<outbound>
+					<source>
+						<c:path>$focus/name</c:path>
+					</source>
+					<expression>
+						<script>
+							<code>
+								name.getOrig()+'-supervip'
+							</code>
+						</script>
+					</expression>
+				</outbound>
+			</attribute>
+			<association>
+            	<ref>ri:group</ref>
+            	<displayName>LDAP Group Membership</displayName>
+            	<kind>entitlement</kind>
+            	<intent>group-supervip</intent>
+            	<direction>objectToSubject</direction>
+            	<associationAttribute>ri:uniqueMember</associationAttribute>
+            	<valueAttribute>ri:dn</valueAttribute>
+            	<shortcutAssociationAttribute>ri:isMemberOf</shortcutAssociationAttribute>
+            	<shortcutValueAttribute>ri:dn</shortcutValueAttribute>
+            </association>
+            <dependency>
+				<kind>generic</kind>
+				<intent>ou-vip</intent>
+			</dependency>
+		</objectType>
+	</schemaHandling>
+	
+	<capabilities>
+		<configured xmlns:cap="http://midpoint.evolveum.com/xml/ns/public/resource/capabilities-3">
+			<cap:activation>
+				<cap:status>
+					<cap:attribute>ri:ds-pwp-account-disabled</cap:attribute>
+					<cap:enableValue/>
+					<cap:disableValue>true</cap:disableValue>
+				</cap:status>
+			</cap:activation>
+		</configured>
+	</capabilities>
+
+</resource>

--- a/testing/story/src/test/resources/ldap-dependency/role-meta-org-supervip.xml
+++ b/testing/story/src/test/resources/ldap-dependency/role-meta-org-supervip.xml
@@ -1,0 +1,36 @@
+<!--
+  ~ Copyright (c) 2016 Evolveum
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<role xmlns="http://midpoint.evolveum.com/xml/ns/public/common/common-3"
+      xmlns:icfs="http://midpoint.evolveum.com/xml/ns/public/connector/icf-1/resource-schema-3"
+      xmlns:t="http://prism.evolveum.com/xml/ns/public/types-3"
+      xmlns:c="http://midpoint.evolveum.com/xml/ns/public/common/common-3"
+      xmlns:q="http://prism.evolveum.com/xml/ns/public/query-3"
+      xmlns:ri="http://midpoint.evolveum.com/xml/ns/public/resource/instance-3"
+      oid="10000000-0000-0000-0000-000000006603">
+    <name>Org Metarole SUPERVIP</name>
+
+    <inducement>
+    	<description>OM-I1-G-supervip</description>
+        <construction>
+        	<description>OM-I1-G-supervip</description>
+            <resourceRef oid="10000000-0000-0000-0000-000000000003"/>
+            <kind>entitlement</kind>
+            <intent>group-supervip</intent>
+        </construction>
+    </inducement>
+ 
+</role>

--- a/testing/story/src/test/resources/ldap-dependency/role-meta-org-vip.xml
+++ b/testing/story/src/test/resources/ldap-dependency/role-meta-org-vip.xml
@@ -1,0 +1,55 @@
+<!--
+  ~ Copyright (c) 2016 Evolveum
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<role xmlns="http://midpoint.evolveum.com/xml/ns/public/common/common-3"
+      xmlns:icfs="http://midpoint.evolveum.com/xml/ns/public/connector/icf-1/resource-schema-3"
+      xmlns:t="http://prism.evolveum.com/xml/ns/public/types-3"
+      xmlns:c="http://midpoint.evolveum.com/xml/ns/public/common/common-3"
+      xmlns:q="http://prism.evolveum.com/xml/ns/public/query-3"
+      xmlns:ri="http://midpoint.evolveum.com/xml/ns/public/resource/instance-3"
+      oid="10000000-0000-0000-0000-000000006602">
+    <name>Org Metarole VIP</name>
+
+    <inducement>
+    	<description>OM-I1-G-vip</description>
+        <construction>
+        	<description>OM-I1-G-vip</description>
+            <resourceRef oid="10000000-0000-0000-0000-000000000003"/>
+            <kind>entitlement</kind>
+            <intent>group-vip</intent>
+        </construction>
+    </inducement>
+        
+    <inducement>
+    	<description>OM-I1-OU-vip</description>
+    	<construction>
+    		<description>OM-I1-OU-vip</description>
+    		<resourceRef oid="10000000-0000-0000-0000-000000000003" type="c:ResourceType"/>
+    		<kind>generic</kind>
+    		<intent>ou-vip</intent>
+    	</construction>
+    	<condition>
+	    <expression>
+	      <script>
+	        <code>
+	          focus.getClass() == com.evolveum.midpoint.xml.ns._public.common.common_3.OrgType.class
+	        </code>
+	      </script>
+	    </expression>
+	  </condition> 
+    </inducement>
+ 
+</role>

--- a/testing/story/src/test/resources/ldap-dependency/role-meta-org.xml
+++ b/testing/story/src/test/resources/ldap-dependency/role-meta-org.xml
@@ -1,0 +1,55 @@
+<!--
+  ~ Copyright (c) 2016 Evolveum
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<role xmlns="http://midpoint.evolveum.com/xml/ns/public/common/common-3"
+      xmlns:icfs="http://midpoint.evolveum.com/xml/ns/public/connector/icf-1/resource-schema-3"
+      xmlns:t="http://prism.evolveum.com/xml/ns/public/types-3"
+      xmlns:c="http://midpoint.evolveum.com/xml/ns/public/common/common-3"
+      xmlns:q="http://prism.evolveum.com/xml/ns/public/query-3"
+      xmlns:ri="http://midpoint.evolveum.com/xml/ns/public/resource/instance-3"
+      oid="10000000-0000-0000-0000-000000006601">
+    <name>Org Metarole</name>
+
+    <inducement>
+    	<description>OM-I1-G</description>
+        <construction>
+        	<description>OM-I1-G</description>
+            <resourceRef oid="10000000-0000-0000-0000-000000000003"/>
+            <kind>entitlement</kind>
+            <intent>group</intent>
+        </construction>
+    </inducement>
+        
+    <inducement>
+    	<description>OM-I1-OU</description>
+    	<construction>
+    		<description>OM-I1-OU</description>
+    		<resourceRef oid="10000000-0000-0000-0000-000000000003" type="c:ResourceType"/>
+    		<kind>generic</kind>
+    		<intent>ou</intent>
+    	</construction>
+    	<condition>
+	    <expression>
+	      <script>
+	        <code>
+	          focus.getClass() == com.evolveum.midpoint.xml.ns._public.common.common_3.OrgType.class
+	        </code>
+	      </script>
+	    </expression>
+	  </condition> 
+    </inducement>
+    
+</role>


### PR DESCRIPTION
having two similar roles for orgs each containing two inducements:
one for creating org unit in ldap, one for creating group in ldap. each group depends on org unit of the same role.

when both roles are assigned and one is removed midpoint fails complaining about dependency.
but this should not happen since group2 does not depend on anything of role1.