### PR TITLE
Use Java 8's @FunctionalInterface where possible

### DIFF
--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/api/model/CountModelProvider.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/api/model/CountModelProvider.java
@@ -24,6 +24,7 @@ import org.apache.wicket.model.IModel;
  * 
  * @author semancik
  */
+@FunctionalInterface
 public interface CountModelProvider {
 	
 	/**

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/TabbedPanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/TabbedPanel.java
@@ -488,7 +488,8 @@ public class TabbedPanel<T extends ITab> extends Panel {
      */
     protected void onTabChange(int index) {}
 
-	public interface RightSideItemProvider extends Serializable {
+	@FunctionalInterface
+    public interface RightSideItemProvider extends Serializable {
 		Component createRightSideItem(String id);
 	}
 }

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/data/column/InlineMenuable.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/data/column/InlineMenuable.java
@@ -24,6 +24,7 @@ import java.util.List;
 /**
  * @author lazyman
  */
+@FunctionalInterface
 public interface InlineMenuable extends Serializable {
 
     String F_MENU_ITEMS = "menuItems";

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/util/Choiceable.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/util/Choiceable.java
@@ -1,5 +1,6 @@
 package com.evolveum.midpoint.web.component.util;
 
+@FunctionalInterface
 public interface Choiceable {
 
 	public String getName();

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/util/FocusListComponent.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/util/FocusListComponent.java
@@ -27,6 +27,7 @@ import com.evolveum.midpoint.xml.ns._public.common.common_3.FocusType;
  *
  * @author mederly
  */
+@FunctionalInterface
 public interface FocusListComponent<F extends FocusType> {
 
 	MainObjectListPanel<F> getObjectListPanel();

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/util/Validatable.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/util/Validatable.java
@@ -1,5 +1,6 @@
 package com.evolveum.midpoint.web.component.util;
 
+@FunctionalInterface
 public interface Validatable {
 	
 	public boolean isEmpty();

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/certification/handlers/CertGuiHandler.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/certification/handlers/CertGuiHandler.java
@@ -23,6 +23,7 @@ import org.apache.wicket.model.IModel;
 /**
  * @author mederly
  */
+@FunctionalInterface
 public interface CertGuiHandler {
     String getCaseInfoButtonTitle(IModel<? extends CertCaseOrWorkItemDto> rowModel, PageBase page);
 }

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/server/TaskTabPanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/server/TaskTabPanel.java
@@ -23,6 +23,7 @@ import java.util.Collection;
 /**
  * @author mederly
  */
+@FunctionalInterface
 public interface TaskTabPanel {
 	Collection<Component> getComponentsToUpdate();
 }

--- a/infra/prism/src/main/java/com/evolveum/midpoint/prism/Checkable.java
+++ b/infra/prism/src/main/java/com/evolveum/midpoint/prism/Checkable.java
@@ -3,6 +3,7 @@ package com.evolveum.midpoint.prism;
 /**
  * @author mederly
  */
+@FunctionalInterface
 public interface Checkable {
 
     void checkConsistence();

--- a/infra/prism/src/main/java/com/evolveum/midpoint/prism/PathVisitable.java
+++ b/infra/prism/src/main/java/com/evolveum/midpoint/prism/PathVisitable.java
@@ -23,6 +23,7 @@ import com.evolveum.midpoint.prism.path.ItemPath;
  * @author Radovan Semancik
  *
  */
+@FunctionalInterface
 public interface PathVisitable {
 	
 	void accept(Visitor visitor, ItemPath path, boolean recursive);

--- a/infra/prism/src/main/java/com/evolveum/midpoint/prism/Revivable.java
+++ b/infra/prism/src/main/java/com/evolveum/midpoint/prism/Revivable.java
@@ -21,6 +21,7 @@ import com.evolveum.midpoint.util.exception.SchemaException;
  * @author Radovan Semancik
  *
  */
+@FunctionalInterface
 public interface Revivable {
 
 	void revive(PrismContext prismContext) throws SchemaException;

--- a/infra/prism/src/main/java/com/evolveum/midpoint/prism/SimpleVisitable.java
+++ b/infra/prism/src/main/java/com/evolveum/midpoint/prism/SimpleVisitable.java
@@ -19,6 +19,7 @@ package com.evolveum.midpoint.prism;
  * @author semancik
  *
  */
+@FunctionalInterface
 public interface SimpleVisitable<T> {
 
 	void simpleAccept(SimpleVisitor<T> visitor);

--- a/infra/prism/src/main/java/com/evolveum/midpoint/prism/SimpleVisitor.java
+++ b/infra/prism/src/main/java/com/evolveum/midpoint/prism/SimpleVisitor.java
@@ -19,6 +19,7 @@ package com.evolveum.midpoint.prism;
  * @author semancik
  *
  */
+@FunctionalInterface
 public interface SimpleVisitor<T> {
 	
 	void visit(T element);

--- a/infra/prism/src/main/java/com/evolveum/midpoint/prism/Structured.java
+++ b/infra/prism/src/main/java/com/evolveum/midpoint/prism/Structured.java
@@ -21,6 +21,7 @@ import com.evolveum.midpoint.prism.path.ItemPath;
  * @author semancik
  *
  */
+@FunctionalInterface
 public interface Structured {
 	
 	Object resolve(ItemPath subpath);

--- a/infra/prism/src/main/java/com/evolveum/midpoint/prism/Visitable.java
+++ b/infra/prism/src/main/java/com/evolveum/midpoint/prism/Visitable.java
@@ -19,6 +19,7 @@ package com.evolveum.midpoint.prism;
  * @author semancik
  *
  */
+@FunctionalInterface
 public interface Visitable {
 	
 	void accept(Visitor visitor);

--- a/infra/prism/src/main/java/com/evolveum/midpoint/prism/Visitor.java
+++ b/infra/prism/src/main/java/com/evolveum/midpoint/prism/Visitor.java
@@ -19,6 +19,7 @@ package com.evolveum.midpoint.prism;
  * @author semancik
  *
  */
+@FunctionalInterface
 public interface Visitor {
 	
 	void visit(Visitable visitable);

--- a/infra/prism/src/main/java/com/evolveum/midpoint/prism/delta/ItemDeltaValidator.java
+++ b/infra/prism/src/main/java/com/evolveum/midpoint/prism/delta/ItemDeltaValidator.java
@@ -21,6 +21,7 @@ import com.evolveum.midpoint.prism.PrismValue;
  * @author semancik
  *
  */
+@FunctionalInterface
 public interface ItemDeltaValidator<V extends PrismValue> {
 	
 	void validate(PlusMinusZero plusMinusZero, V itemValue);

--- a/infra/prism/src/main/java/com/evolveum/midpoint/prism/marshaller/PrismBeanInspector.java
+++ b/infra/prism/src/main/java/com/evolveum/midpoint/prism/marshaller/PrismBeanInspector.java
@@ -59,6 +59,7 @@ public class PrismBeanInspector {
 
 	//region Caching mechanism (multiple dimensions)
 
+    @FunctionalInterface
     interface Getter1<V, P1> {
         V get(P1 param1);
     }
@@ -73,6 +74,7 @@ public class PrismBeanInspector {
         }
     }
 
+    @FunctionalInterface
     interface Getter2<V, P1, P2> {
         V get(P1 param1, P2 param2);
     }
@@ -91,6 +93,7 @@ public class PrismBeanInspector {
         });
     }
 
+    @FunctionalInterface
     interface Getter3<V, P1, P2, P3> {
         V get(P1 param1, P2 param2, P3 param3);
     }

--- a/infra/prism/src/main/java/com/evolveum/midpoint/prism/polystring/PolyStringNormalizer.java
+++ b/infra/prism/src/main/java/com/evolveum/midpoint/prism/polystring/PolyStringNormalizer.java
@@ -23,6 +23,7 @@ package com.evolveum.midpoint.prism.polystring;
  * @see PolyString
  * @author Radovan Semancik
  */
+@FunctionalInterface
 public interface PolyStringNormalizer {
 
 	/**

--- a/infra/prism/src/main/java/com/evolveum/midpoint/prism/query/ItemFilter.java
+++ b/infra/prism/src/main/java/com/evolveum/midpoint/prism/query/ItemFilter.java
@@ -19,6 +19,7 @@ import org.jetbrains.annotations.NotNull;
 
 import com.evolveum.midpoint.prism.path.ItemPath;
 
+@FunctionalInterface
 public interface ItemFilter {
 	
 	@NotNull ItemPath getFullPath();

--- a/infra/prism/src/main/java/com/evolveum/midpoint/prism/query/Visitor.java
+++ b/infra/prism/src/main/java/com/evolveum/midpoint/prism/query/Visitor.java
@@ -16,6 +16,7 @@
 
 package com.evolveum.midpoint.prism.query;
 
+@FunctionalInterface
 public interface Visitor {
 
 	void visit(ObjectFilter filter);

--- a/infra/prism/src/main/java/com/evolveum/midpoint/prism/schema/SchemaDescription.java
+++ b/infra/prism/src/main/java/com/evolveum/midpoint/prism/schema/SchemaDescription.java
@@ -286,7 +286,8 @@ public class SchemaDescription implements DebugDumpable {
 		return DOMUtil.getFirstChildElement(node);
 	}
 	
-	private interface InputStreamable {
+	@FunctionalInterface
+    private interface InputStreamable {
 		InputStream openInputStream();
 	}
 

--- a/infra/prism/src/main/java/com/evolveum/midpoint/prism/util/PrismContextFactory.java
+++ b/infra/prism/src/main/java/com/evolveum/midpoint/prism/util/PrismContextFactory.java
@@ -24,6 +24,7 @@ import com.evolveum.midpoint.util.exception.SchemaException;
  * @author Radovan Semancik
  *
  */
+@FunctionalInterface
 public interface PrismContextFactory {
 	
 	/**

--- a/infra/schema/src/main/java/com/evolveum/midpoint/schema/ResultHandler.java
+++ b/infra/schema/src/main/java/com/evolveum/midpoint/schema/ResultHandler.java
@@ -27,6 +27,7 @@ import com.evolveum.midpoint.xml.ns._public.common.common_3.ObjectType;
  * 
  * @author Radovan Semancik
  */
+@FunctionalInterface
 public interface ResultHandler<T extends ObjectType> {
 
     /**

--- a/infra/schema/src/main/java/com/evolveum/midpoint/schema/result/AsynchronousOperationQueryable.java
+++ b/infra/schema/src/main/java/com/evolveum/midpoint/schema/result/AsynchronousOperationQueryable.java
@@ -23,6 +23,7 @@ import com.evolveum.midpoint.util.exception.SchemaException;
  * 
  * @author Radovan Semancik
  */
+@FunctionalInterface
 public interface AsynchronousOperationQueryable {
 
 	OperationResultStatus queryOperationStatus(String asyncronousOperationReference, OperationResult parentResult) throws ObjectNotFoundException, SchemaException;

--- a/infra/util/src/main/java/com/evolveum/midpoint/util/Cloner.java
+++ b/infra/util/src/main/java/com/evolveum/midpoint/util/Cloner.java
@@ -19,6 +19,7 @@ package com.evolveum.midpoint.util;
  * @author semancik
  *
  */
+@FunctionalInterface
 public interface Cloner<T> {
 
 	public T clone(T original);

--- a/infra/util/src/main/java/com/evolveum/midpoint/util/DebugDumpable.java
+++ b/infra/util/src/main/java/com/evolveum/midpoint/util/DebugDumpable.java
@@ -19,6 +19,7 @@ package com.evolveum.midpoint.util;
  * @author Radovan Semancik
  *
  */
+@FunctionalInterface
 public interface DebugDumpable {
 	
 	String INDENT_STRING = "  ";

--- a/infra/util/src/main/java/com/evolveum/midpoint/util/DomElementVisitor.java
+++ b/infra/util/src/main/java/com/evolveum/midpoint/util/DomElementVisitor.java
@@ -21,6 +21,7 @@ import org.w3c.dom.Element;
  * @author Radovan Semancik
  *
  */
+@FunctionalInterface
 public interface DomElementVisitor {
 
 	public void visit(Element element);

--- a/infra/util/src/main/java/com/evolveum/midpoint/util/FailableProcessor.java
+++ b/infra/util/src/main/java/com/evolveum/midpoint/util/FailableProcessor.java
@@ -19,6 +19,7 @@ package com.evolveum.midpoint.util;
  * @author semancik
  *
  */
+@FunctionalInterface
 public interface FailableProcessor<T> {
 
 	void process(T object) throws Exception;

--- a/infra/util/src/main/java/com/evolveum/midpoint/util/FailableRunnable.java
+++ b/infra/util/src/main/java/com/evolveum/midpoint/util/FailableRunnable.java
@@ -20,6 +20,7 @@ package com.evolveum.midpoint.util;
  * 
  * @author semancik
  */
+@FunctionalInterface
 public interface FailableRunnable {
 	
 	public abstract void run() throws Exception;

--- a/infra/util/src/main/java/com/evolveum/midpoint/util/Foreachable.java
+++ b/infra/util/src/main/java/com/evolveum/midpoint/util/Foreachable.java
@@ -19,6 +19,7 @@ package com.evolveum.midpoint.util;
  * @author semancik
  *
  */
+@FunctionalInterface
 public interface Foreachable<T> {
 	
 	/**

--- a/infra/util/src/main/java/com/evolveum/midpoint/util/Handler.java
+++ b/infra/util/src/main/java/com/evolveum/midpoint/util/Handler.java
@@ -19,6 +19,7 @@ package com.evolveum.midpoint.util;
  * @author Radovan Semancik
  *
  */
+@FunctionalInterface
 public interface Handler<T> {
 
     // returns false if the iteration (if any) has to be stopped

--- a/infra/util/src/main/java/com/evolveum/midpoint/util/HeteroComparator.java
+++ b/infra/util/src/main/java/com/evolveum/midpoint/util/HeteroComparator.java
@@ -19,6 +19,7 @@ package com.evolveum.midpoint.util;
  * @author semancik
  *
  */
+@FunctionalInterface
 public interface HeteroComparator<A,B> {
 
 	boolean isEquivalent(A a, B b);

--- a/infra/util/src/main/java/com/evolveum/midpoint/util/HumanReadableDescribable.java
+++ b/infra/util/src/main/java/com/evolveum/midpoint/util/HumanReadableDescribable.java
@@ -21,6 +21,7 @@ package com.evolveum.midpoint.util;
  * 
  * @author semancik
  */
+@FunctionalInterface
 public interface HumanReadableDescribable {
 
 	String toHumanReadableDescription();

--- a/infra/util/src/main/java/com/evolveum/midpoint/util/Processor.java
+++ b/infra/util/src/main/java/com/evolveum/midpoint/util/Processor.java
@@ -19,6 +19,7 @@ package com.evolveum.midpoint.util;
  * @author semancik
  *
  */
+@FunctionalInterface
 public interface Processor<T> {
 
 	void process(T object);

--- a/infra/util/src/main/java/com/evolveum/midpoint/util/SchemaFailableProcessor.java
+++ b/infra/util/src/main/java/com/evolveum/midpoint/util/SchemaFailableProcessor.java
@@ -21,6 +21,7 @@ import com.evolveum.midpoint.util.exception.SchemaException;
  * @author semancik
  *
  */
+@FunctionalInterface
 public interface SchemaFailableProcessor<T> {
 
 	void process(T object) throws SchemaException;

--- a/infra/util/src/main/java/com/evolveum/midpoint/util/ShortDumpable.java
+++ b/infra/util/src/main/java/com/evolveum/midpoint/util/ShortDumpable.java
@@ -18,6 +18,7 @@ package com.evolveum.midpoint.util;
 /**
  * @author Radovan Semancik
  */
+@FunctionalInterface
 public interface ShortDumpable {
 	
 	/**

--- a/infra/util/src/main/java/com/evolveum/midpoint/util/Transformer.java
+++ b/infra/util/src/main/java/com/evolveum/midpoint/util/Transformer.java
@@ -19,6 +19,7 @@ package com.evolveum.midpoint.util;
  * @author semancik
  *
  */
+@FunctionalInterface
 public interface Transformer<T,X> {
 
 	X transform(T in);

--- a/infra/util/src/main/java/com/evolveum/midpoint/util/Validator.java
+++ b/infra/util/src/main/java/com/evolveum/midpoint/util/Validator.java
@@ -20,6 +20,7 @@ package com.evolveum.midpoint.util;
  * 
  * @author Radovan Semancik
  */
+@FunctionalInterface
 public interface Validator<T> {
 	
 	/**

--- a/infra/util/src/main/java/com/evolveum/midpoint/util/aspect/ObjectFormatter.java
+++ b/infra/util/src/main/java/com/evolveum/midpoint/util/aspect/ObjectFormatter.java
@@ -19,6 +19,7 @@ package com.evolveum.midpoint.util.aspect;
  * @author Radovan Semancik
  *
  */
+@FunctionalInterface
 public interface ObjectFormatter {
 	
 	public String format(Object o);

--- a/model/model-api/src/main/java/com/evolveum/midpoint/model/api/validator/ResourceValidator.java
+++ b/model/model-api/src/main/java/com/evolveum/midpoint/model/api/validator/ResourceValidator.java
@@ -32,6 +32,7 @@ import java.util.Locale;
  *
  * @author mederly
  */
+@FunctionalInterface
 public interface ResourceValidator {
 
 	String CAT_BASIC = "basic";

--- a/model/model-impl/src/main/java/com/evolveum/midpoint/model/impl/integrity/DuplicateShadowsResolver.java
+++ b/model/model-impl/src/main/java/com/evolveum/midpoint/model/impl/integrity/DuplicateShadowsResolver.java
@@ -24,6 +24,7 @@ import java.util.Collection;
 /**
  * @author Pavol Mederly
  */
+@FunctionalInterface
 public interface DuplicateShadowsResolver {
 
     /**

--- a/model/model-impl/src/main/java/com/evolveum/midpoint/model/impl/lens/FailableLensFunction.java
+++ b/model/model-impl/src/main/java/com/evolveum/midpoint/model/impl/lens/FailableLensFunction.java
@@ -26,6 +26,7 @@ import com.evolveum.midpoint.util.exception.SecurityViolationException;
  * @author semancik
  *
  */
+@FunctionalInterface
 public interface FailableLensFunction<T, R> {
 	
 	R apply(T param) throws ObjectNotFoundException, SchemaException, CommunicationException, ConfigurationException, SecurityViolationException, ExpressionEvaluationException;

--- a/model/model-impl/src/main/java/com/evolveum/midpoint/model/impl/lens/ProjectorComponentRunnable.java
+++ b/model/model-impl/src/main/java/com/evolveum/midpoint/model/impl/lens/ProjectorComponentRunnable.java
@@ -29,6 +29,7 @@ import com.evolveum.midpoint.util.exception.SecurityViolationException;
  * 
  * @author semancik
  */
+@FunctionalInterface
 public interface ProjectorComponentRunnable {
 	
 	void run() throws SchemaException, ObjectNotFoundException, CommunicationException, ConfigurationException, 

--- a/model/model-impl/src/main/java/com/evolveum/midpoint/model/impl/lens/projector/MappingExtractor.java
+++ b/model/model-impl/src/main/java/com/evolveum/midpoint/model/impl/lens/projector/MappingExtractor.java
@@ -23,6 +23,7 @@ import com.evolveum.midpoint.prism.ItemDefinition;
 import com.evolveum.midpoint.prism.PrismValue;
 import com.evolveum.midpoint.xml.ns._public.common.common_3.FocusType;
 
+@FunctionalInterface
 public interface MappingExtractor<V extends PrismValue, D extends ItemDefinition, F extends FocusType> {
 
 	Collection<? extends PrismValueDeltaSetTripleProducer<V,D>> getMappings(Construction<F> construction);

--- a/model/model-impl/src/main/java/com/evolveum/midpoint/model/impl/lens/projector/MappingInitializer.java
+++ b/model/model-impl/src/main/java/com/evolveum/midpoint/model/impl/lens/projector/MappingInitializer.java
@@ -24,6 +24,7 @@ import com.evolveum.midpoint.util.exception.SchemaException;
  * @author Radovan Semancik
  *
  */
+@FunctionalInterface
 public interface MappingInitializer<V extends PrismValue,D extends ItemDefinition> {
 
 	Mapping.Builder<V,D> initialize(Mapping.Builder<V,D> mapping) throws SchemaException;

--- a/model/model-impl/src/main/java/com/evolveum/midpoint/model/impl/lens/projector/MappingOutputProcessor.java
+++ b/model/model-impl/src/main/java/com/evolveum/midpoint/model/impl/lens/projector/MappingOutputProcessor.java
@@ -25,6 +25,7 @@ import com.evolveum.midpoint.util.exception.SchemaException;
  * @author semancik
  *
  */
+@FunctionalInterface
 public interface MappingOutputProcessor<V extends PrismValue> {
 
 	/**

--- a/model/model-impl/src/main/java/com/evolveum/midpoint/model/impl/rest/ConvertorInterface.java
+++ b/model/model-impl/src/main/java/com/evolveum/midpoint/model/impl/rest/ConvertorInterface.java
@@ -21,6 +21,7 @@ import org.jetbrains.annotations.NotNull;
 /**
  * @author mederly
  */
+@FunctionalInterface
 public interface ConvertorInterface {
 
 	/**

--- a/model/model-impl/src/main/java/com/evolveum/midpoint/model/impl/scripting/ActionExecutor.java
+++ b/model/model-impl/src/main/java/com/evolveum/midpoint/model/impl/scripting/ActionExecutor.java
@@ -25,6 +25,7 @@ import com.evolveum.midpoint.xml.ns._public.model.scripting_3.ActionExpressionTy
  *
  * @author mederly
  */
+@FunctionalInterface
 public interface ActionExecutor {
 
     /**

--- a/model/model-impl/src/main/java/com/evolveum/midpoint/model/impl/sync/ReconciliationTaskResultListener.java
+++ b/model/model-impl/src/main/java/com/evolveum/midpoint/model/impl/sync/ReconciliationTaskResultListener.java
@@ -23,6 +23,7 @@ package com.evolveum.midpoint.model.impl.sync;
  * @author Radovan Semancik
  *
  */
+@FunctionalInterface
 public interface ReconciliationTaskResultListener {
 
 	void process(ReconciliationTaskResult reconResult);

--- a/model/notifications-api/src/main/java/com/evolveum/midpoint/notifications/api/EventHandler.java
+++ b/model/notifications-api/src/main/java/com/evolveum/midpoint/notifications/api/EventHandler.java
@@ -25,6 +25,7 @@ import com.evolveum.midpoint.xml.ns._public.common.common_3.EventHandlerType;
 /**
  * @author mederly
  */
+@FunctionalInterface
 public interface EventHandler {
 
     // true if we should continue with processing, false otherwise

--- a/provisioning/provisioning-api/src/main/java/com/evolveum/midpoint/provisioning/api/ConstraintViolationConfirmer.java
+++ b/provisioning/provisioning-api/src/main/java/com/evolveum/midpoint/provisioning/api/ConstraintViolationConfirmer.java
@@ -22,6 +22,7 @@ import com.evolveum.midpoint.xml.ns._public.common.common_3.ShadowType;
 /**
  * @author mederly
  */
+@FunctionalInterface
 public interface ConstraintViolationConfirmer {
 
 	/**

--- a/provisioning/provisioning-api/src/main/java/com/evolveum/midpoint/provisioning/api/ProvisioningListener.java
+++ b/provisioning/provisioning-api/src/main/java/com/evolveum/midpoint/provisioning/api/ProvisioningListener.java
@@ -19,6 +19,7 @@ package com.evolveum.midpoint.provisioning.api;
  * @author Radovan Semancik
  *
  */
+@FunctionalInterface
 public interface ProvisioningListener {
 	
 	/**

--- a/provisioning/provisioning-impl/src/main/java/com/evolveum/midpoint/provisioning/impl/ConnectorManager.java
+++ b/provisioning/provisioning-impl/src/main/java/com/evolveum/midpoint/provisioning/impl/ConnectorManager.java
@@ -539,7 +539,8 @@ public class ConnectorManager {
 		}
 	}
 	
-	private interface ConnectorFactoryConsumer {
+	@FunctionalInterface
+    private interface ConnectorFactoryConsumer {
 		void process(ConnectorFactory connectorFactory) throws CommunicationException;
 	}
 

--- a/provisioning/ucf-api/src/main/java/com/evolveum/midpoint/provisioning/ucf/api/ShadowResultHandler.java
+++ b/provisioning/ucf-api/src/main/java/com/evolveum/midpoint/provisioning/ucf/api/ShadowResultHandler.java
@@ -26,6 +26,7 @@ import com.evolveum.midpoint.xml.ns._public.common.common_3.ShadowType;
  * 
  * @author Radovan Semancik
  */
+@FunctionalInterface
 public interface ShadowResultHandler {
 
     /**

--- a/provisioning/ucf-api/src/main/java/com/evolveum/midpoint/provisioning/ucf/api/Token.java
+++ b/provisioning/ucf-api/src/main/java/com/evolveum/midpoint/provisioning/ucf/api/Token.java
@@ -19,6 +19,7 @@ package com.evolveum.midpoint.provisioning.ucf.api;
  *
  * @author Radovan Semancik
  */
+@FunctionalInterface
 public interface Token {
 	
 	/**

--- a/repo/repo-sql-impl-test/src/test/java/com/evolveum/midpoint/repo/sql/ConcurrencyTest.java
+++ b/repo/repo-sql-impl-test/src/test/java/com/evolveum/midpoint/repo/sql/ConcurrencyTest.java
@@ -183,6 +183,7 @@ public class ConcurrencyTest extends BaseSQLRepoTest {
         concurrencyUniversal("Test4", 60000L, 0L, mts, checker);
     }
 
+    @FunctionalInterface
     private interface Checker {
         void check(int iteration, String oid) throws Exception;
     }

--- a/repo/repo-sql-impl/src/main/java/com/evolveum/midpoint/repo/sql/data/common/enums/SchemaEnum.java
+++ b/repo/repo-sql-impl/src/main/java/com/evolveum/midpoint/repo/sql/data/common/enums/SchemaEnum.java
@@ -22,6 +22,7 @@ package com.evolveum.midpoint.repo.sql.data.common.enums;
  *
  * @author lazyman
  */
+@FunctionalInterface
 public interface SchemaEnum<C> {
 
     C getSchemaValue();

--- a/repo/repo-sql-impl/src/main/java/com/evolveum/midpoint/repo/sql/query2/definition/JpaEntityDefinition.java
+++ b/repo/repo-sql-impl/src/main/java/com/evolveum/midpoint/repo/sql/query2/definition/JpaEntityDefinition.java
@@ -85,6 +85,7 @@ public class JpaEntityDefinition extends JpaDataNodeDefinition implements DebugD
         return null;
     }
 
+    @FunctionalInterface
     public interface LinkDefinitionHandler {
         void handle(JpaLinkDefinition linkDefinition);
     }

--- a/repo/repo-test-util/src/main/java/com/evolveum/midpoint/test/ObjectChecker.java
+++ b/repo/repo-test-util/src/main/java/com/evolveum/midpoint/test/ObjectChecker.java
@@ -19,6 +19,7 @@ package com.evolveum.midpoint.test;
  * @author semancik
  *
  */
+@FunctionalInterface
 public interface ObjectChecker<T> {
 	
 	public void check(T change);

--- a/repo/repo-test-util/src/main/java/com/evolveum/midpoint/test/ObjectSource.java
+++ b/repo/repo-test-util/src/main/java/com/evolveum/midpoint/test/ObjectSource.java
@@ -19,6 +19,7 @@ package com.evolveum.midpoint.test;
  * @author semancik
  *
  */
+@FunctionalInterface
 public interface ObjectSource<T> {
 
 	public T get();

--- a/repo/task-api/src/main/java/com/evolveum/midpoint/task/api/LightweightIdentifierGenerator.java
+++ b/repo/task-api/src/main/java/com/evolveum/midpoint/task/api/LightweightIdentifierGenerator.java
@@ -19,6 +19,7 @@ package com.evolveum.midpoint.task.api;
  * @author semancik
  *
  */
+@FunctionalInterface
 public interface LightweightIdentifierGenerator {
 	
 	public LightweightIdentifier generate();

--- a/repo/task-api/src/main/java/com/evolveum/midpoint/task/api/LightweightTaskHandler.java
+++ b/repo/task-api/src/main/java/com/evolveum/midpoint/task/api/LightweightTaskHandler.java
@@ -23,6 +23,7 @@ package com.evolveum.midpoint.task.api;
  *
  * @author Pavol Mederly
  */
+@FunctionalInterface
 public interface LightweightTaskHandler {
 	
 	public void run(Task task);

--- a/repo/task-api/src/main/java/com/evolveum/midpoint/task/api/TaskDeletionListener.java
+++ b/repo/task-api/src/main/java/com/evolveum/midpoint/task/api/TaskDeletionListener.java
@@ -21,6 +21,7 @@ import com.evolveum.midpoint.schema.result.OperationResult;
 /**
  * @author mederly
  */
+@FunctionalInterface
 public interface TaskDeletionListener {
 
 	/**

--- a/samples/model-client-sample/src/test/java/com/evolveum/midpoint/testing/model/client/sample/TestExchangeAlreadyExistsHandling.java
+++ b/samples/model-client-sample/src/test/java/com/evolveum/midpoint/testing/model/client/sample/TestExchangeAlreadyExistsHandling.java
@@ -364,6 +364,7 @@ public class TestExchangeAlreadyExistsHandling extends AbstractTestForExchangeCo
 //        cleanup();
     }
 
+    @FunctionalInterface
     private interface OperationResultMatcher {
         boolean match(OperationResultType operationResultType);
     }

--- a/samples/model-client-sample/src/test/java/com/evolveum/midpoint/testing/model/client/sample/TestExchangeConnectorLow.java
+++ b/samples/model-client-sample/src/test/java/com/evolveum/midpoint/testing/model/client/sample/TestExchangeConnectorLow.java
@@ -637,6 +637,7 @@ public class TestExchangeConnectorLow extends AbstractTestForExchangeConnector {
         cleanup();
     }
 
+    @FunctionalInterface
     private interface OperationResultMatcher {
         boolean match(OperationResultType operationResultType);
     }

--- a/tools/xjc-plugin/src/main/java/com/evolveum/midpoint/schema/xjc/Processor.java
+++ b/tools/xjc-plugin/src/main/java/com/evolveum/midpoint/schema/xjc/Processor.java
@@ -23,6 +23,7 @@ import org.xml.sax.ErrorHandler;
 /**
  * @author lazyman
  */
+@FunctionalInterface
 public interface Processor {
 
     boolean run(Outline outline, Options opt, ErrorHandler errorHandler) throws Exception;


### PR DESCRIPTION
Now that midPoint runs on Java 8, this rather noisy pull allows the codebase to take advantage of @FunctionalInterface where needed, in hopes that lambdas can then be used where possible.