### PR TITLE
Load artifacts from repository under https rather than http

### DIFF
--- a/build-system/pom.xml
+++ b/build-system/pom.xml
@@ -31,7 +31,7 @@
         <pluginRepository>
             <id>evolveum</id>
             <name>Evolveum</name>
-            <url>http://nexus.evolveum.com/nexus/content/groups/public</url>
+            <url>https://nexus.evolveum.com/nexus/content/groups/public</url>
         </pluginRepository>
     </pluginRepositories>
     <properties>
@@ -1197,12 +1197,12 @@
       <repository>
         <id>evolveum-nexus</id>
         <name>Internal Releases</name>
-        <url>http://nexus.evolveum.com/nexus/content/repositories/releases/</url>
+        <url>https://nexus.evolveum.com/nexus/content/repositories/releases/</url>
       </repository>
       <snapshotRepository>
         <id>evolveum-nexus</id>
         <name>Internal Snapshots</name>
-        <url>http://nexus.evolveum.com/nexus/content/repositories/snapshots/</url>
+        <url>https://nexus.evolveum.com/nexus/content/repositories/snapshots/</url>
       </snapshotRepository>
     </distributionManagement>
 

--- a/infra/schema-pure-jaxb/pom.xml
+++ b/infra/schema-pure-jaxb/pom.xml
@@ -35,12 +35,12 @@
       <repository>
         <id>evolveum-nexus</id>
         <name>Internal Releases</name>
-        <url>http://nexus.evolveum.com/nexus/content/repositories/releases/</url>
+        <url>https://nexus.evolveum.com/nexus/content/repositories/releases/</url>
       </repository>
       <snapshotRepository>
         <id>evolveum-nexus</id>
         <name>Internal Releases</name>
-        <url>http://nexus.evolveum.com/nexus/content/repositories/snapshots/</url>
+        <url>https://nexus.evolveum.com/nexus/content/repositories/snapshots/</url>
       </snapshotRepository>
     </distributionManagement>
 

--- a/model/model-client/pom.xml
+++ b/model/model-client/pom.xml
@@ -35,12 +35,12 @@
       <repository>
         <id>evolveum-nexus</id>
         <name>Internal Releases</name>
-        <url>http://nexus.evolveum.com/nexus/content/repositories/releases/</url>
+        <url>https://nexus.evolveum.com/nexus/content/repositories/releases/</url>
       </repository>
       <snapshotRepository>
         <id>evolveum-nexus</id>
         <name>Internal Releases</name>
-        <url>http://nexus.evolveum.com/nexus/content/repositories/snapshots/</url>
+        <url>https://nexus.evolveum.com/nexus/content/repositories/snapshots/</url>
       </snapshotRepository>
     </distributionManagement>
 

--- a/pom.xml
+++ b/pom.xml
@@ -40,12 +40,12 @@
         <repository>
             <id>evolveum-nexus</id>
             <name>Internal Releases</name>
-            <url>http://nexus.evolveum.com/nexus/content/repositories/releases/</url>
+            <url>https://nexus.evolveum.com/nexus/content/repositories/releases/</url>
         </repository>
         <snapshotRepository>
             <id>evolveum-nexus</id>
             <name>Internal Snapshots</name>
-            <url>http://nexus.evolveum.com/nexus/content/repositories/snapshots/</url>
+            <url>https://nexus.evolveum.com/nexus/content/repositories/snapshots/</url>
         </snapshotRepository>
     </distributionManagement>
 
@@ -140,12 +140,12 @@
 		<repository>
 			<id>evolveum</id>
 			<name>Evolveum Public Releases</name>
-			<url>http://nexus.evolveum.com/nexus/content/groups/public</url>
+			<url>https://nexus.evolveum.com/nexus/content/groups/public</url>
 		</repository>
 		<repository>
 			<id>evolveum-snapshots</id>
 			<name>Evolveum Snapshots</name>
-			<url>http://nexus.evolveum.com/nexus/content/repositories/snapshots/</url>
+			<url>https://nexus.evolveum.com/nexus/content/repositories/snapshots/</url>
 		</repository>
 	</repositories>
 	<properties>

--- a/samples/model-client-sample/pom.xml
+++ b/samples/model-client-sample/pom.xml
@@ -47,12 +47,12 @@
       <repository>
         <id>evolveum-nexus</id>
         <name>Internal Releases</name>
-        <url>http://nexus.evolveum.com/nexus/content/repositories/releases/</url>
+        <url>https://nexus.evolveum.com/nexus/content/repositories/releases/</url>
       </repository>
       <snapshotRepository>
         <id>evolveum-nexus</id>
         <name>Internal Releases</name>
-        <url>http://nexus.evolveum.com/nexus/content/repositories/snapshots/</url>
+        <url>https://nexus.evolveum.com/nexus/content/repositories/snapshots/</url>
       </snapshotRepository>
     </distributionManagement>
 

--- a/testing/minipoint/pom.xml
+++ b/testing/minipoint/pom.xml
@@ -51,13 +51,13 @@
     </repository>
     <repository>
       <id>evolveum-nexus-relases</id>
-      <url>http://nexus.evolveum.com/nexus/content/repositories/releases/</url>
+      <url>https://nexus.evolveum.com/nexus/content/repositories/releases/</url>
       <releases><enabled>true</enabled></releases>
       <snapshots><enabled>false</enabled></snapshots>
     </repository>
     <repository>
       <id>evolveum-nexus-snapshots</id>
-      <url>http://nexus.evolveum.com/nexus/content/repositories/snapshots/</url>
+      <url>https://nexus.evolveum.com/nexus/content/repositories/snapshots/</url>
       <releases><enabled>false</enabled></releases>
       <snapshots><enabled>true</enabled></snapshots>
     </repository>
@@ -66,12 +66,12 @@
       <repository>
         <id>evolveum-nexus</id>
         <name>Internal Releases</name>
-        <url>http://nexus.evolveum.com/nexus/content/repositories/releases/</url>
+        <url>https://nexus.evolveum.com/nexus/content/repositories/releases/</url>
       </repository>
       <snapshotRepository>
         <id>evolveum-nexus</id>
         <name>Internal Snapshots</name>
-        <url>http://nexus.evolveum.com/nexus/content/repositories/snapshots/</url>
+        <url>https://nexus.evolveum.com/nexus/content/repositories/snapshots/</url>
       </snapshotRepository>
     </distributionManagement>
   <dependencies>


### PR DESCRIPTION
Opt for a "more secure" option to load/download artifacts from the nexus repository. 