### PR TITLE
Multi value target - changed target Edit do Add

### DIFF
--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/form/multivalue/MultiValueChoosePanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/form/multivalue/MultiValueChoosePanel.java
@@ -237,9 +237,6 @@ public class MultiValueChoosePanel<T extends ObjectType> extends BasePanel<List<
 		getModel().setObject(chosenValues);
 		choosePerformedHook(target, chosenValues);
 
-		if (LOGGER.isTraceEnabled()) {
-			LOGGER.trace("New object instance has been added to the model.");
-		}
 		target.add(MultiValueChoosePanel.this);
 	}
 
@@ -253,9 +250,6 @@ public class MultiValueChoosePanel<T extends ObjectType> extends BasePanel<List<
 		getModel().setObject(modelList);
 		choosePerformedHook(target, modelList);
 
-		if (LOGGER.isTraceEnabled()) {
-			LOGGER.trace("New object instance has been added to the model.");
-		}
 		target.add(MultiValueChoosePanel.this);
 	}
 

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/form/multivalue/MultiValueChoosePanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/form/multivalue/MultiValueChoosePanel.java
@@ -22,6 +22,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import javax.xml.namespace.QName;
 
@@ -165,12 +166,6 @@ public class MultiValueChoosePanel<T extends ObjectType> extends BasePanel<List<
 		add(selectedRowsList);
     }
 
-	protected void replaceIfEmpty(List<T> chosenValues) {
-				
-		getModel().setObject(chosenValues); 
-		LOGGER.debug("Replaced model object with selected : {}", chosenValues);
-	}
-
 	protected ObjectQuery createChooseQuery(List<PrismReferenceValue> values) {
 		ArrayList<String> oidList = new ArrayList<>();
 		ObjectQuery query = new ObjectQuery();
@@ -219,17 +214,18 @@ public class MultiValueChoosePanel<T extends ObjectType> extends BasePanel<List<
 			@Override
 			protected void addPerformed(AjaxRequestTarget target, QName type, List<T> selected) {
 				getPageBase().hideMainPopup(target);
-				choosePerformed(target, selected);
+				MultiValueChoosePanel.this.addPerformed(target, selected);
 			}
-			
+
 			@Override
-					protected void onSelectPerformed(AjaxRequestTarget target, T focus) {
-						super.onSelectPerformed(target, focus);
-						if( ! multiselect) {
-							// asList alone is not modifiable, you can't add/remove elements later
-							choosePerformed(target, new ArrayList<>(asList(focus)));
-						}
-					}
+			protected void onSelectPerformed(AjaxRequestTarget target, T focus) {
+				super.onSelectPerformed(target, focus);
+				if (!multiselect) {
+					// asList alone is not modifiable, you can't add/remove
+					// elements later
+					selectPerformed(target, new ArrayList<>(asList(focus)));
+				}
+			}
 
 		};
 
@@ -237,9 +233,25 @@ public class MultiValueChoosePanel<T extends ObjectType> extends BasePanel<List<
 
 	}
 
-	protected void choosePerformed(AjaxRequestTarget target, List<T> chosenValues) {
+	protected void selectPerformed(AjaxRequestTarget target, List<T> chosenValues) {
+		getModel().setObject(chosenValues);
 		choosePerformedHook(target, chosenValues);
-		replaceIfEmpty(chosenValues);
+
+		if (LOGGER.isTraceEnabled()) {
+			LOGGER.trace("New object instance has been added to the model.");
+		}
+		target.add(MultiValueChoosePanel.this);
+	}
+
+	protected void addPerformed(AjaxRequestTarget target, List<T> addedValues) {
+		List<T> modelList = getModelObject();
+		if(modelList == null) {
+			modelList = new ArrayList<T>();
+		}
+		addedValues.removeAll(modelList); // add values not already in
+		modelList.addAll(addedValues);
+		getModel().setObject(modelList);
+		choosePerformedHook(target, modelList);
 
 		if (LOGGER.isTraceEnabled()) {
 			LOGGER.trace("New object instance has been added to the model.");

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/reports/component/ConvertingMultiValueChoosePanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/reports/component/ConvertingMultiValueChoosePanel.java
@@ -24,7 +24,6 @@ public class ConvertingMultiValueChoosePanel<U, T extends ObjectType> extends Mu
 
 	public ConvertingMultiValueChoosePanel(String id, List<Class<? extends T>> types, Function<T, U> transformFunction,
 			IModel<List<U>> targetModel, boolean multiselect) {
-		// FIXME ? convert target model to List<T> with inverse function
 		super(id, new ListModel<>(), types, multiselect);
 
 		this.transformFunction = transformFunction;
@@ -33,7 +32,6 @@ public class ConvertingMultiValueChoosePanel<U, T extends ObjectType> extends Mu
 
 	@Override
 	protected void choosePerformedHook(AjaxRequestTarget target, List<T> selected) {
-
 		if(selected != null) {
 			targetModel.setObject(
 					selected.stream()

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/reports/component/ConvertingMultiValueChoosePanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/reports/component/ConvertingMultiValueChoosePanel.java
@@ -24,6 +24,7 @@ public class ConvertingMultiValueChoosePanel<U, T extends ObjectType> extends Mu
 
 	public ConvertingMultiValueChoosePanel(String id, List<Class<? extends T>> types, Function<T, U> transformFunction,
 			IModel<List<U>> targetModel, boolean multiselect) {
+		// FIXME ? convert target model to List<T> with inverse function
 		super(id, new ListModel<>(), types, multiselect);
 
 		this.transformFunction = transformFunction;
@@ -32,6 +33,7 @@ public class ConvertingMultiValueChoosePanel<U, T extends ObjectType> extends Mu
 
 	@Override
 	protected void choosePerformedHook(AjaxRequestTarget target, List<T> selected) {
+
 		if(selected != null) {
 			targetModel.setObject(
 					selected.stream()


### PR DESCRIPTION
Selecting targets in Audit Log Viewer popup object browser and pressing 'Add' now only adds the selected values instead of replacing the old list. This way you can even select multiple targets of different types for audit.