### PR TITLE
Update copyright tags to match 2017.

### DIFF
--- a/cli/common/pom.xml
+++ b/cli/common/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/cli/common/testng-unit.xml
+++ b/cli/common/testng-unit.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/cli/ninja/pom.xml
+++ b/cli/ninja/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/cli/ninja/src/main/resources/logback-ninja.xml
+++ b/cli/ninja/src/main/resources/logback-ninja.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/cli/ninja/src/main/resources/logback.xml
+++ b/cli/ninja/src/main/resources/logback.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/cli/ninja/src/test/resources/logback-test.xml
+++ b/cli/ninja/src/test/resources/logback-test.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/cli/ninja/src/test/resources/user.xml
+++ b/cli/ninja/src/test/resources/user.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/cli/ninja/testng-unit.xml
+++ b/cli/ninja/testng-unit.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/cli/seppuku/pom.xml
+++ b/cli/seppuku/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/cli/seppuku/src/main/resources/ctx-main.xml
+++ b/cli/seppuku/src/main/resources/ctx-main.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/cli/seppuku/src/main/resources/logback-seppuku.xml
+++ b/cli/seppuku/src/main/resources/logback-seppuku.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/cli/seppuku/src/main/resources/logback.xml
+++ b/cli/seppuku/src/main/resources/logback.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/cli/seppuku/src/test/resources/logback-test.xml
+++ b/cli/seppuku/src/test/resources/logback-test.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/cli/seppuku/testng-unit.xml
+++ b/cli/seppuku/testng-unit.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/config/initial-objects/010-value-policy.xml
+++ b/config/initial-objects/010-value-policy.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2014 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/config/initial-objects/020-system-configuration.xml
+++ b/config/initial-objects/020-system-configuration.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/config/initial-objects/030-role-superuser.xml
+++ b/config/initial-objects/030-role-superuser.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/config/initial-objects/040-role-enduser.xml
+++ b/config/initial-objects/040-role-enduser.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/config/initial-objects/041-role-approver.xml
+++ b/config/initial-objects/041-role-approver.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2016 Evolveum
+  ~ Copyright (c) 2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/config/initial-objects/042-role-reviewer.xml
+++ b/config/initial-objects/042-role-reviewer.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/config/initial-objects/043-role-delegator.xml
+++ b/config/initial-objects/043-role-delegator.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2016 Evolveum
+  ~ Copyright (c) 2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/config/initial-objects/050-user-administrator.xml
+++ b/config/initial-objects/050-user-administrator.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2014 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/config/initial-objects/060-task-cleanup.xml
+++ b/config/initial-objects/060-task-cleanup.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2014 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/config/initial-objects/070-task-validity.xml
+++ b/config/initial-objects/070-task-validity.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2014 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/config/initial-objects/080-task-trigger.xml
+++ b/config/initial-objects/080-task-trigger.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2014 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/config/initial-objects/130-report-certification-definitions.xml
+++ b/config/initial-objects/130-report-certification-definitions.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/config/initial-objects/140-report-certification-campaigns.xml
+++ b/config/initial-objects/140-report-certification-campaigns.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/config/initial-objects/150-report-certification-cases.xml
+++ b/config/initial-objects/150-report-certification-cases.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/config/initial-objects/160-report-certification-decisions.xml
+++ b/config/initial-objects/160-report-certification-decisions.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/config/initial-objects/200-lookup-languages.xml
+++ b/config/initial-objects/200-lookup-languages.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2016 Evolveum, AMI Praha
+  ~ Copyright (c) 2017 Evolveum, AMI Praha
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/config/initial-objects/210-lookup-locales.xml
+++ b/config/initial-objects/210-lookup-locales.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2016 Evolveum, AMI Praha
+  ~ Copyright (c) 2017 Evolveum, AMI Praha
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/config/initial-objects/220-lookup-timezones.xml
+++ b/config/initial-objects/220-lookup-timezones.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2016 Evolveum, AMI Praha
+  ~ Copyright (c) 2017 Evolveum, AMI Praha
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/config/initial-objects/230-lookup-lifecycle-state.xml
+++ b/config/initial-objects/230-lookup-lifecycle-state.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2016 Evolveum, AMI Praha
+  ~ Copyright (c) 2017 Evolveum, AMI Praha
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/custom/pom.xml
+++ b/custom/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2014 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/dist/midpoint-api/pom.xml
+++ b/dist/midpoint-api/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/dist/src/main/assembly/dist.xml
+++ b/dist/src/main/assembly/dist.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/api/component/BasePanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/api/component/BasePanel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/api/component/ObjectBrowserPanel.html
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/api/component/ObjectBrowserPanel.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/api/component/ObjectBrowserPanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/api/component/ObjectBrowserPanel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/api/component/PopupObjectListPanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/api/component/PopupObjectListPanel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/api/component/RelationSelectorAssignablePanel.html
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/api/component/RelationSelectorAssignablePanel.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/api/component/autocomplete/AbstractAutoCompletePanel.html
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/api/component/autocomplete/AbstractAutoCompletePanel.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/api/component/autocomplete/AutoCompleteQNamePanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/api/component/autocomplete/AutoCompleteQNamePanel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/api/component/autocomplete/AutoCompleteTextPanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/api/component/autocomplete/AutoCompleteTextPanel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/api/component/button/CsvDownloadButtonPanel.html
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/api/component/button/CsvDownloadButtonPanel.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/api/component/button/DropdownButtonDto.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/api/component/button/DropdownButtonDto.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/api/component/button/DropdownButtonPanel.html
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/api/component/button/DropdownButtonPanel.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/api/component/button/DropdownButtonPanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/api/component/button/DropdownButtonPanel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/api/component/captcha/CaptchaPanel.html
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/api/component/captcha/CaptchaPanel.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/api/component/password/PasswordPanel.html
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/api/component/password/PasswordPanel.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/api/component/password/PasswordPanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/api/component/password/PasswordPanel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/api/component/result/OperationResultPanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/api/component/result/OperationResultPanel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/api/model/LoadableModel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/api/model/LoadableModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/api/model/NonEmptyLoadableModel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/api/model/NonEmptyLoadableModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/api/model/NonEmptyModel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/api/model/NonEmptyModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/api/page/PageBase.html
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/api/page/PageBase.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/api/page/PageBase.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/api/page/PageBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/api/util/FocusTabVisibleBehavior.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/api/util/FocusTabVisibleBehavior.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/api/util/WebComponentUtil.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/api/util/WebComponentUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/application/AuthorizationActionValue.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/application/AuthorizationActionValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/application/DescriptorLoader.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/application/DescriptorLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/AjaxIconButton.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/AjaxIconButton.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/AsyncUpdatePanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/AsyncUpdatePanel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/DateLabelComponent.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/DateLabelComponent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/FocusSummaryPanel.html
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/FocusSummaryPanel.html
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/GuiComponents.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/GuiComponents.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/LockoutStatusPanel.html
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/LockoutStatusPanel.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/ObjectPolicyConfigurationEditor.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/ObjectPolicyConfigurationEditor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/TabbedPanel.html
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/TabbedPanel.html
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/assignment/ACAttributeValuePanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/assignment/ACAttributeValuePanel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/assignment/AssignmentCatalogPanel.html
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/assignment/AssignmentCatalogPanel.html
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/assignment/AssignmentDetailsPanel.html
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/assignment/AssignmentDetailsPanel.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/assignment/AssignmentEditorDto.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/assignment/AssignmentEditorDto.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/assignment/AssignmentEditorDtoType.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/assignment/AssignmentEditorDtoType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/assignment/AssignmentEditorPanel.html
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/assignment/AssignmentEditorPanel.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/assignment/AssignmentHeaderPanel.html
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/assignment/AssignmentHeaderPanel.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/assignment/AssignmentHeaderPanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/assignment/AssignmentHeaderPanel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/assignment/AssignmentTablePanel.html
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/assignment/AssignmentTablePanel.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/assignment/CatalogItemsPanel.html
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/assignment/CatalogItemsPanel.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/assignment/DelegationEditorPanel.html
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/assignment/DelegationEditorPanel.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/assignment/DelegationEditorPanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/assignment/DelegationEditorPanel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/assignment/MetadataPanel.html
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/assignment/MetadataPanel.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/assignment/MetadataPanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/assignment/MetadataPanel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/assignment/RelationTypes.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/assignment/RelationTypes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/assignment/ShoppingCartEditorPanel.html
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/assignment/ShoppingCartEditorPanel.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/assignment/ShoppingCartEditorPanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/assignment/ShoppingCartEditorPanel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/box/InfoBoxPanel.html
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/box/InfoBoxPanel.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/breadcrumbs/Breadcrumb.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/breadcrumbs/Breadcrumb.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/breadcrumbs/BreadcrumbPageClass.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/breadcrumbs/BreadcrumbPageClass.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/breadcrumbs/BreadcrumbPageInstance.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/breadcrumbs/BreadcrumbPageInstance.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/data/BaseSortableDataProvider.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/data/BaseSortableDataProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/data/BoxedTablePanel.html
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/data/BoxedTablePanel.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/data/BoxedTablePanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/data/BoxedTablePanel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/data/CountToolbar.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/data/CountToolbar.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/data/DoubleButtonPanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/data/DoubleButtonPanel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/data/MultiButtonPanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/data/MultiButtonPanel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/data/MultiButtonTable.html
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/data/MultiButtonTable.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/data/SelectableBeanObjectDataProvider.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/data/SelectableBeanObjectDataProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/data/SingleButtonPanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/data/SingleButtonPanel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/data/column/CheckBoxHeaderColumn.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/data/column/CheckBoxHeaderColumn.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/data/column/ColumnUtils.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/data/column/ColumnUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/data/column/InlineMenuHeaderColumn.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/data/column/InlineMenuHeaderColumn.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/data/column/LinkColumn.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/data/column/LinkColumn.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/data/column/LinkPanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/data/column/LinkPanel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/data/column/ObjectLinkColumn.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/data/column/ObjectLinkColumn.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/dialog/ChooseFocusTypeDialogPanel.html
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/dialog/ChooseFocusTypeDialogPanel.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~    Licensed under the Apache License, Version 2.0 (the "License");
   ~    you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/dialog/ConfirmationPanel.html
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/dialog/ConfirmationPanel.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~    Licensed under the Apache License, Version 2.0 (the "License");
   ~    you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/dialog/ConfirmationPanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/dialog/ConfirmationPanel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/dialog/DeleteAllPanel.html
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/dialog/DeleteAllPanel.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/dialog/HelpInfoPanel.html
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/dialog/HelpInfoPanel.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/dialog/MainPopupDialog.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/dialog/MainPopupDialog.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/form/AceEditorFormGroup.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/form/AceEditorFormGroup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/form/CheckFormGroup.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/form/CheckFormGroup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/form/DateFormGroup.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/form/DateFormGroup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/form/DropDownFormGroup.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/form/DropDownFormGroup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/form/Form.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/form/Form.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/form/TextAreaFormGroup.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/form/TextAreaFormGroup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/form/TextFormGroup.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/form/TextFormGroup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/form/ValueChoosePanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/form/ValueChoosePanel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/form/multivalue/GenericMultiValueLabelEditPanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/form/multivalue/GenericMultiValueLabelEditPanel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/form/multivalue/MultiValueAutoCompleteTextPanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/form/multivalue/MultiValueAutoCompleteTextPanel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/form/multivalue/MultiValueChoosePanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/form/multivalue/MultiValueChoosePanel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/form/multivalue/MultiValueDropDownPanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/form/multivalue/MultiValueDropDownPanel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/form/multivalue/MultiValueTextEditPanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/form/multivalue/MultiValueTextEditPanel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/form/multivalue/MultiValueTextFormGroup.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/form/multivalue/MultiValueTextFormGroup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/form/multivalue/MultiValueTextPanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/form/multivalue/MultiValueTextPanel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/input/MultiStateHorizontalButton.html
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/input/MultiStateHorizontalButton.html
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/input/MultiStateHorizontalButton.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/input/MultiStateHorizontalButton.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/input/QNameChoiceRenderer.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/input/QNameChoiceRenderer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/input/QNameEditorPanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/input/QNameEditorPanel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/input/ThreeStateBooleanPanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/input/ThreeStateBooleanPanel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/input/TwoStateBooleanPanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/input/TwoStateBooleanPanel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/menu/BaseMenuItem.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/menu/BaseMenuItem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/menu/MainMenuItem.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/menu/MainMenuItem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/menu/MainMenuPanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/menu/MainMenuPanel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/menu/MenuItem.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/menu/MenuItem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/menu/UserMenuPanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/menu/UserMenuPanel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/menu/cog/InlineMenu.html
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/menu/cog/InlineMenu.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/menu/cog/InlineMenu.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/menu/cog/InlineMenu.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/menu/cog/MenuLinkPanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/menu/cog/MenuLinkPanel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/message/FeedbackListView.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/message/FeedbackListView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/objectdetails/AbstractObjectMainPanel.html
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/objectdetails/AbstractObjectMainPanel.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/objectdetails/AbstractObjectTabPanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/objectdetails/AbstractObjectTabPanel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/objectdetails/AbstractRoleMainPanel.html
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/objectdetails/AbstractRoleMainPanel.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/objectdetails/FocusAssignmentsTabPanel.html
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/objectdetails/FocusAssignmentsTabPanel.html
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/objectdetails/FocusAssignmentsTabPanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/objectdetails/FocusAssignmentsTabPanel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/objectdetails/FocusDetailsTabPanel.html
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/objectdetails/FocusDetailsTabPanel.html
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/objectdetails/FocusDetailsTabPanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/objectdetails/FocusDetailsTabPanel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/objectdetails/FocusProjectionsTabPanel.html
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/objectdetails/FocusProjectionsTabPanel.html
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/objectdetails/FocusProjectionsTabPanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/objectdetails/FocusProjectionsTabPanel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/objectdetails/ObjectHistoryTabPanel.html
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/objectdetails/ObjectHistoryTabPanel.html
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/prism/CheckTableHeader.html
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/prism/CheckTableHeader.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/prism/CheckTableHeader.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/prism/CheckTableHeader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/prism/ContainerWrapper.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/prism/ContainerWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/prism/ContainerWrapperFactory.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/prism/ContainerWrapperFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/prism/DynamicFormPanel.html
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/prism/DynamicFormPanel.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/prism/H3Header.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/prism/H3Header.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/prism/ItemWrapper.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/prism/ItemWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/prism/ObjectWrapper.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/prism/ObjectWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/prism/PrismContainerPanel.html
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/prism/PrismContainerPanel.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/prism/PrismContainerPanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/prism/PrismContainerPanel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/prism/PrismHeaderPanel.html
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/prism/PrismHeaderPanel.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/prism/PrismHeaderPanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/prism/PrismHeaderPanel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/prism/PrismObjectPanel.html
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/prism/PrismObjectPanel.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/prism/PrismObjectPanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/prism/PrismObjectPanel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/prism/PrismPropertyPanel.html
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/prism/PrismPropertyPanel.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/prism/PrismPropertyPanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/prism/PrismPropertyPanel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/prism/PrismValuePanel.html
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/prism/PrismValuePanel.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/prism/PrismValuePanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/prism/PrismValuePanel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/prism/PropertyOrReferenceWrapper.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/prism/PropertyOrReferenceWrapper.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2010-2016 Evolveum
+ *  Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/prism/SimpleErrorPanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/prism/SimpleErrorPanel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/prism/show/PagePreviewChanges.html
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/prism/show/PagePreviewChanges.html
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/prism/show/SceneButtonPanel.html
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/prism/show/SceneButtonPanel.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/prism/show/SceneButtonPanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/prism/show/SceneButtonPanel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/prism/show/SceneDto.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/prism/show/SceneDto.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/prism/show/SceneItemDto.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/prism/show/SceneItemDto.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/prism/show/SceneItemLineDto.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/prism/show/SceneItemLineDto.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/prism/show/SceneItemLinePanel.html
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/prism/show/SceneItemLinePanel.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/prism/show/SceneItemLinePanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/prism/show/SceneItemLinePanel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/prism/show/SceneItemPanel.html
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/prism/show/SceneItemPanel.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/prism/show/SceneItemPanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/prism/show/SceneItemPanel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/prism/show/SceneItemValuePanel.html
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/prism/show/SceneItemValuePanel.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/prism/show/SceneItemValuePanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/prism/show/SceneItemValuePanel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/prism/show/ScenePanel.html
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/prism/show/ScenePanel.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/prism/show/ScenePanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/prism/show/ScenePanel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/prism/show/WrapperScene.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/prism/show/WrapperScene.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/progress/ProgressPanel.html
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/progress/ProgressPanel.html
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/progress/ProgressPanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/progress/ProgressPanel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/progress/ProgressReporter.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/progress/ProgressReporter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/progress/ProgressReportingAwarePage.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/progress/ProgressReportingAwarePage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/refresh/AutoRefreshDto.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/refresh/AutoRefreshDto.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/refresh/AutoRefreshPanel.html
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/refresh/AutoRefreshPanel.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/refresh/AutoRefreshPanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/refresh/AutoRefreshPanel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/refresh/Refreshable.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/refresh/Refreshable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/refresh/RemovableAjaxTimerBehavior.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/refresh/RemovableAjaxTimerBehavior.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/search/BrowserPopupPanel.html
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/search/BrowserPopupPanel.html
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/search/BrowserPopupPanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/search/BrowserPopupPanel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/search/ComboPopupPanel.html
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/search/ComboPopupPanel.html
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/search/ComboPopupPanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/search/ComboPopupPanel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/search/DisplayableRenderer.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/search/DisplayableRenderer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/search/ObjectBrowserDialog.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/search/ObjectBrowserDialog.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/search/SearchFormPanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/search/SearchFormPanel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/search/SearchPopupPanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/search/SearchPopupPanel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/search/TextPopupPanel.html
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/search/TextPopupPanel.html
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/search/TextPopupPanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/search/TextPopupPanel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/util/BaseDeprecatedPanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/util/BaseDeprecatedPanel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/util/FocusListComponent.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/util/FocusListComponent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/util/FocusListInlineMenuHelper.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/util/FocusListInlineMenuHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/util/FutureUpdateBehavior.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/util/FutureUpdateBehavior.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/util/ListDataProvider.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/util/ListDataProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/util/ListDataProvider2.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/util/ListDataProvider2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/util/ObjectWrapperUtil.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/util/ObjectWrapperUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/util/SimplePanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/util/SimplePanel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/util/SummaryTagSimple.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/util/SummaryTagSimple.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/wf/WorkItemsPanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/wf/WorkItemsPanel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/wizard/ResourceWizardPreviousButton.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/wizard/ResourceWizardPreviousButton.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/wizard/WizardIssuesPanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/wizard/WizardIssuesPanel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/wizard/WizardStep.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/wizard/WizardStep.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/wizard/WizardSteps.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/wizard/WizardSteps.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/wizard/resource/ConfigurationStep.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/wizard/resource/ConfigurationStep.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/wizard/resource/SchemaStep.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/wizard/resource/SchemaStep.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/wizard/resource/SynchronizationStep.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/wizard/resource/SynchronizationStep.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/wizard/resource/component/WizardHelpDialog.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/wizard/resource/component/WizardHelpDialog.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/wizard/resource/component/capability/AddCapabilityDialog.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/wizard/resource/component/capability/AddCapabilityDialog.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/wizard/resource/component/schemahandling/AttributeEditorUtils.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/wizard/resource/component/schemahandling/AttributeEditorUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/wizard/resource/component/schemahandling/modal/ExpressionVariableEditorDialog.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/wizard/resource/component/schemahandling/modal/ExpressionVariableEditorDialog.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/wizard/resource/component/schemahandling/modal/LimitationsEditorDialog.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/wizard/resource/component/schemahandling/modal/LimitationsEditorDialog.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/wizard/resource/component/schemahandling/modal/MappingEditorDialog.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/wizard/resource/component/schemahandling/modal/MappingEditorDialog.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/wizard/resource/component/synchronization/SynchronizationActionEditorDialog.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/wizard/resource/component/synchronization/SynchronizationActionEditorDialog.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/wizard/resource/dto/Capability.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/wizard/resource/dto/Capability.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/wizard/resource/dto/WizardIssuesDto.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/wizard/resource/dto/WizardIssuesDto.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/model/ContainerWrapperFromObjectWrapperModel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/model/ContainerWrapperFromObjectWrapperModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/model/LookupPropertyModel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/model/LookupPropertyModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/model/PrismPropertyRealValueFromContainerableModel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/model/PrismPropertyRealValueFromContainerableModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/model/PrismPropertyRealValueFromObjectWrapperModel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/model/PrismPropertyRealValueFromObjectWrapperModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/model/PrismPropertyRealValueFromPrismObjectModel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/model/PrismPropertyRealValueFromPrismObjectModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/model/PropertyWrapperFromObjectWrapperModel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/model/PropertyWrapperFromObjectWrapperModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/model/ReadOnlyPrismObjectFromObjectWrapperModel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/model/ReadOnlyPrismObjectFromObjectWrapperModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/PageAdminObjectDetails.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/PageAdminObjectDetails.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/certification/CertDefinitionSummaryPanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/certification/CertDefinitionSummaryPanel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/certification/DefinitionBasicPanel.html
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/certification/DefinitionBasicPanel.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/certification/DefinitionBasicPanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/certification/DefinitionBasicPanel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/certification/DefinitionStagePanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/certification/DefinitionStagePanel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/certification/PageCertCampaign.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/certification/PageCertCampaign.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/certification/PageCertDefinition.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/certification/PageCertDefinition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/certification/PageCertDefinitions.html
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/certification/PageCertDefinitions.html
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/certification/PageCertDefinitions.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/certification/PageCertDefinitions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/certification/StageEditorPanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/certification/StageEditorPanel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/certification/dto/CertCampaignListItemDto.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/certification/dto/CertCampaignListItemDto.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/certification/dto/CertCaseOrWorkItemDto.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/certification/dto/CertCaseOrWorkItemDto.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/certification/dto/DefinitionScopeDto.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/certification/dto/DefinitionScopeDto.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/certification/handlers/CertGuiHandlerRegistry.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/certification/handlers/CertGuiHandlerRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/certification/helpers/AvailableResponses.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/certification/helpers/AvailableResponses.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/configuration/PageEvaluateMapping.html
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/configuration/PageEvaluateMapping.html
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/configuration/PageEvaluateMapping.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/configuration/PageEvaluateMapping.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/configuration/component/AceEditorDialog.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/configuration/component/AceEditorDialog.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/configuration/component/AdminGuiConfigPanel.html
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/configuration/component/AdminGuiConfigPanel.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~    Licensed under the Apache License, Version 2.0 (the "License");
   ~    you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/configuration/component/AdminGuiConfigPanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/configuration/component/AdminGuiConfigPanel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/configuration/component/ChooseTypePanel.html
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/configuration/component/ChooseTypePanel.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/configuration/component/ChooseTypePanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/configuration/component/ChooseTypePanel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/configuration/component/ObjectPolicyPanel.html
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/configuration/component/ObjectPolicyPanel.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/configuration/component/ObjectPolicyPanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/configuration/component/ObjectPolicyPanel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/configuration/component/ObjectSelectionPage.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/configuration/component/ObjectSelectionPage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/configuration/component/ObjectSelectionPanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/configuration/component/ObjectSelectionPanel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/configuration/component/RichHyperlinkConfigDialog.html
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/configuration/component/RichHyperlinkConfigDialog.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~    Licensed under the Apache License, Version 2.0 (the "License");
   ~    you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/configuration/component/RichHyperlinkConfigDialog.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/configuration/component/RichHyperlinkConfigDialog.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/configuration/component/RichHyperlinkConfigPanel.html
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/configuration/component/RichHyperlinkConfigPanel.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~    Licensed under the Apache License, Version 2.0 (the "License");
   ~    you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/configuration/component/SystemConfigPanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/configuration/component/SystemConfigPanel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/configuration/dto/AccountDetailsSearchDto.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/configuration/dto/AccountDetailsSearchDto.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/configuration/dto/DebugSearchDto.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/configuration/dto/DebugSearchDto.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/configuration/dto/ExecuteMappingDto.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/configuration/dto/ExecuteMappingDto.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/configuration/dto/ObjectPolicyDialogDto.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/configuration/dto/ObjectPolicyDialogDto.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/home/PageDashboard.html
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/home/PageDashboard.html
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/home/PageDashboard.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/home/PageDashboard.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/home/component/AsyncDashboardPanel.html
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/home/component/AsyncDashboardPanel.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/home/component/AsyncDashboardPanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/home/component/AsyncDashboardPanel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/home/component/DashboardPanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/home/component/DashboardPanel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/home/component/MyAssignmentsPanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/home/component/MyAssignmentsPanel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/home/dto/AssignmentItemDto.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/home/dto/AssignmentItemDto.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/orgs/OrgTreeAssignablePanel.html
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/orgs/OrgTreeAssignablePanel.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/orgs/OrgTreePanel.html
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/orgs/OrgTreePanel.html
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/reports/component/AceEditorPanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/reports/component/AceEditorPanel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/reports/component/AuditLogViewerPanel.html
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/reports/component/AuditLogViewerPanel.html
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/reports/component/AuditPopupPanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/reports/component/AuditPopupPanel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/reports/component/ParameterPropertiesPopupPanel.html
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/reports/component/ParameterPropertiesPopupPanel.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/reports/component/ParameterPropertiesPopupPanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/reports/component/ParameterPropertiesPopupPanel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/reports/component/ReconciliationPopupPanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/reports/component/ReconciliationPopupPanel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/reports/component/UserReportConfigPanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/reports/component/UserReportConfigPanel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/reports/dto/ReportOutputSearchDto.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/reports/dto/ReportOutputSearchDto.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/reports/dto/ReportSearchDto.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/reports/dto/ReportSearchDto.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/resources/CapabilitiesPanel.html
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/resources/CapabilitiesPanel.html
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/resources/CapabilitiesPanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/resources/CapabilitiesPanel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/resources/PageConnectorHosts.html
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/resources/PageConnectorHosts.html
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/resources/PageResource.html
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/resources/PageResource.html
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/resources/PageResource.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/resources/PageResource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/resources/PageResourceVisualization.html
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/resources/PageResourceVisualization.html
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/resources/PageResourceVisualization.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/resources/PageResourceVisualization.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/resources/ResourceContentPanel.html
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/resources/ResourceContentPanel.html
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/resources/ResourceContentResourcePanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/resources/ResourceContentResourcePanel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/resources/ResourceContentTabPanel.html
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/resources/ResourceContentTabPanel.html
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/resources/ResourceContentTabPanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/resources/ResourceContentTabPanel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/resources/ResourceDetailsTabPanel.html
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/resources/ResourceDetailsTabPanel.html
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/resources/ResourceDetailsTabPanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/resources/ResourceDetailsTabPanel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/resources/ResourceSummaryPanel.html
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/resources/ResourceSummaryPanel.html
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/resources/ResourceTasksPanel.html
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/resources/ResourceTasksPanel.html
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/resources/ResourceTasksPanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/resources/ResourceTasksPanel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/resources/ResourceWizardIssuesModel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/resources/ResourceWizardIssuesModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/resources/ResourceWizardModel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/resources/ResourceWizardModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/resources/component/TestConnectionResultPanel.html
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/resources/component/TestConnectionResultPanel.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/resources/component/TestConnectionResultPanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/resources/component/TestConnectionResultPanel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/resources/content/PageAccount.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/resources/content/PageAccount.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/resources/content/dto/ResourceContentSearchDto.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/resources/content/dto/ResourceContentSearchDto.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/resources/dto/ResourceVisualizationDto.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/resources/dto/ResourceVisualizationDto.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/roles/PageRole.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/roles/PageRole.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/roles/RoleMemberPanel.html
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/roles/RoleMemberPanel.html
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/roles/RoleMemberSearchDto.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/roles/RoleMemberSearchDto.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/server/PageTaskAdd.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/server/PageTaskAdd.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/server/PageTaskController.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/server/PageTaskController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/server/PageTaskEdit.html
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/server/PageTaskEdit.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/server/PageTasksCertScheduling.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/server/PageTasksCertScheduling.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/server/TaskApprovalsTabPanel.html
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/server/TaskApprovalsTabPanel.html
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/server/TaskApprovalsTabPanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/server/TaskApprovalsTabPanel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/server/TaskBasicTabPanel.html
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/server/TaskBasicTabPanel.html
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/server/TaskBasicTabPanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/server/TaskBasicTabPanel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/server/TaskChangesPanel.html
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/server/TaskChangesPanel.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/server/TaskChangesPanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/server/TaskChangesPanel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/server/TaskMainPanel.html
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/server/TaskMainPanel.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/server/TaskMainPanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/server/TaskMainPanel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/server/TaskOperationTabPanel.html
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/server/TaskOperationTabPanel.html
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/server/TaskOperationTabPanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/server/TaskOperationTabPanel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/server/TaskPerformanceTabPanel.html
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/server/TaskPerformanceTabPanel.html
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/server/TaskPerformanceTabPanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/server/TaskPerformanceTabPanel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/server/TaskProgressTabPanel.html
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/server/TaskProgressTabPanel.html
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/server/TaskProgressTabPanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/server/TaskProgressTabPanel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/server/TaskResultTabPanel.html
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/server/TaskResultTabPanel.html
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/server/TaskResultTabPanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/server/TaskResultTabPanel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/server/TaskSchedulingTabPanel.html
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/server/TaskSchedulingTabPanel.html
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/server/TaskSchedulingTabPanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/server/TaskSchedulingTabPanel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/server/TaskShowAdvancedFeaturesPanel.html
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/server/TaskShowAdvancedFeaturesPanel.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/server/TaskShowAdvancedFeaturesPanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/server/TaskShowAdvancedFeaturesPanel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/server/TaskSubtasksAndThreadsTabPanel.html
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/server/TaskSubtasksAndThreadsTabPanel.html
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/server/TaskSubtasksAndThreadsTabPanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/server/TaskSubtasksAndThreadsTabPanel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/server/TaskSummaryPanel.html
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/server/TaskSummaryPanel.html
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/server/TaskSummaryPanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/server/TaskSummaryPanel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/server/TaskTabPanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/server/TaskTabPanel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/server/TaskWfChildPanel.html
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/server/TaskWfChildPanel.html
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/server/TaskWfChildPanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/server/TaskWfChildPanel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/server/TaskWfParentPanel.html
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/server/TaskWfParentPanel.html
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/server/TaskWfParentPanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/server/TaskWfParentPanel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/server/currentState/IterativeInformationPanel.html
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/server/currentState/IterativeInformationPanel.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/server/currentState/IterativeInformationPanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/server/currentState/IterativeInformationPanel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/server/dto/ActionsExecutedInformationDto.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/server/dto/ActionsExecutedInformationDto.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/server/dto/ActionsExecutedObjectsTableLineDto.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/server/dto/ActionsExecutedObjectsTableLineDto.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/server/dto/ApprovalOutcomeIcon.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/server/dto/ApprovalOutcomeIcon.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/server/dto/OperationResultStatusPresentationProperties.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/server/dto/OperationResultStatusPresentationProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/server/dto/SynchronizationInformationDto.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/server/dto/SynchronizationInformationDto.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/server/dto/TaskAddDto.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/server/dto/TaskAddDto.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/server/dto/TaskChangesDto.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/server/dto/TaskChangesDto.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/server/dto/TaskCurrentStateDto.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/server/dto/TaskCurrentStateDto.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/server/dto/TaskEditableState.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/server/dto/TaskEditableState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/server/dto/TasksSearchDto.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/server/dto/TasksSearchDto.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/server/dto/WorkerThreadDto.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/server/dto/WorkerThreadDto.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/server/handlers/DefaultHandlerPanel.html
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/server/handlers/DefaultHandlerPanel.html
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/server/handlers/DefaultHandlerPanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/server/handlers/DefaultHandlerPanel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/server/handlers/DeleteHandlerPanel.html
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/server/handlers/DeleteHandlerPanel.html
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/server/handlers/DeleteHandlerPanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/server/handlers/DeleteHandlerPanel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/server/handlers/ExecuteChangesHandlerPanel.html
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/server/handlers/ExecuteChangesHandlerPanel.html
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/server/handlers/ExecuteChangesHandlerPanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/server/handlers/ExecuteChangesHandlerPanel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/server/handlers/GenericHandlerPanel.html
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/server/handlers/GenericHandlerPanel.html
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/server/handlers/GenericHandlerPanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/server/handlers/GenericHandlerPanel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/server/handlers/HandlerDtoFactory.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/server/handlers/HandlerDtoFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/server/handlers/HandlerPanelFactory.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/server/handlers/HandlerPanelFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/server/handlers/LiveSyncHandlerPanel.html
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/server/handlers/LiveSyncHandlerPanel.html
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/server/handlers/LiveSyncHandlerPanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/server/handlers/LiveSyncHandlerPanel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/server/handlers/QueryBasedHandlerPanel.html
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/server/handlers/QueryBasedHandlerPanel.html
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/server/handlers/QueryBasedHandlerPanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/server/handlers/QueryBasedHandlerPanel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/server/handlers/ReportCreateHandlerPanel.html
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/server/handlers/ReportCreateHandlerPanel.html
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/server/handlers/ReportCreateHandlerPanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/server/handlers/ReportCreateHandlerPanel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/server/handlers/ResourceRelatedHandlerPanel.html
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/server/handlers/ResourceRelatedHandlerPanel.html
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/server/handlers/ResourceRelatedHandlerPanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/server/handlers/ResourceRelatedHandlerPanel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/server/handlers/ScannerHandlerPanel.html
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/server/handlers/ScannerHandlerPanel.html
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/server/handlers/ScannerHandlerPanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/server/handlers/ScannerHandlerPanel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/server/handlers/ScriptExecutionHandlerPanel.html
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/server/handlers/ScriptExecutionHandlerPanel.html
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/server/handlers/ScriptExecutionHandlerPanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/server/handlers/ScriptExecutionHandlerPanel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/server/handlers/dto/DeleteHandlerDto.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/server/handlers/dto/DeleteHandlerDto.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/server/handlers/dto/ExecuteChangesHandlerDto.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/server/handlers/dto/ExecuteChangesHandlerDto.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/server/handlers/dto/GenericHandlerDto.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/server/handlers/dto/GenericHandlerDto.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/server/handlers/dto/HandlerDto.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/server/handlers/dto/HandlerDto.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/server/handlers/dto/HandlerDtoEditableState.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/server/handlers/dto/HandlerDtoEditableState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/server/handlers/dto/LiveSyncHandlerDto.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/server/handlers/dto/LiveSyncHandlerDto.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/server/handlers/dto/QueryBasedHandlerDto.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/server/handlers/dto/QueryBasedHandlerDto.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/server/handlers/dto/RecomputeHandlerDto.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/server/handlers/dto/RecomputeHandlerDto.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/server/handlers/dto/ReportCreateHandlerDto.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/server/handlers/dto/ReportCreateHandlerDto.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/server/handlers/dto/ScannerHandlerDto.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/server/handlers/dto/ScannerHandlerDto.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/server/handlers/dto/ScriptExecutionHandlerDto.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/server/handlers/dto/ScriptExecutionHandlerDto.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/server/subtasks/SubtasksPanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/server/subtasks/SubtasksPanel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/services/PageServices.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/services/PageServices.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/users/PageMergeObjects.html
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/users/PageMergeObjects.html
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/users/PageMergeObjects.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/users/PageMergeObjects.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/users/PageOrgUnit.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/users/PageOrgUnit.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/users/PageUser.html
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/users/PageUser.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/users/PageUser.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/users/PageUser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/users/PageUserHistory.html
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/users/PageUserHistory.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/users/PageUserHistory.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/users/PageUserHistory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/users/PageUsers.html
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/users/PageUsers.html
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/users/PageXmlDataReview.html
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/users/PageXmlDataReview.html
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/users/PageXmlDataReview.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/users/PageXmlDataReview.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/users/component/AssignmentPreviewDialog.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/users/component/AssignmentPreviewDialog.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/users/component/AssociationValueChoicePanel.html
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/users/component/AssociationValueChoicePanel.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/users/component/AssociationValueChoicePanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/users/component/AssociationValueChoicePanel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/users/component/ExecuteChangeOptionsPanel.html
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/users/component/ExecuteChangeOptionsPanel.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/users/component/ExecuteChangeOptionsPanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/users/component/ExecuteChangeOptionsPanel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/users/component/MergeObjectDetailsPanel.html
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/users/component/MergeObjectDetailsPanel.html
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~    Licensed under the Apache License, Version 2.0 (the "License");
   ~    you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/users/component/MergeObjectDetailsPanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/users/component/MergeObjectDetailsPanel.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/users/component/MergeObjectsPanel.html
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/users/component/MergeObjectsPanel.html
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~    Licensed under the Apache License, Version 2.0 (the "License");
   ~    you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/users/component/OrgMemberPanel.html
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/users/component/OrgMemberPanel.html
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/users/component/OrgUnitAddDeletePopup.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/users/component/OrgUnitAddDeletePopup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/users/component/TreeTablePanel.html
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/users/component/TreeTablePanel.html
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/users/dto/FocusSubwrapperDto.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/users/dto/FocusSubwrapperDto.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/users/dto/OrgUnitSearchDto.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/users/dto/OrgUnitSearchDto.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/workflow/PageWorkItem.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/workflow/PageWorkItem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/workflow/PageWorkItemsAll.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/workflow/PageWorkItemsAll.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/workflow/PageWorkItemsAllocatedToMe.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/workflow/PageWorkItemsAllocatedToMe.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/workflow/WorkItemPanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/workflow/WorkItemPanel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/workflow/WorkItemSummaryPanel.html
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/workflow/WorkItemSummaryPanel.html
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/workflow/WorkItemSummaryPanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/workflow/WorkItemSummaryPanel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/error/PageError410.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/error/PageError410.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/self/PageAbstractSelfCredentials.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/self/PageAbstractSelfCredentials.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/self/PageAssignmentDetails.html
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/self/PageAssignmentDetails.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~    Licensed under the Apache License, Version 2.0 (the "License");
   ~    you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/self/PageAssignmentShoppingKart.html
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/self/PageAssignmentShoppingKart.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~    Licensed under the Apache License, Version 2.0 (the "License");
   ~    you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/self/PageAssignmentsList.html
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/self/PageAssignmentsList.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~    Licensed under the Apache License, Version 2.0 (the "License");
   ~    you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/self/PageSelf.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/self/PageSelf.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/self/PageSelfCredentials.html
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/self/PageSelfCredentials.html
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/self/PageSelfDashboard.html
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/self/PageSelfDashboard.html
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/self/PageSelfDashboard.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/self/PageSelfDashboard.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/self/component/ChangePasswordPanel.html
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/self/component/ChangePasswordPanel.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/self/component/ChangePasswordPanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/self/component/ChangePasswordPanel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/self/component/DashboardSearchPanel.html
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/self/component/DashboardSearchPanel.html
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/self/component/LinksPanel.html
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/self/component/LinksPanel.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/self/dto/AssignmentViewType.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/self/dto/AssignmentViewType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/security/LoggingRequestCycleListener.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/security/LoggingRequestCycleListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/security/MidPointApplication.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/security/MidPointApplication.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/security/MidPointAuthWebSession.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/security/MidPointAuthWebSession.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/security/MidPointAuthenticationProvider.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/security/MidPointAuthenticationProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/security/MidPointAuthenticationSuccessHandler.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/security/MidPointAuthenticationSuccessHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/security/PageUrlMapping.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/security/PageUrlMapping.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/session/AuditLogStorage.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/session/AuditLogStorage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/session/ConfigurationStorage.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/session/ConfigurationStorage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/session/PageStorage.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/session/PageStorage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/session/ReportsStorage.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/session/ReportsStorage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/session/ResourceContentStorage.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/session/ResourceContentStorage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/session/ResourcesStorage.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/session/ResourcesStorage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/session/RoleCatalogStorage.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/session/RoleCatalogStorage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/session/RoleMembersStorage.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/session/RoleMembersStorage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/session/RolesStorage.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/session/RolesStorage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/session/ServicesStorage.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/session/ServicesStorage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/session/SessionStorage.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/session/SessionStorage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/session/TasksStorage.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/session/TasksStorage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/session/UserProfileStorage.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/session/UserProfileStorage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/session/UsersStorage.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/session/UsersStorage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/util/DateValidator.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/util/DateValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/util/WebXmlUtil.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/util/WebXmlUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/resources/ctx-overlay.xml
+++ b/gui/admin-gui/src/main/resources/ctx-overlay.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  ~ Copyright (c) 2016 Evolveum
+  ~ Copyright (c) 2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/resources/initial-objects/010-value-policy.xml
+++ b/gui/admin-gui/src/main/resources/initial-objects/010-value-policy.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2014 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/resources/initial-objects/030-role-superuser.xml
+++ b/gui/admin-gui/src/main/resources/initial-objects/030-role-superuser.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/resources/initial-objects/041-role-approver.xml
+++ b/gui/admin-gui/src/main/resources/initial-objects/041-role-approver.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2016 Evolveum
+  ~ Copyright (c) 2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/resources/initial-objects/042-role-reviewer.xml
+++ b/gui/admin-gui/src/main/resources/initial-objects/042-role-reviewer.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/resources/initial-objects/050-user-administrator.xml
+++ b/gui/admin-gui/src/main/resources/initial-objects/050-user-administrator.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2014 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/resources/initial-objects/060-task-cleanup.xml
+++ b/gui/admin-gui/src/main/resources/initial-objects/060-task-cleanup.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2014 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/resources/initial-objects/070-task-validity.xml
+++ b/gui/admin-gui/src/main/resources/initial-objects/070-task-validity.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2014 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/resources/initial-objects/080-task-trigger.xml
+++ b/gui/admin-gui/src/main/resources/initial-objects/080-task-trigger.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2014 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/resources/initial-objects/130-report-certification-definitions.xml
+++ b/gui/admin-gui/src/main/resources/initial-objects/130-report-certification-definitions.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/resources/initial-objects/140-report-certification-campaigns.xml
+++ b/gui/admin-gui/src/main/resources/initial-objects/140-report-certification-campaigns.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/resources/initial-objects/150-report-certification-cases.xml
+++ b/gui/admin-gui/src/main/resources/initial-objects/150-report-certification-cases.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/resources/initial-objects/160-report-certification-decisions.xml
+++ b/gui/admin-gui/src/main/resources/initial-objects/160-report-certification-decisions.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/resources/initial-objects/200-lookup-languages.xml
+++ b/gui/admin-gui/src/main/resources/initial-objects/200-lookup-languages.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2016 Evolveum, AMI Praha
+  ~ Copyright (c) 2017 Evolveum, AMI Praha
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/resources/initial-objects/210-lookup-locales.xml
+++ b/gui/admin-gui/src/main/resources/initial-objects/210-lookup-locales.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2016 Evolveum, AMI Praha
+  ~ Copyright (c) 2017 Evolveum, AMI Praha
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/resources/initial-objects/220-lookup-timezones.xml
+++ b/gui/admin-gui/src/main/resources/initial-objects/220-lookup-timezones.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2016 Evolveum, AMI Praha
+  ~ Copyright (c) 2017 Evolveum, AMI Praha
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/resources/initial-objects/230-lookup-lifecycle-state.xml
+++ b/gui/admin-gui/src/main/resources/initial-objects/230-lookup-lifecycle-state.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2016 Evolveum, AMI Praha
+  ~ Copyright (c) 2017 Evolveum, AMI Praha
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/resources/localization/Midpoint.properties
+++ b/gui/admin-gui/src/main/resources/localization/Midpoint.properties
@@ -1,4 +1,4 @@
-# Copyright (c) 2010-2016 Evolveum
+# Copyright (c) 2010-2017 Evolveum
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/resources/localization/Midpoint_cs.properties
+++ b/gui/admin-gui/src/main/resources/localization/Midpoint_cs.properties
@@ -1,4 +1,4 @@
-# Copyright (c) 2010-2016 Evolveum
+# Copyright (c) 2010-2017 Evolveum
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/resources/localization/Midpoint_de.properties
+++ b/gui/admin-gui/src/main/resources/localization/Midpoint_de.properties
@@ -1,4 +1,4 @@
-# Copyright (c) 2010-2016 Evolveum
+# Copyright (c) 2010-2017 Evolveum
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/resources/localization/Midpoint_en.properties
+++ b/gui/admin-gui/src/main/resources/localization/Midpoint_en.properties
@@ -1,4 +1,4 @@
-# Copyright (c) 2010-2016 Evolveum
+# Copyright (c) 2010-2017 Evolveum
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/resources/localization/Midpoint_es.properties
+++ b/gui/admin-gui/src/main/resources/localization/Midpoint_es.properties
@@ -1,4 +1,4 @@
-# Copyright (c) 2010-2016 Evolveum
+# Copyright (c) 2010-2017 Evolveum
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/resources/localization/Midpoint_et.properties
+++ b/gui/admin-gui/src/main/resources/localization/Midpoint_et.properties
@@ -1,4 +1,4 @@
-# Copyright (c) 2010-2016 Evolveum
+# Copyright (c) 2010-2017 Evolveum
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/resources/localization/Midpoint_hu.properties
+++ b/gui/admin-gui/src/main/resources/localization/Midpoint_hu.properties
@@ -1,4 +1,4 @@
-# Copyright (c) 2010-2016 Evolveum
+# Copyright (c) 2010-2017 Evolveum
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/resources/localization/Midpoint_pl.properties
+++ b/gui/admin-gui/src/main/resources/localization/Midpoint_pl.properties
@@ -1,4 +1,4 @@
-# Copyright (c) 2010-2016 Evolveum
+# Copyright (c) 2010-2017 Evolveum
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/resources/localization/Midpoint_pt_BR.properties
+++ b/gui/admin-gui/src/main/resources/localization/Midpoint_pt_BR.properties
@@ -1,4 +1,4 @@
-# Copyright (c) 2010-2016 Evolveum
+# Copyright (c) 2010-2017 Evolveum
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/resources/localization/Midpoint_ru.properties
+++ b/gui/admin-gui/src/main/resources/localization/Midpoint_ru.properties
@@ -1,4 +1,4 @@
-# Copyright (c) 2010-2016 Evolveum
+# Copyright (c) 2010-2017 Evolveum
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/resources/localization/Midpoint_sk.properties
+++ b/gui/admin-gui/src/main/resources/localization/Midpoint_sk.properties
@@ -1,4 +1,4 @@
-# Copyright (c) 2010-2016 Evolveum
+# Copyright (c) 2010-2017 Evolveum
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/resources/localization/Midpoint_tr.properties
+++ b/gui/admin-gui/src/main/resources/localization/Midpoint_tr.properties
@@ -1,4 +1,4 @@
-# Copyright (c) 2010-2016 Evolveum
+# Copyright (c) 2010-2017 Evolveum
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/resources/localization/Midpoint_zh_CN.properties
+++ b/gui/admin-gui/src/main/resources/localization/Midpoint_zh_CN.properties
@@ -1,4 +1,4 @@
-# Copyright (c) 2010-2016 Evolveum
+# Copyright (c) 2010-2017 Evolveum
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/resources/logback.xml
+++ b/gui/admin-gui/src/main/resources/logback.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/webapp/META-INF/atmosphere.xml
+++ b/gui/admin-gui/src/main/webapp/META-INF/atmosphere.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/webapp/WEB-INF/ctx-init.xml
+++ b/gui/admin-gui/src/main/webapp/WEB-INF/ctx-init.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/webapp/WEB-INF/ctx-web-security-basic.xml
+++ b/gui/admin-gui/src/main/webapp/WEB-INF/ctx-web-security-basic.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- ~ Copyright (c) 2010-2016 Evolveum ~ ~ Licensed under the Apache License, 
+<!-- ~ Copyright (c) 2010-2017 Evolveum ~ ~ Licensed under the Apache License,
 	Version 2.0 (the "License"); ~ you may not use this file except in compliance 
 	with the License. ~ You may obtain a copy of the License at ~ ~ http://www.apache.org/licenses/LICENSE-2.0 
 	~ ~ Unless required by applicable law or agreed to in writing, software ~ 

--- a/gui/admin-gui/src/main/webapp/WEB-INF/ctx-web-security-cas.xml
+++ b/gui/admin-gui/src/main/webapp/WEB-INF/ctx-web-security-cas.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/webapp/WEB-INF/ctx-web-security-ldap.xml
+++ b/gui/admin-gui/src/main/webapp/WEB-INF/ctx-web-security-ldap.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- ~ Copyright (c) 2010-2016 Evolveum ~ ~ Licensed under the Apache License, 
+<!-- ~ Copyright (c) 2010-2017 Evolveum ~ ~ Licensed under the Apache License,
 	Version 2.0 (the "License"); ~ you may not use this file except in compliance 
 	with the License. ~ You may obtain a copy of the License at ~ ~ http://www.apache.org/licenses/LICENSE-2.0 
 	~ ~ Unless required by applicable law or agreed to in writing, software ~ 

--- a/gui/admin-gui/src/main/webapp/WEB-INF/ctx-web-security.xml
+++ b/gui/admin-gui/src/main/webapp/WEB-INF/ctx-web-security.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/webapp/WEB-INF/ctx-webapp.xml
+++ b/gui/admin-gui/src/main/webapp/WEB-INF/ctx-webapp.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/webapp/WEB-INF/descriptor.xml
+++ b/gui/admin-gui/src/main/webapp/WEB-INF/descriptor.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2014 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/webapp/WEB-INF/web.xml
+++ b/gui/admin-gui/src/main/webapp/WEB-INF/web.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2014 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/webapp/WEB-INF/wro.xml
+++ b/gui/admin-gui/src/main/webapp/WEB-INF/wro.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/webapp/css/fonts.css
+++ b/gui/admin-gui/src/main/webapp/css/fonts.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/webapp/less/midpoint-theme-variables.less
+++ b/gui/admin-gui/src/main/webapp/less/midpoint-theme-variables.less
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/main/webapp/less/midpoint-theme.less
+++ b/gui/admin-gui/src/main/webapp/less/midpoint-theme.less
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/test/java/com/evolveum/midpoint/web/PageLoginTest.java
+++ b/gui/admin-gui/src/test/java/com/evolveum/midpoint/web/PageLoginTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/test/java/com/evolveum/midpoint/web/TestCleanStartup.java
+++ b/gui/admin-gui/src/test/java/com/evolveum/midpoint/web/TestCleanStartup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/test/resources/common/resource-dummy-initialized.xml
+++ b/gui/admin-gui/src/test/resources/common/resource-dummy-initialized.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2014 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/test/resources/common/resource-dummy.xml
+++ b/gui/admin-gui/src/test/resources/common/resource-dummy.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/test/resources/common/role-mapmaker.xml
+++ b/gui/admin-gui/src/test/resources/common/role-mapmaker.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2014-2016 Evolveum
+  ~ Copyright (c) 2014-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/test/resources/common/role-superuser.xml
+++ b/gui/admin-gui/src/test/resources/common/role-superuser.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/test/resources/common/shadow-account-jack-dummy.xml
+++ b/gui/admin-gui/src/test/resources/common/shadow-account-jack-dummy.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/test/resources/common/user-administrator.xml
+++ b/gui/admin-gui/src/test/resources/common/user-administrator.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/test/resources/common/user-empty.xml
+++ b/gui/admin-gui/src/test/resources/common/user-empty.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <!--
-  ~ Copyright (c) 2016 Evolveum
+  ~ Copyright (c) 2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/test/resources/common/user-jack-repo.xml
+++ b/gui/admin-gui/src/test/resources/common/user-jack-repo.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/test/resources/common/user-jack.xml
+++ b/gui/admin-gui/src/test/resources/common/user-jack.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/gui/admin-gui/src/test/resources/logback-test.xml
+++ b/gui/admin-gui/src/test/resources/logback-test.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/gui/admin-gui/testng-unit.xml
+++ b/gui/admin-gui/testng-unit.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/gui/pom.xml
+++ b/gui/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/icf-connectors/dummy-connector-fake/pom.xml
+++ b/icf-connectors/dummy-connector-fake/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/icf-connectors/dummy-connector-fake/testng-unit.xml
+++ b/icf-connectors/dummy-connector-fake/testng-unit.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/icf-connectors/dummy-connector/pom.xml
+++ b/icf-connectors/dummy-connector/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/icf-connectors/dummy-connector/testng-unit.xml
+++ b/icf-connectors/dummy-connector/testng-unit.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/icf-connectors/dummy-resource/pom.xml
+++ b/icf-connectors/dummy-resource/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/icf-connectors/dummy-resource/src/main/java/com/evolveum/icf/dummy/resource/DummyAccount.java
+++ b/icf-connectors/dummy-resource/src/main/java/com/evolveum/icf/dummy/resource/DummyAccount.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/icf-connectors/dummy-resource/src/main/java/com/evolveum/icf/dummy/resource/DummyGroup.java
+++ b/icf-connectors/dummy-resource/src/main/java/com/evolveum/icf/dummy/resource/DummyGroup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/icf-connectors/dummy-resource/testng-unit.xml
+++ b/icf-connectors/dummy-resource/testng-unit.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/icf-connectors/pom.xml
+++ b/icf-connectors/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/infra/common/pom.xml
+++ b/infra/common/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/infra/common/src/main/java/com/evolveum/midpoint/common/crypto/CryptoUtil.java
+++ b/infra/common/src/main/java/com/evolveum/midpoint/common/crypto/CryptoUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/infra/common/src/main/java/com/evolveum/midpoint/common/refinery/LayerRefinedAttributeDefinition.java
+++ b/infra/common/src/main/java/com/evolveum/midpoint/common/refinery/LayerRefinedAttributeDefinition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/infra/common/src/main/java/com/evolveum/midpoint/common/refinery/LayerRefinedObjectClassDefinition.java
+++ b/infra/common/src/main/java/com/evolveum/midpoint/common/refinery/LayerRefinedObjectClassDefinition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/infra/common/src/main/java/com/evolveum/midpoint/common/refinery/LayerRefinedResourceSchema.java
+++ b/infra/common/src/main/java/com/evolveum/midpoint/common/refinery/LayerRefinedResourceSchema.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/infra/common/src/main/java/com/evolveum/midpoint/common/refinery/LayerRefinedResourceSchemaImpl.java
+++ b/infra/common/src/main/java/com/evolveum/midpoint/common/refinery/LayerRefinedResourceSchemaImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/infra/common/src/main/java/com/evolveum/midpoint/common/refinery/RefinedAttributeDefinition.java
+++ b/infra/common/src/main/java/com/evolveum/midpoint/common/refinery/RefinedAttributeDefinition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/infra/common/src/main/java/com/evolveum/midpoint/common/refinery/RefinedAttributeDefinitionImpl.java
+++ b/infra/common/src/main/java/com/evolveum/midpoint/common/refinery/RefinedAttributeDefinitionImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/infra/common/src/main/java/com/evolveum/midpoint/common/refinery/RefinedConnectorSchema.java
+++ b/infra/common/src/main/java/com/evolveum/midpoint/common/refinery/RefinedConnectorSchema.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/infra/common/src/main/java/com/evolveum/midpoint/common/refinery/RefinedObjectClassDefinitionImpl.java
+++ b/infra/common/src/main/java/com/evolveum/midpoint/common/refinery/RefinedObjectClassDefinitionImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/infra/common/src/main/java/com/evolveum/midpoint/common/validator/Validator.java
+++ b/infra/common/src/main/java/com/evolveum/midpoint/common/validator/Validator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/infra/common/src/main/resources/ctx-common.xml
+++ b/infra/common/src/main/resources/ctx-common.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/infra/common/src/test/java/com/evolveum/midpoint/common/TestActivationComputer.java
+++ b/infra/common/src/test/java/com/evolveum/midpoint/common/TestActivationComputer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/infra/common/src/test/resources/logback-test.xml
+++ b/infra/common/src/test/resources/logback-test.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/infra/common/src/test/resources/objects/c0c010c0-d34d-b33f-f00d-111111111111.xml
+++ b/infra/common/src/test/resources/objects/c0c010c0-d34d-b33f-f00d-111111111111.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/infra/common/src/test/resources/objects/c0c010c0-d34d-b33f-f00d-111111111112.xml
+++ b/infra/common/src/test/resources/objects/c0c010c0-d34d-b33f-f00d-111111111112.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/infra/common/src/test/resources/objects/c0c010c0-d34d-b33f-f00d-999111111122.xml
+++ b/infra/common/src/test/resources/objects/c0c010c0-d34d-b33f-f00d-999111111122.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/infra/common/src/test/resources/objects/c0c010c0-d34d-b33f-f00d-999888111111.xml
+++ b/infra/common/src/test/resources/objects/c0c010c0-d34d-b33f-f00d-999888111111.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/infra/common/src/test/resources/objects/c0c010c0-d34d-b33f-f00d-999888111112.xml
+++ b/infra/common/src/test/resources/objects/c0c010c0-d34d-b33f-f00d-999888111112.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/infra/common/src/test/resources/objects/c0c010c0-d34d-b33f-f00d-999888111113.xml
+++ b/infra/common/src/test/resources/objects/c0c010c0-d34d-b33f-f00d-999888111113.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/infra/common/src/test/resources/refinery/account-jack.xml
+++ b/infra/common/src/test/resources/refinery/account-jack.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/infra/common/src/test/resources/refinery/resource-complex.xml
+++ b/infra/common/src/test/resources/refinery/resource-complex.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2014 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/infra/common/src/test/resources/refinery/resource-ldap-posix.xml
+++ b/infra/common/src/test/resources/refinery/resource-ldap-posix.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/infra/common/src/test/resources/refinery/resource-simple.xml
+++ b/infra/common/src/test/resources/refinery/resource-simple.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/infra/common/src/test/resources/validator/no-name.xml
+++ b/infra/common/src/test/resources/validator/no-name.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/infra/common/src/test/resources/validator/not-well-formed.xml
+++ b/infra/common/src/test/resources/validator/not-well-formed.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/infra/common/src/test/resources/validator/resource-1-valid.xml
+++ b/infra/common/src/test/resources/validator/resource-1-valid.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/infra/common/src/test/resources/validator/three-objects.xml
+++ b/infra/common/src/test/resources/validator/three-objects.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/infra/common/src/test/resources/validator/three-users-schema-violation.xml
+++ b/infra/common/src/test/resources/validator/three-users-schema-violation.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/infra/common/src/test/resources/validator/undeclared-prefix.xml
+++ b/infra/common/src/test/resources/validator/undeclared-prefix.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/infra/common/testng-unit.xml
+++ b/infra/common/testng-unit.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2014 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/infra/pom.xml
+++ b/infra/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/infra/prism/pom.xml
+++ b/infra/prism/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/infra/prism/src/main/java/com/evolveum/midpoint/prism/ComplexTypeDefinition.java
+++ b/infra/prism/src/main/java/com/evolveum/midpoint/prism/ComplexTypeDefinition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/infra/prism/src/main/java/com/evolveum/midpoint/prism/ComplexTypeDefinitionImpl.java
+++ b/infra/prism/src/main/java/com/evolveum/midpoint/prism/ComplexTypeDefinitionImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/infra/prism/src/main/java/com/evolveum/midpoint/prism/Definition.java
+++ b/infra/prism/src/main/java/com/evolveum/midpoint/prism/Definition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/infra/prism/src/main/java/com/evolveum/midpoint/prism/DefinitionImpl.java
+++ b/infra/prism/src/main/java/com/evolveum/midpoint/prism/DefinitionImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/infra/prism/src/main/java/com/evolveum/midpoint/prism/IPrismValue.java
+++ b/infra/prism/src/main/java/com/evolveum/midpoint/prism/IPrismValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/infra/prism/src/main/java/com/evolveum/midpoint/prism/ItemDefinitionImpl.java
+++ b/infra/prism/src/main/java/com/evolveum/midpoint/prism/ItemDefinitionImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/infra/prism/src/main/java/com/evolveum/midpoint/prism/ItemNameQualificationStrategy.java
+++ b/infra/prism/src/main/java/com/evolveum/midpoint/prism/ItemNameQualificationStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/infra/prism/src/main/java/com/evolveum/midpoint/prism/LocalDefinitionStore.java
+++ b/infra/prism/src/main/java/com/evolveum/midpoint/prism/LocalDefinitionStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/infra/prism/src/main/java/com/evolveum/midpoint/prism/NameQualificationStrategy.java
+++ b/infra/prism/src/main/java/com/evolveum/midpoint/prism/NameQualificationStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/infra/prism/src/main/java/com/evolveum/midpoint/prism/ParserElementSource.java
+++ b/infra/prism/src/main/java/com/evolveum/midpoint/prism/ParserElementSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/infra/prism/src/main/java/com/evolveum/midpoint/prism/ParserFileSource.java
+++ b/infra/prism/src/main/java/com/evolveum/midpoint/prism/ParserFileSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/infra/prism/src/main/java/com/evolveum/midpoint/prism/ParserInputStreamSource.java
+++ b/infra/prism/src/main/java/com/evolveum/midpoint/prism/ParserInputStreamSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/infra/prism/src/main/java/com/evolveum/midpoint/prism/ParserSource.java
+++ b/infra/prism/src/main/java/com/evolveum/midpoint/prism/ParserSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/infra/prism/src/main/java/com/evolveum/midpoint/prism/ParserStringSource.java
+++ b/infra/prism/src/main/java/com/evolveum/midpoint/prism/ParserStringSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/infra/prism/src/main/java/com/evolveum/midpoint/prism/ParserXNodeSource.java
+++ b/infra/prism/src/main/java/com/evolveum/midpoint/prism/ParserXNodeSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/infra/prism/src/main/java/com/evolveum/midpoint/prism/ParsingContext.java
+++ b/infra/prism/src/main/java/com/evolveum/midpoint/prism/ParsingContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/infra/prism/src/main/java/com/evolveum/midpoint/prism/PrismConstants.java
+++ b/infra/prism/src/main/java/com/evolveum/midpoint/prism/PrismConstants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/infra/prism/src/main/java/com/evolveum/midpoint/prism/PrismContainerDefinitionImpl.java
+++ b/infra/prism/src/main/java/com/evolveum/midpoint/prism/PrismContainerDefinitionImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/infra/prism/src/main/java/com/evolveum/midpoint/prism/PrismContext.java
+++ b/infra/prism/src/main/java/com/evolveum/midpoint/prism/PrismContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/infra/prism/src/main/java/com/evolveum/midpoint/prism/PrismContextImpl.java
+++ b/infra/prism/src/main/java/com/evolveum/midpoint/prism/PrismContextImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/infra/prism/src/main/java/com/evolveum/midpoint/prism/PrismObjectDefinition.java
+++ b/infra/prism/src/main/java/com/evolveum/midpoint/prism/PrismObjectDefinition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/infra/prism/src/main/java/com/evolveum/midpoint/prism/PrismObjectDefinitionImpl.java
+++ b/infra/prism/src/main/java/com/evolveum/midpoint/prism/PrismObjectDefinitionImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/infra/prism/src/main/java/com/evolveum/midpoint/prism/PrismObjectValue.java
+++ b/infra/prism/src/main/java/com/evolveum/midpoint/prism/PrismObjectValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/infra/prism/src/main/java/com/evolveum/midpoint/prism/PrismParser.java
+++ b/infra/prism/src/main/java/com/evolveum/midpoint/prism/PrismParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/infra/prism/src/main/java/com/evolveum/midpoint/prism/PrismParserNoIO.java
+++ b/infra/prism/src/main/java/com/evolveum/midpoint/prism/PrismParserNoIO.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/infra/prism/src/main/java/com/evolveum/midpoint/prism/PrismPropertyDefinitionImpl.java
+++ b/infra/prism/src/main/java/com/evolveum/midpoint/prism/PrismPropertyDefinitionImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/infra/prism/src/main/java/com/evolveum/midpoint/prism/PrismReferenceDefinition.java
+++ b/infra/prism/src/main/java/com/evolveum/midpoint/prism/PrismReferenceDefinition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/infra/prism/src/main/java/com/evolveum/midpoint/prism/PrismSerializer.java
+++ b/infra/prism/src/main/java/com/evolveum/midpoint/prism/PrismSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/infra/prism/src/main/java/com/evolveum/midpoint/prism/Referencable.java
+++ b/infra/prism/src/main/java/com/evolveum/midpoint/prism/Referencable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/infra/prism/src/main/java/com/evolveum/midpoint/prism/SimpleTypeDefinition.java
+++ b/infra/prism/src/main/java/com/evolveum/midpoint/prism/SimpleTypeDefinition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/infra/prism/src/main/java/com/evolveum/midpoint/prism/SimpleTypeDefinitionImpl.java
+++ b/infra/prism/src/main/java/com/evolveum/midpoint/prism/SimpleTypeDefinitionImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/infra/prism/src/main/java/com/evolveum/midpoint/prism/TypeDefinition.java
+++ b/infra/prism/src/main/java/com/evolveum/midpoint/prism/TypeDefinition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/infra/prism/src/main/java/com/evolveum/midpoint/prism/TypeDefinitionImpl.java
+++ b/infra/prism/src/main/java/com/evolveum/midpoint/prism/TypeDefinitionImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/infra/prism/src/main/java/com/evolveum/midpoint/prism/XmlEntityResolver.java
+++ b/infra/prism/src/main/java/com/evolveum/midpoint/prism/XmlEntityResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/infra/prism/src/main/java/com/evolveum/midpoint/prism/lex/LexicalParsingMode.java
+++ b/infra/prism/src/main/java/com/evolveum/midpoint/prism/lex/LexicalParsingMode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/infra/prism/src/main/java/com/evolveum/midpoint/prism/lex/LexicalProcessorRegistry.java
+++ b/infra/prism/src/main/java/com/evolveum/midpoint/prism/lex/LexicalProcessorRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/infra/prism/src/main/java/com/evolveum/midpoint/prism/lex/LexicalUtils.java
+++ b/infra/prism/src/main/java/com/evolveum/midpoint/prism/lex/LexicalUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/infra/prism/src/main/java/com/evolveum/midpoint/prism/lex/dom/DomLexicalProcessor.java
+++ b/infra/prism/src/main/java/com/evolveum/midpoint/prism/lex/dom/DomLexicalProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/infra/prism/src/main/java/com/evolveum/midpoint/prism/lex/dom/DomLexicalWriter.java
+++ b/infra/prism/src/main/java/com/evolveum/midpoint/prism/lex/dom/DomLexicalWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/infra/prism/src/main/java/com/evolveum/midpoint/prism/lex/json/AbstractJsonLexicalProcessor.java
+++ b/infra/prism/src/main/java/com/evolveum/midpoint/prism/lex/json/AbstractJsonLexicalProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/infra/prism/src/main/java/com/evolveum/midpoint/prism/lex/json/ItemPathTypeSerializer.java
+++ b/infra/prism/src/main/java/com/evolveum/midpoint/prism/lex/json/ItemPathTypeSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/infra/prism/src/main/java/com/evolveum/midpoint/prism/lex/json/JsonLexicalProcessor.java
+++ b/infra/prism/src/main/java/com/evolveum/midpoint/prism/lex/json/JsonLexicalProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/infra/prism/src/main/java/com/evolveum/midpoint/prism/lex/json/JsonNullValueParser.java
+++ b/infra/prism/src/main/java/com/evolveum/midpoint/prism/lex/json/JsonNullValueParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/infra/prism/src/main/java/com/evolveum/midpoint/prism/lex/json/NullLexicalProcessor.java
+++ b/infra/prism/src/main/java/com/evolveum/midpoint/prism/lex/json/NullLexicalProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/infra/prism/src/main/java/com/evolveum/midpoint/prism/lex/json/YamlLexicalProcessor.java
+++ b/infra/prism/src/main/java/com/evolveum/midpoint/prism/lex/json/YamlLexicalProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/infra/prism/src/main/java/com/evolveum/midpoint/prism/marshaller/ItemInfo.java
+++ b/infra/prism/src/main/java/com/evolveum/midpoint/prism/marshaller/ItemInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/infra/prism/src/main/java/com/evolveum/midpoint/prism/marshaller/JaxbDomHack.java
+++ b/infra/prism/src/main/java/com/evolveum/midpoint/prism/marshaller/JaxbDomHack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/infra/prism/src/main/java/com/evolveum/midpoint/prism/marshaller/PrismBeanInspector.java
+++ b/infra/prism/src/main/java/com/evolveum/midpoint/prism/marshaller/PrismBeanInspector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/infra/prism/src/main/java/com/evolveum/midpoint/prism/marshaller/PrismParserImpl.java
+++ b/infra/prism/src/main/java/com/evolveum/midpoint/prism/marshaller/PrismParserImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/infra/prism/src/main/java/com/evolveum/midpoint/prism/marshaller/PrismParserImplIO.java
+++ b/infra/prism/src/main/java/com/evolveum/midpoint/prism/marshaller/PrismParserImplIO.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/infra/prism/src/main/java/com/evolveum/midpoint/prism/marshaller/PrismParserImplNoIO.java
+++ b/infra/prism/src/main/java/com/evolveum/midpoint/prism/marshaller/PrismParserImplNoIO.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/infra/prism/src/main/java/com/evolveum/midpoint/prism/marshaller/PrismSerializerImpl.java
+++ b/infra/prism/src/main/java/com/evolveum/midpoint/prism/marshaller/PrismSerializerImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/infra/prism/src/main/java/com/evolveum/midpoint/prism/marshaller/TrivialXPathParser.java
+++ b/infra/prism/src/main/java/com/evolveum/midpoint/prism/marshaller/TrivialXPathParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/infra/prism/src/main/java/com/evolveum/midpoint/prism/marshaller/XNodeProcessorEvaluationMode.java
+++ b/infra/prism/src/main/java/com/evolveum/midpoint/prism/marshaller/XNodeProcessorEvaluationMode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/infra/prism/src/main/java/com/evolveum/midpoint/prism/marshaller/XNodeProcessorUtil.java
+++ b/infra/prism/src/main/java/com/evolveum/midpoint/prism/marshaller/XNodeProcessorUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/infra/prism/src/main/java/com/evolveum/midpoint/prism/marshaller/XPathHolder.java
+++ b/infra/prism/src/main/java/com/evolveum/midpoint/prism/marshaller/XPathHolder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/infra/prism/src/main/java/com/evolveum/midpoint/prism/marshaller/XPathSegment.java
+++ b/infra/prism/src/main/java/com/evolveum/midpoint/prism/marshaller/XPathSegment.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/infra/prism/src/main/java/com/evolveum/midpoint/prism/match/MatchingRuleRegistryFactory.java
+++ b/infra/prism/src/main/java/com/evolveum/midpoint/prism/match/MatchingRuleRegistryFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/infra/prism/src/main/java/com/evolveum/midpoint/prism/match/UuidMatchingRule.java
+++ b/infra/prism/src/main/java/com/evolveum/midpoint/prism/match/UuidMatchingRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/infra/prism/src/main/java/com/evolveum/midpoint/prism/path/CanonicalItemPath.java
+++ b/infra/prism/src/main/java/com/evolveum/midpoint/prism/path/CanonicalItemPath.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/infra/prism/src/main/java/com/evolveum/midpoint/prism/query/EqualFilter.java
+++ b/infra/prism/src/main/java/com/evolveum/midpoint/prism/query/EqualFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/infra/prism/src/main/java/com/evolveum/midpoint/prism/query/GreaterFilter.java
+++ b/infra/prism/src/main/java/com/evolveum/midpoint/prism/query/GreaterFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/infra/prism/src/main/java/com/evolveum/midpoint/prism/query/LessFilter.java
+++ b/infra/prism/src/main/java/com/evolveum/midpoint/prism/query/LessFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/infra/prism/src/main/java/com/evolveum/midpoint/prism/query/OrgFilter.java
+++ b/infra/prism/src/main/java/com/evolveum/midpoint/prism/query/OrgFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/infra/prism/src/main/java/com/evolveum/midpoint/prism/query/RefFilter.java
+++ b/infra/prism/src/main/java/com/evolveum/midpoint/prism/query/RefFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/infra/prism/src/main/java/com/evolveum/midpoint/prism/query/SubstringFilter.java
+++ b/infra/prism/src/main/java/com/evolveum/midpoint/prism/query/SubstringFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/infra/prism/src/main/java/com/evolveum/midpoint/prism/query/UndefinedFilter.java
+++ b/infra/prism/src/main/java/com/evolveum/midpoint/prism/query/UndefinedFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/infra/prism/src/main/java/com/evolveum/midpoint/prism/schema/DefinitionSearchContext.java
+++ b/infra/prism/src/main/java/com/evolveum/midpoint/prism/schema/DefinitionSearchContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/infra/prism/src/main/java/com/evolveum/midpoint/prism/schema/DefinitionSearchContextCtdImpl.java
+++ b/infra/prism/src/main/java/com/evolveum/midpoint/prism/schema/DefinitionSearchContextCtdImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/infra/prism/src/main/java/com/evolveum/midpoint/prism/schema/DefinitionSearchContextItemImpl.java
+++ b/infra/prism/src/main/java/com/evolveum/midpoint/prism/schema/DefinitionSearchContextItemImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/infra/prism/src/main/java/com/evolveum/midpoint/prism/schema/DefinitionSearchImplementation.java
+++ b/infra/prism/src/main/java/com/evolveum/midpoint/prism/schema/DefinitionSearchImplementation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/infra/prism/src/main/java/com/evolveum/midpoint/prism/schema/DefinitionStoreUtils.java
+++ b/infra/prism/src/main/java/com/evolveum/midpoint/prism/schema/DefinitionStoreUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/infra/prism/src/main/java/com/evolveum/midpoint/prism/schema/DefinitionsStore.java
+++ b/infra/prism/src/main/java/com/evolveum/midpoint/prism/schema/DefinitionsStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/infra/prism/src/main/java/com/evolveum/midpoint/prism/schema/DomToSchemaProcessor.java
+++ b/infra/prism/src/main/java/com/evolveum/midpoint/prism/schema/DomToSchemaProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/infra/prism/src/main/java/com/evolveum/midpoint/prism/schema/GlobalDefinitionSearchContext.java
+++ b/infra/prism/src/main/java/com/evolveum/midpoint/prism/schema/GlobalDefinitionSearchContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/infra/prism/src/main/java/com/evolveum/midpoint/prism/schema/GlobalDefinitionsStore.java
+++ b/infra/prism/src/main/java/com/evolveum/midpoint/prism/schema/GlobalDefinitionsStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/infra/prism/src/main/java/com/evolveum/midpoint/prism/schema/HierarchicalDefinitionsStore.java
+++ b/infra/prism/src/main/java/com/evolveum/midpoint/prism/schema/HierarchicalDefinitionsStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/infra/prism/src/main/java/com/evolveum/midpoint/prism/schema/PrismSchema.java
+++ b/infra/prism/src/main/java/com/evolveum/midpoint/prism/schema/PrismSchema.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/infra/prism/src/main/java/com/evolveum/midpoint/prism/schema/SchemaRegistry.java
+++ b/infra/prism/src/main/java/com/evolveum/midpoint/prism/schema/SchemaRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/infra/prism/src/main/java/com/evolveum/midpoint/prism/schema/SchemaToDomProcessor.java
+++ b/infra/prism/src/main/java/com/evolveum/midpoint/prism/schema/SchemaToDomProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/infra/prism/src/main/java/com/evolveum/midpoint/prism/schema/SearchContexts.java
+++ b/infra/prism/src/main/java/com/evolveum/midpoint/prism/schema/SearchContexts.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/infra/prism/src/main/java/com/evolveum/midpoint/prism/schema/XmlEntityResolverImpl.java
+++ b/infra/prism/src/main/java/com/evolveum/midpoint/prism/schema/XmlEntityResolverImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/infra/prism/src/main/java/com/evolveum/midpoint/prism/util/PrismUtil.java
+++ b/infra/prism/src/main/java/com/evolveum/midpoint/prism/util/PrismUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/infra/prism/src/main/resources/META-INF/catalog-test.xml
+++ b/infra/prism/src/main/resources/META-INF/catalog-test.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/infra/prism/src/main/resources/xml/ns/public/annotation-3.xsd
+++ b/infra/prism/src/main/resources/xml/ns/public/annotation-3.xsd
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/infra/prism/src/test/java/com/evolveum/midpoint/prism/TestCompare.java
+++ b/infra/prism/src/test/java/com/evolveum/midpoint/prism/TestCompare.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/infra/prism/src/test/java/com/evolveum/midpoint/prism/TestCompareJson.java
+++ b/infra/prism/src/test/java/com/evolveum/midpoint/prism/TestCompareJson.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/infra/prism/src/test/java/com/evolveum/midpoint/prism/TestCompareXml.java
+++ b/infra/prism/src/test/java/com/evolveum/midpoint/prism/TestCompareXml.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/infra/prism/src/test/java/com/evolveum/midpoint/prism/TestCompareYaml.java
+++ b/infra/prism/src/test/java/com/evolveum/midpoint/prism/TestCompareYaml.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/infra/prism/src/test/java/com/evolveum/midpoint/prism/TestDelta.java
+++ b/infra/prism/src/test/java/com/evolveum/midpoint/prism/TestDelta.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/infra/prism/src/test/java/com/evolveum/midpoint/prism/TestDiff.java
+++ b/infra/prism/src/test/java/com/evolveum/midpoint/prism/TestDiff.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/infra/prism/src/test/java/com/evolveum/midpoint/prism/TestPrismContext.java
+++ b/infra/prism/src/test/java/com/evolveum/midpoint/prism/TestPrismContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/infra/prism/src/test/java/com/evolveum/midpoint/prism/TestPrismParsing.java
+++ b/infra/prism/src/test/java/com/evolveum/midpoint/prism/TestPrismParsing.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/infra/prism/src/test/java/com/evolveum/midpoint/prism/TestUnknownItems.java
+++ b/infra/prism/src/test/java/com/evolveum/midpoint/prism/TestUnknownItems.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/infra/prism/src/test/resources/common/root-foo.xml
+++ b/infra/prism/src/test/resources/common/root-foo.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/infra/prism/src/test/resources/common/xml/event-handler.xml
+++ b/infra/prism/src/test/resources/common/xml/event-handler.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-  ~ Copyright (c) 2010-2014 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/infra/prism/src/test/resources/common/xml/user-barbossa.xml
+++ b/infra/prism/src/test/resources/common/xml/user-barbossa.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/infra/prism/src/test/resources/common/xml/user-jack-adhoc.xml
+++ b/infra/prism/src/test/resources/common/xml/user-jack-adhoc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/infra/prism/src/test/resources/common/xml/user-jack-modified.xml
+++ b/infra/prism/src/test/resources/common/xml/user-jack-modified.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/infra/prism/src/test/resources/common/xml/user-jack-no-ns.xml
+++ b/infra/prism/src/test/resources/common/xml/user-jack-no-ns.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/infra/prism/src/test/resources/common/xml/user-jack-object.xml
+++ b/infra/prism/src/test/resources/common/xml/user-jack-object.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/infra/prism/src/test/resources/common/xml/user-jack.xml
+++ b/infra/prism/src/test/resources/common/xml/user-jack.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2014 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/infra/prism/src/test/resources/common/xml/user-will.xml
+++ b/infra/prism/src/test/resources/common/xml/user-will.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/infra/prism/src/test/resources/common/xml/user-wrong-item.xml
+++ b/infra/prism/src/test/resources/common/xml/user-wrong-item.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/infra/prism/src/test/resources/common/xml/user-wrong-namespace.xml
+++ b/infra/prism/src/test/resources/common/xml/user-wrong-namespace.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/infra/prism/src/test/resources/logback-test.xml
+++ b/infra/prism/src/test/resources/logback-test.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/infra/prism/src/test/resources/query/filter-not-full-text.xml
+++ b/infra/prism/src/test/resources/query/filter-not-full-text.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/infra/prism/src/test/resources/query/filter-not-in-oid.xml
+++ b/infra/prism/src/test/resources/query/filter-not-in-oid.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/infra/prism/src/test/resources/schema/extension-secondary.xsd
+++ b/infra/prism/src/test/resources/schema/extension-secondary.xsd
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/infra/prism/testng-unit.xml
+++ b/infra/prism/testng-unit.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/infra/schema-pure-jaxb/pom.xml
+++ b/infra/schema-pure-jaxb/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/infra/schema-pure-jaxb/src/compile/resources/catalog.xml
+++ b/infra/schema-pure-jaxb/src/compile/resources/catalog.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/infra/schema-pure-jaxb/testng-unit.xml
+++ b/infra/schema-pure-jaxb/testng-unit.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/infra/schema/pom.xml
+++ b/infra/schema/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/infra/schema/src/compile/resources/jax-ws-catalog.xml
+++ b/infra/schema/src/compile/resources/jax-ws-catalog.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  ~ Copyright (c) 2010-2014 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/infra/schema/src/main/java/com/evolveum/midpoint/schema/ObjectTreeDeltas.java
+++ b/infra/schema/src/main/java/com/evolveum/midpoint/schema/ObjectTreeDeltas.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/infra/schema/src/main/java/com/evolveum/midpoint/schema/RepositoryQueryDiagRequest.java
+++ b/infra/schema/src/main/java/com/evolveum/midpoint/schema/RepositoryQueryDiagRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/infra/schema/src/main/java/com/evolveum/midpoint/schema/RepositoryQueryDiagResponse.java
+++ b/infra/schema/src/main/java/com/evolveum/midpoint/schema/RepositoryQueryDiagResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/infra/schema/src/main/java/com/evolveum/midpoint/schema/SelectorOptions.java
+++ b/infra/schema/src/main/java/com/evolveum/midpoint/schema/SelectorOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/infra/schema/src/main/java/com/evolveum/midpoint/schema/processor/ConnectorSchema.java
+++ b/infra/schema/src/main/java/com/evolveum/midpoint/schema/processor/ConnectorSchema.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/infra/schema/src/main/java/com/evolveum/midpoint/schema/processor/ObjectClassComplexTypeDefinitionImpl.java
+++ b/infra/schema/src/main/java/com/evolveum/midpoint/schema/processor/ObjectClassComplexTypeDefinitionImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/infra/schema/src/main/java/com/evolveum/midpoint/schema/processor/ResourceAttribute.java
+++ b/infra/schema/src/main/java/com/evolveum/midpoint/schema/processor/ResourceAttribute.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/infra/schema/src/main/java/com/evolveum/midpoint/schema/processor/ResourceAttributeContainerDefinition.java
+++ b/infra/schema/src/main/java/com/evolveum/midpoint/schema/processor/ResourceAttributeContainerDefinition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/infra/schema/src/main/java/com/evolveum/midpoint/schema/processor/ResourceAttributeContainerDefinitionImpl.java
+++ b/infra/schema/src/main/java/com/evolveum/midpoint/schema/processor/ResourceAttributeContainerDefinitionImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/infra/schema/src/main/java/com/evolveum/midpoint/schema/processor/ResourceAttributeDefinition.java
+++ b/infra/schema/src/main/java/com/evolveum/midpoint/schema/processor/ResourceAttributeDefinition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/infra/schema/src/main/java/com/evolveum/midpoint/schema/processor/ResourceSchema.java
+++ b/infra/schema/src/main/java/com/evolveum/midpoint/schema/processor/ResourceSchema.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/infra/schema/src/main/java/com/evolveum/midpoint/schema/processor/SpecificAttributesDefinition.java
+++ b/infra/schema/src/main/java/com/evolveum/midpoint/schema/processor/SpecificAttributesDefinition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/infra/schema/src/main/java/com/evolveum/midpoint/schema/util/ExceptionUtil.java
+++ b/infra/schema/src/main/java/com/evolveum/midpoint/schema/util/ExceptionUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/infra/schema/src/main/java/com/evolveum/midpoint/schema/util/FormTypeUtil.java
+++ b/infra/schema/src/main/java/com/evolveum/midpoint/schema/util/FormTypeUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/infra/schema/src/main/java/com/evolveum/midpoint/schema/util/ObjectQueryUtil.java
+++ b/infra/schema/src/main/java/com/evolveum/midpoint/schema/util/ObjectQueryUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/infra/schema/src/main/java/com/evolveum/midpoint/schema/util/PolicyRuleTypeUtil.java
+++ b/infra/schema/src/main/java/com/evolveum/midpoint/schema/util/PolicyRuleTypeUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/infra/schema/src/main/resources/META-INF/catalog-runtime.xml
+++ b/infra/schema/src/main/resources/META-INF/catalog-runtime.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/infra/schema/src/main/resources/META-INF/catalog-schema-dist.xml
+++ b/infra/schema/src/main/resources/META-INF/catalog-schema-dist.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/infra/schema/src/main/resources/META-INF/jax-ws-catalog.xml
+++ b/infra/schema/src/main/resources/META-INF/jax-ws-catalog.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/infra/schema/src/main/resources/META-INF/schemas-in-this-module.xml
+++ b/infra/schema/src/main/resources/META-INF/schemas-in-this-module.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  ~ Copyright (c) 2010-2014 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/infra/schema/src/main/resources/localization/schema.properties
+++ b/infra/schema/src/main/resources/localization/schema.properties
@@ -1,4 +1,4 @@
-# Copyright (c) 2010-2016 Evolveum
+# Copyright (c) 2010-2017 Evolveum
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/infra/schema/src/main/resources/localization/schema_cs.properties
+++ b/infra/schema/src/main/resources/localization/schema_cs.properties
@@ -1,4 +1,4 @@
-# Copyright (c) 2010-2016 Evolveum
+# Copyright (c) 2010-2017 Evolveum
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/infra/schema/src/main/resources/localization/schema_de.properties
+++ b/infra/schema/src/main/resources/localization/schema_de.properties
@@ -1,4 +1,4 @@
-# Copyright (c) 2010-2016 Evolveum
+# Copyright (c) 2010-2017 Evolveum
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/infra/schema/src/main/resources/localization/schema_en.properties
+++ b/infra/schema/src/main/resources/localization/schema_en.properties
@@ -1,4 +1,4 @@
-# Copyright (c) 2010-2016 Evolveum
+# Copyright (c) 2010-2017 Evolveum
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/infra/schema/src/main/resources/localization/schema_es.properties
+++ b/infra/schema/src/main/resources/localization/schema_es.properties
@@ -1,4 +1,4 @@
-# Copyright (c) 2010-2016 Evolveum
+# Copyright (c) 2010-2017 Evolveum
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/infra/schema/src/main/resources/localization/schema_et.properties
+++ b/infra/schema/src/main/resources/localization/schema_et.properties
@@ -1,4 +1,4 @@
-# Copyright (c) 2010-2016 Evolveum
+# Copyright (c) 2010-2017 Evolveum
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/infra/schema/src/main/resources/localization/schema_hu.properties
+++ b/infra/schema/src/main/resources/localization/schema_hu.properties
@@ -1,4 +1,4 @@
-# Copyright (c) 2010-2016 Evolveum
+# Copyright (c) 2010-2017 Evolveum
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/infra/schema/src/main/resources/localization/schema_pl.properties
+++ b/infra/schema/src/main/resources/localization/schema_pl.properties
@@ -1,4 +1,4 @@
-# Copyright (c) 2010-2016 Evolveum
+# Copyright (c) 2010-2017 Evolveum
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/infra/schema/src/main/resources/localization/schema_pt_BR.properties
+++ b/infra/schema/src/main/resources/localization/schema_pt_BR.properties
@@ -1,4 +1,4 @@
-# Copyright (c) 2010-2016 Evolveum
+# Copyright (c) 2010-2017 Evolveum
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/infra/schema/src/main/resources/localization/schema_ru.properties
+++ b/infra/schema/src/main/resources/localization/schema_ru.properties
@@ -1,4 +1,4 @@
-# Copyright (c) 2010-2016 Evolveum
+# Copyright (c) 2010-2017 Evolveum
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/infra/schema/src/main/resources/localization/schema_sk.properties
+++ b/infra/schema/src/main/resources/localization/schema_sk.properties
@@ -1,4 +1,4 @@
-# Copyright (c) 2010-2016 Evolveum
+# Copyright (c) 2010-2017 Evolveum
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/infra/schema/src/main/resources/localization/schema_tr.properties
+++ b/infra/schema/src/main/resources/localization/schema_tr.properties
@@ -1,4 +1,4 @@
-# Copyright (c) 2010-2016 Evolveum
+# Copyright (c) 2010-2017 Evolveum
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/infra/schema/src/main/resources/localization/schema_zh_CN.properties
+++ b/infra/schema/src/main/resources/localization/schema_zh_CN.properties
@@ -1,4 +1,4 @@
-# Copyright (c) 2010-2016 Evolveum
+# Copyright (c) 2010-2017 Evolveum
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/infra/schema/src/main/resources/xml/ns/private/webservice/modelService.wsdl
+++ b/infra/schema/src/main/resources/xml/ns/private/webservice/modelService.wsdl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/infra/schema/src/main/resources/xml/ns/private/webservice/reportService.wsdl
+++ b/infra/schema/src/main/resources/xml/ns/private/webservice/reportService.wsdl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/infra/schema/src/main/resources/xml/ns/public/common/common-certification-3.xsd
+++ b/infra/schema/src/main/resources/xml/ns/public/common/common-certification-3.xsd
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/infra/schema/src/main/resources/xml/ns/public/common/common-model-context-3.xsd
+++ b/infra/schema/src/main/resources/xml/ns/public/common/common-model-context-3.xsd
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/infra/schema/src/main/resources/xml/ns/public/common/common-notifications-3.xsd
+++ b/infra/schema/src/main/resources/xml/ns/public/common/common-notifications-3.xsd
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/infra/schema/src/main/resources/xml/ns/public/common/common-workflows-3.xsd
+++ b/infra/schema/src/main/resources/xml/ns/public/common/common-workflows-3.xsd
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/infra/schema/src/main/resources/xml/ns/public/task/jdbc-ping-3.xsd
+++ b/infra/schema/src/main/resources/xml/ns/public/task/jdbc-ping-3.xsd
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/infra/schema/src/test/java/com/evolveum/midpoint/schema/TestFilterSimplifier.java
+++ b/infra/schema/src/test/java/com/evolveum/midpoint/schema/TestFilterSimplifier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/infra/schema/src/test/java/com/evolveum/midpoint/schema/TestImmutable.java
+++ b/infra/schema/src/test/java/com/evolveum/midpoint/schema/TestImmutable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/infra/schema/src/test/java/com/evolveum/midpoint/schema/TestOperationResult.java
+++ b/infra/schema/src/test/java/com/evolveum/midpoint/schema/TestOperationResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/infra/schema/src/test/java/com/evolveum/midpoint/schema/TestSchemaRegistry.java
+++ b/infra/schema/src/test/java/com/evolveum/midpoint/schema/TestSchemaRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/infra/schema/src/test/java/com/evolveum/midpoint/schema/parser/AbstractContainerValueParserTest.java
+++ b/infra/schema/src/test/java/com/evolveum/midpoint/schema/parser/AbstractContainerValueParserTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/infra/schema/src/test/java/com/evolveum/midpoint/schema/parser/AbstractObjectParserTest.java
+++ b/infra/schema/src/test/java/com/evolveum/midpoint/schema/parser/AbstractObjectParserTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/infra/schema/src/test/java/com/evolveum/midpoint/schema/parser/AbstractParserTest.java
+++ b/infra/schema/src/test/java/com/evolveum/midpoint/schema/parser/AbstractParserTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/infra/schema/src/test/java/com/evolveum/midpoint/schema/parser/AbstractPropertyValueParserTest.java
+++ b/infra/schema/src/test/java/com/evolveum/midpoint/schema/parser/AbstractPropertyValueParserTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/infra/schema/src/test/java/com/evolveum/midpoint/schema/parser/TestParseCertificationCase.java
+++ b/infra/schema/src/test/java/com/evolveum/midpoint/schema/parser/TestParseCertificationCase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/infra/schema/src/test/java/com/evolveum/midpoint/schema/parser/TestParseMapping.java
+++ b/infra/schema/src/test/java/com/evolveum/midpoint/schema/parser/TestParseMapping.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/infra/schema/src/test/java/com/evolveum/midpoint/schema/parser/TestParseMappings.java
+++ b/infra/schema/src/test/java/com/evolveum/midpoint/schema/parser/TestParseMappings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/infra/schema/src/test/java/com/evolveum/midpoint/schema/parser/TestParseMetarole.java
+++ b/infra/schema/src/test/java/com/evolveum/midpoint/schema/parser/TestParseMetarole.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/infra/schema/src/test/java/com/evolveum/midpoint/schema/parser/TestParseShadow.java
+++ b/infra/schema/src/test/java/com/evolveum/midpoint/schema/parser/TestParseShadow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/infra/schema/src/test/java/com/evolveum/midpoint/schema/parser/TestParseUser.java
+++ b/infra/schema/src/test/java/com/evolveum/midpoint/schema/parser/TestParseUser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/infra/schema/src/test/java/com/evolveum/midpoint/schema/processor/TestResourceSchema.java
+++ b/infra/schema/src/test/java/com/evolveum/midpoint/schema/processor/TestResourceSchema.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/infra/schema/src/test/resources/common/account-jack.xml
+++ b/infra/schema/src/test/resources/common/account-jack.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/infra/schema/src/test/resources/common/filter.xml
+++ b/infra/schema/src/test/resources/common/filter.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2014 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/infra/schema/src/test/resources/common/generic-sample-configuration.xml
+++ b/infra/schema/src/test/resources/common/generic-sample-configuration.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/infra/schema/src/test/resources/common/lookup-table.xml
+++ b/infra/schema/src/test/resources/common/lookup-table.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/infra/schema/src/test/resources/common/password-policy.xml
+++ b/infra/schema/src/test/resources/common/password-policy.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/infra/schema/src/test/resources/common/resource-opendj-no-xmlns.xml
+++ b/infra/schema/src/test/resources/common/resource-opendj-no-xmlns.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2014 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/infra/schema/src/test/resources/common/role.xml
+++ b/infra/schema/src/test/resources/common/role.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/infra/schema/src/test/resources/common/task-1.xml
+++ b/infra/schema/src/test/resources/common/task-1.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/infra/schema/src/test/resources/common/task-bulk-action-1.xml
+++ b/infra/schema/src/test/resources/common/task-bulk-action-1.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2014 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/infra/schema/src/test/resources/common/user-barbossa-modify-delete-assignment-account-opendj-attr.xml
+++ b/infra/schema/src/test/resources/common/user-barbossa-modify-delete-assignment-account-opendj-attr.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/infra/schema/src/test/resources/common/user-barbossa.xml
+++ b/infra/schema/src/test/resources/common/user-barbossa.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/infra/schema/src/test/resources/common/user-bill.xml
+++ b/infra/schema/src/test/resources/common/user-bill.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/infra/schema/src/test/resources/common/user-jack.xml
+++ b/infra/schema/src/test/resources/common/user-jack.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2014 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/infra/schema/src/test/resources/common/xml/no-ns/resource-opendj-simple.xml
+++ b/infra/schema/src/test/resources/common/xml/no-ns/resource-opendj-simple.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/infra/schema/src/test/resources/common/xml/no-ns/resource-opendj.xml
+++ b/infra/schema/src/test/resources/common/xml/no-ns/resource-opendj.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/infra/schema/src/test/resources/common/xml/no-ns/user-jack.xml
+++ b/infra/schema/src/test/resources/common/xml/no-ns/user-jack.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/infra/schema/src/test/resources/common/xml/ns/certification-case-1.xml
+++ b/infra/schema/src/test/resources/common/xml/ns/certification-case-1.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/infra/schema/src/test/resources/common/xml/ns/mapping.xml
+++ b/infra/schema/src/test/resources/common/xml/ns/mapping.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/infra/schema/src/test/resources/common/xml/ns/mappings.xml
+++ b/infra/schema/src/test/resources/common/xml/ns/mappings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/infra/schema/src/test/resources/common/xml/ns/metarole.xml
+++ b/infra/schema/src/test/resources/common/xml/ns/metarole.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/infra/schema/src/test/resources/common/xml/ns/resource-opendj-simple.xml
+++ b/infra/schema/src/test/resources/common/xml/ns/resource-opendj-simple.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/infra/schema/src/test/resources/common/xml/ns/resource-opendj.xml
+++ b/infra/schema/src/test/resources/common/xml/ns/resource-opendj.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/infra/schema/src/test/resources/common/xml/ns/shadow-hbarbossa.xml
+++ b/infra/schema/src/test/resources/common/xml/ns/shadow-hbarbossa.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/infra/schema/src/test/resources/common/xml/ns/user-jack.xml
+++ b/infra/schema/src/test/resources/common/xml/ns/user-jack.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2014 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/infra/schema/src/test/resources/converter/account-jack.xml
+++ b/infra/schema/src/test/resources/converter/account-jack.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/infra/schema/src/test/resources/deltaconverter/role-modify-inducement.xml
+++ b/infra/schema/src/test/resources/deltaconverter/role-modify-inducement.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  ~ Copyright (c) 2010-2014 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/infra/schema/src/test/resources/deltaconverter/task-new.xml
+++ b/infra/schema/src/test/resources/deltaconverter/task-new.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/infra/schema/src/test/resources/deltaconverter/task-old.xml
+++ b/infra/schema/src/test/resources/deltaconverter/task-old.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/infra/schema/src/test/resources/deltaconverter/user-modify-add-account.xml
+++ b/infra/schema/src/test/resources/deltaconverter/user-modify-add-account.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/infra/schema/src/test/resources/deltaconverter/user-modify-add-role-pirate.xml
+++ b/infra/schema/src/test/resources/deltaconverter/user-modify-add-role-pirate.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/infra/schema/src/test/resources/deltaconverter/user-modify-givenname.xml
+++ b/infra/schema/src/test/resources/deltaconverter/user-modify-givenname.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/infra/schema/src/test/resources/deltaconverter/user-modify-password.xml
+++ b/infra/schema/src/test/resources/deltaconverter/user-modify-password.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/infra/schema/src/test/resources/diff/resource-after-ns-change.xml
+++ b/infra/schema/src/test/resources/diff/resource-after-ns-change.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/infra/schema/src/test/resources/diff/resource-after.xml
+++ b/infra/schema/src/test/resources/diff/resource-after.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/infra/schema/src/test/resources/diff/resource-before.xml
+++ b/infra/schema/src/test/resources/diff/resource-before.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/infra/schema/src/test/resources/diff/resource2-broken.xml
+++ b/infra/schema/src/test/resources/diff/resource2-broken.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/infra/schema/src/test/resources/diff/resource2-fixed.xml
+++ b/infra/schema/src/test/resources/diff/resource2-fixed.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/infra/schema/src/test/resources/diff/shadow-before.xml
+++ b/infra/schema/src/test/resources/diff/shadow-before.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/infra/schema/src/test/resources/diff/task-after.xml
+++ b/infra/schema/src/test/resources/diff/task-after.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/infra/schema/src/test/resources/diff/task-before.xml
+++ b/infra/schema/src/test/resources/diff/task-before.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/infra/schema/src/test/resources/diff/user-after.xml
+++ b/infra/schema/src/test/resources/diff/user-after.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/infra/schema/src/test/resources/diff/user-before.xml
+++ b/infra/schema/src/test/resources/diff/user-before.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/infra/schema/src/test/resources/diff/user-jack-after.xml
+++ b/infra/schema/src/test/resources/diff/user-jack-after.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/infra/schema/src/test/resources/diff/user-jack-before.xml
+++ b/infra/schema/src/test/resources/diff/user-jack-before.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/infra/schema/src/test/resources/diff/user-real-after.xml
+++ b/infra/schema/src/test/resources/diff/user-real-after.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/infra/schema/src/test/resources/diff/user-real-before.xml
+++ b/infra/schema/src/test/resources/diff/user-real-before.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/infra/schema/src/test/resources/expression/expression-1.xml
+++ b/infra/schema/src/test/resources/expression/expression-1.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/infra/schema/src/test/resources/expression/expression-explicit-ns.xml
+++ b/infra/schema/src/test/resources/expression/expression-explicit-ns.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/infra/schema/src/test/resources/logback-test.xml
+++ b/infra/schema/src/test/resources/logback-test.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/infra/schema/src/test/resources/object-template/object-template.xml
+++ b/infra/schema/src/test/resources/object-template/object-template.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/infra/schema/src/test/resources/object-template/user-template.xml
+++ b/infra/schema/src/test/resources/object-template/user-template.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/infra/schema/src/test/resources/object-template/wrong-template.xml
+++ b/infra/schema/src/test/resources/object-template/wrong-template.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/infra/schema/src/test/resources/processor/object1.xml
+++ b/infra/schema/src/test/resources/processor/object1.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -27,4 +27,3 @@
 		<group>123456</group>			
 		<ufo>Mars attacks!</ufo>
 </account>
-            

--- a/infra/schema/src/test/resources/queryconvertor/filter-account-by-attributes-and-resource-ref-no-ns.xml
+++ b/infra/schema/src/test/resources/queryconvertor/filter-account-by-attributes-and-resource-ref-no-ns.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/infra/schema/src/test/resources/queryconvertor/filter-account-by-attributes-and-resource-ref.xml
+++ b/infra/schema/src/test/resources/queryconvertor/filter-account-by-attributes-and-resource-ref.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/infra/schema/src/test/resources/queryconvertor/filter-account.xml
+++ b/infra/schema/src/test/resources/queryconvertor/filter-account.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  ~ Copyright (c) 2010-2014 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/infra/schema/src/test/resources/queryconvertor/filter-and-generic.xml
+++ b/infra/schema/src/test/resources/queryconvertor/filter-and-generic.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  ~ Copyright (c) 2010-2014 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/infra/schema/src/test/resources/queryconvertor/filter-by-type.xml
+++ b/infra/schema/src/test/resources/queryconvertor/filter-by-type.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2014 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/infra/schema/src/test/resources/queryconvertor/filter-connector-by-type.xml
+++ b/infra/schema/src/test/resources/queryconvertor/filter-connector-by-type.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2014 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/infra/schema/src/test/resources/queryconvertor/filter-or-composite.xml
+++ b/infra/schema/src/test/resources/queryconvertor/filter-or-composite.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  ~ Copyright (c) 2010-2014 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/infra/schema/src/test/resources/queryconvertor/filter-user-by-fullName.xml
+++ b/infra/schema/src/test/resources/queryconvertor/filter-user-by-fullName.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2014 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/infra/schema/src/test/resources/queryconvertor/filter-user-by-name.xml
+++ b/infra/schema/src/test/resources/queryconvertor/filter-user-by-name.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  ~ Copyright (c) 2010-2014 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/infra/schema/src/test/resources/queryconvertor/filter-user-substring-anchor-start-end-expression.xml
+++ b/infra/schema/src/test/resources/queryconvertor/filter-user-substring-anchor-start-end-expression.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/infra/schema/src/test/resources/queryconvertor/filter-user-substring-employeeType.xml
+++ b/infra/schema/src/test/resources/queryconvertor/filter-user-substring-employeeType.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/infra/schema/src/test/resources/queryconvertor/filter-user-substring-expression.xml
+++ b/infra/schema/src/test/resources/queryconvertor/filter-user-substring-expression.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/infra/schema/src/test/resources/queryconvertor/filter-user-substring-fullName.xml
+++ b/infra/schema/src/test/resources/queryconvertor/filter-user-substring-fullName.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  ~ Copyright (c) 2010-2014 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/infra/schema/src/test/resources/queryconvertor/test100All.xml
+++ b/infra/schema/src/test/resources/queryconvertor/test100All.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/infra/schema/src/test/resources/queryconvertor/test110None.xml
+++ b/infra/schema/src/test/resources/queryconvertor/test110None.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/infra/schema/src/test/resources/queryconvertor/test120Undefined.xml
+++ b/infra/schema/src/test/resources/queryconvertor/test120Undefined.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/infra/schema/src/test/resources/queryconvertor/test200Equal.xml
+++ b/infra/schema/src/test/resources/queryconvertor/test200Equal.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/infra/schema/src/test/resources/queryconvertor/test210EqualMultiple.xml
+++ b/infra/schema/src/test/resources/queryconvertor/test210EqualMultiple.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/infra/schema/src/test/resources/queryconvertor/test220EqualRightHandItem.xml
+++ b/infra/schema/src/test/resources/queryconvertor/test220EqualRightHandItem.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/infra/schema/src/test/resources/queryconvertor/test300Greater.xml
+++ b/infra/schema/src/test/resources/queryconvertor/test300Greater.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/infra/schema/src/test/resources/queryconvertor/test310AllComparisons.xml
+++ b/infra/schema/src/test/resources/queryconvertor/test310AllComparisons.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/infra/schema/src/test/resources/queryconvertor/test350Substring.xml
+++ b/infra/schema/src/test/resources/queryconvertor/test350Substring.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~  
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/infra/schema/src/test/resources/queryconvertor/test360Ref.xml
+++ b/infra/schema/src/test/resources/queryconvertor/test360Ref.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/infra/schema/src/test/resources/queryconvertor/test365RefTwoWay.xml
+++ b/infra/schema/src/test/resources/queryconvertor/test365RefTwoWay.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/infra/schema/src/test/resources/queryconvertor/test400OrgFilterRoot.xml
+++ b/infra/schema/src/test/resources/queryconvertor/test400OrgFilterRoot.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/infra/schema/src/test/resources/queryconvertor/test420OrgFilterDirect.xml
+++ b/infra/schema/src/test/resources/queryconvertor/test420OrgFilterDirect.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/infra/schema/src/test/resources/queryconvertor/test430OrgFilterDefaultScope.xml
+++ b/infra/schema/src/test/resources/queryconvertor/test430OrgFilterDefaultScope.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/infra/schema/src/test/resources/queryconvertor/test500InOid.xml
+++ b/infra/schema/src/test/resources/queryconvertor/test500InOid.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/infra/schema/src/test/resources/queryconvertor/test510InOidContainer.xml
+++ b/infra/schema/src/test/resources/queryconvertor/test510InOidContainer.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/infra/schema/src/test/resources/queryconvertor/test590Logicals.xml
+++ b/infra/schema/src/test/resources/queryconvertor/test590Logicals.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/infra/schema/src/test/resources/queryconvertor/test600Type.xml
+++ b/infra/schema/src/test/resources/queryconvertor/test600Type.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/infra/schema/src/test/resources/queryconvertor/test700Exists.xml
+++ b/infra/schema/src/test/resources/queryconvertor/test700Exists.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/infra/schema/src/test/resources/schema-registry/data-schemadir.xml
+++ b/infra/schema/src/test/resources/schema-registry/data-schemadir.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/infra/schema/src/test/resources/testdata/attribute-description-1.xml
+++ b/infra/schema/src/test/resources/testdata/attribute-description-1.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/infra/schema/src/test/resources/testdata/attribute-description-2.xml
+++ b/infra/schema/src/test/resources/testdata/attribute-description-2.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/infra/schema/src/test/resources/util/object-change-modify-activation.xml
+++ b/infra/schema/src/test/resources/util/object-change-modify-activation.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/infra/schema/src/test/resources/util/object-change-modify-password-hack.xml
+++ b/infra/schema/src/test/resources/util/object-change-modify-password-hack.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/infra/schema/src/test/resources/util/object-change-modify-password.xml
+++ b/infra/schema/src/test/resources/util/object-change-modify-password.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/infra/schema/src/test/resources/util/user-8859-2.xml
+++ b/infra/schema/src/test/resources/util/user-8859-2.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="iso-8859-2"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/infra/schema/src/test/resources/util/user-utf8.xml
+++ b/infra/schema/src/test/resources/util/user-utf8.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/infra/schema/src/test/resources/xpath/changetype-1.xml
+++ b/infra/schema/src/test/resources/xpath/changetype-1.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/infra/schema/src/test/resources/xpath/data.xml
+++ b/infra/schema/src/test/resources/xpath/data.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/infra/schema/testng-unit.xml
+++ b/infra/schema/testng-unit.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/infra/test-util/pom.xml
+++ b/infra/test-util/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/infra/test-util/src/main/java/com/evolveum/midpoint/test/ldap/AbstractResourceController.java
+++ b/infra/test-util/src/main/java/com/evolveum/midpoint/test/ldap/AbstractResourceController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/infra/test-util/src/main/java/com/evolveum/midpoint/test/util/MidPointAsserts.java
+++ b/infra/test-util/src/main/java/com/evolveum/midpoint/test/util/MidPointAsserts.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/infra/test-util/src/main/java/com/evolveum/midpoint/test/util/TestUtil.java
+++ b/infra/test-util/src/main/java/com/evolveum/midpoint/test/util/TestUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/infra/test-util/src/main/resources/test-data/ldif/example-4000.ldif
+++ b/infra/test-util/src/main/resources/test-data/ldif/example-4000.ldif
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2010-2016 Evolveum
+# Copyright (c) 2010-2017 Evolveum
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/infra/test-util/src/main/resources/test-data/ldif/example.ldif
+++ b/infra/test-util/src/main/resources/test-data/ldif/example.ldif
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2010-2016 Evolveum
+# Copyright (c) 2010-2017 Evolveum
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/infra/test-util/testng-unit.xml
+++ b/infra/test-util/testng-unit.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/infra/util/pom.xml
+++ b/infra/util/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/infra/util/src/main/java/com/evolveum/midpoint/util/DebugDumpable.java
+++ b/infra/util/src/main/java/com/evolveum/midpoint/util/DebugDumpable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/infra/util/src/main/java/com/evolveum/midpoint/util/SystemUtil.java
+++ b/infra/util/src/main/java/com/evolveum/midpoint/util/SystemUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/infra/util/src/main/java/com/evolveum/midpoint/util/aspect/MidpointInterceptor.java
+++ b/infra/util/src/main/java/com/evolveum/midpoint/util/aspect/MidpointInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/infra/util/src/main/java/com/evolveum/midpoint/util/aspect/MidpointPointcut.java
+++ b/infra/util/src/main/java/com/evolveum/midpoint/util/aspect/MidpointPointcut.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/infra/util/src/main/java/com/evolveum/midpoint/util/aspect/ProfilingDataLog.java
+++ b/infra/util/src/main/java/com/evolveum/midpoint/util/aspect/ProfilingDataLog.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/infra/util/src/main/java/com/evolveum/midpoint/util/exception/PolicyViolationException.java
+++ b/infra/util/src/main/java/com/evolveum/midpoint/util/exception/PolicyViolationException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/infra/util/src/main/resources/ctx-interceptor.xml
+++ b/infra/util/src/main/resources/ctx-interceptor.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/infra/util/src/test/resources/domutil/fix-namespace.xml
+++ b/infra/util/src/test/resources/domutil/fix-namespace.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/infra/util/src/test/resources/domutil/qnames.xml
+++ b/infra/util/src/test/resources/domutil/qnames.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/infra/util/src/test/resources/domutil/xsi-type.xml
+++ b/infra/util/src/test/resources/domutil/xsi-type.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/infra/util/src/test/resources/logback-test.xml
+++ b/infra/util/src/test/resources/logback-test.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/infra/util/testng-unit.xml
+++ b/infra/util/testng-unit.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/infra/ws-util/pom.xml
+++ b/infra/ws-util/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/infra/ws-util/src/test/resources/logback-test.xml
+++ b/infra/ws-util/src/test/resources/logback-test.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/certification-api/pom.xml
+++ b/model/certification-api/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/certification-api/src/main/java/com/evolveum/midpoint/certification/api/AccessCertificationApiConstants.java
+++ b/model/certification-api/src/main/java/com/evolveum/midpoint/certification/api/AccessCertificationApiConstants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/model/certification-api/src/main/java/com/evolveum/midpoint/certification/api/CertificationManager.java
+++ b/model/certification-api/src/main/java/com/evolveum/midpoint/certification/api/CertificationManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/model/certification-api/testng-unit.xml
+++ b/model/certification-api/testng-unit.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/certification-impl/src/main/java/com/evolveum/midpoint/certification/impl/AccCertCaseOperationsHelper.java
+++ b/model/certification-impl/src/main/java/com/evolveum/midpoint/certification/impl/AccCertCaseOperationsHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/model/certification-impl/src/main/java/com/evolveum/midpoint/certification/impl/outcomeStrategies/AcceptedIfNotDeniedStrategy.java
+++ b/model/certification-impl/src/main/java/com/evolveum/midpoint/certification/impl/outcomeStrategies/AcceptedIfNotDeniedStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/model/certification-impl/src/main/java/com/evolveum/midpoint/certification/impl/outcomeStrategies/AllMustAcceptStrategy.java
+++ b/model/certification-impl/src/main/java/com/evolveum/midpoint/certification/impl/outcomeStrategies/AllMustAcceptStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/model/certification-impl/src/main/java/com/evolveum/midpoint/certification/impl/outcomeStrategies/BaseOutcomeStrategy.java
+++ b/model/certification-impl/src/main/java/com/evolveum/midpoint/certification/impl/outcomeStrategies/BaseOutcomeStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/model/certification-impl/src/main/java/com/evolveum/midpoint/certification/impl/outcomeStrategies/OneAcceptAcceptsStrategy.java
+++ b/model/certification-impl/src/main/java/com/evolveum/midpoint/certification/impl/outcomeStrategies/OneAcceptAcceptsStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/model/certification-impl/src/main/java/com/evolveum/midpoint/certification/impl/outcomeStrategies/OneDenyDeniesStrategy.java
+++ b/model/certification-impl/src/main/java/com/evolveum/midpoint/certification/impl/outcomeStrategies/OneDenyDeniesStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/model/certification-impl/src/main/java/com/evolveum/midpoint/certification/impl/outcomeStrategies/OutcomeStrategy.java
+++ b/model/certification-impl/src/main/java/com/evolveum/midpoint/certification/impl/outcomeStrategies/OutcomeStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/model/certification-impl/src/main/java/com/evolveum/midpoint/certification/impl/outcomeStrategies/ResponsesSummary.java
+++ b/model/certification-impl/src/main/java/com/evolveum/midpoint/certification/impl/outcomeStrategies/ResponsesSummary.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/model/certification-impl/src/main/resources/ctx-certification.xml
+++ b/model/certification-impl/src/main/resources/ctx-certification.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/certification-impl/src/test/resources/common/certification-of-critical-roles.xml
+++ b/model/certification-impl/src/test/resources/common/certification-of-critical-roles.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/certification-impl/src/test/resources/common/certification-of-eroot-user-assignments.xml
+++ b/model/certification-impl/src/test/resources/common/certification-of-eroot-user-assignments.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/certification-impl/src/test/resources/common/certification-of-role-inducements.xml
+++ b/model/certification-impl/src/test/resources/common/certification-of-role-inducements.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/certification-impl/src/test/resources/common/metarole-cxo.xml
+++ b/model/certification-impl/src/test/resources/common/metarole-cxo.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/certification-impl/src/test/resources/common/orgs-and-users.xml
+++ b/model/certification-impl/src/test/resources/common/orgs-and-users.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/certification-impl/src/test/resources/common/resource-dummy-black.xml
+++ b/model/certification-impl/src/test/resources/common/resource-dummy-black.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/certification-impl/src/test/resources/common/resource-dummy.xml
+++ b/model/certification-impl/src/test/resources/common/resource-dummy.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/certification-impl/src/test/resources/common/role-ceo.xml
+++ b/model/certification-impl/src/test/resources/common/role-ceo.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/certification-impl/src/test/resources/common/role-coo.xml
+++ b/model/certification-impl/src/test/resources/common/role-coo.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/certification-impl/src/test/resources/common/role-cto.xml
+++ b/model/certification-impl/src/test/resources/common/role-cto.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/certification-impl/src/test/resources/common/role-eroot-user-assignment-campaign-owner.xml
+++ b/model/certification-impl/src/test/resources/common/role-eroot-user-assignment-campaign-owner.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/certification-impl/src/test/resources/common/role-reviewer.xml
+++ b/model/certification-impl/src/test/resources/common/role-reviewer.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/certification-impl/src/test/resources/common/role-superuser.xml
+++ b/model/certification-impl/src/test/resources/common/role-superuser.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/certification-impl/src/test/resources/common/system-configuration.xml
+++ b/model/certification-impl/src/test/resources/common/system-configuration.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/certification-impl/src/test/resources/common/user-administrator.xml
+++ b/model/certification-impl/src/test/resources/common/user-administrator.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/certification-impl/src/test/resources/common/user-assignment-more-reviewers-certification.xml
+++ b/model/certification-impl/src/test/resources/common/user-assignment-more-reviewers-certification.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/certification-impl/src/test/resources/common/user-jack.xml
+++ b/model/certification-impl/src/test/resources/common/user-jack.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/certification-impl/src/test/resources/ctx-certification-test-main.xml
+++ b/model/certification-impl/src/test/resources/ctx-certification-test-main.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/certification-impl/src/test/resources/logback-test.xml
+++ b/model/certification-impl/src/test/resources/logback-test.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2014 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/certification-impl/testng-integration.xml
+++ b/model/certification-impl/testng-integration.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-api/pom.xml
+++ b/model/model-api/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-api/src/main/java/com/evolveum/midpoint/model/api/ModelAuthorizationAction.java
+++ b/model/model-api/src/main/java/com/evolveum/midpoint/model/api/ModelAuthorizationAction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/model/model-api/src/main/java/com/evolveum/midpoint/model/api/ModelCompareOptions.java
+++ b/model/model-api/src/main/java/com/evolveum/midpoint/model/api/ModelCompareOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/model/model-api/src/main/java/com/evolveum/midpoint/model/api/context/EvaluatedAssignment.java
+++ b/model/model-api/src/main/java/com/evolveum/midpoint/model/api/context/EvaluatedAssignment.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/model/model-api/src/main/java/com/evolveum/midpoint/model/api/context/ModelElementContext.java
+++ b/model/model-api/src/main/java/com/evolveum/midpoint/model/api/context/ModelElementContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/model/model-api/src/main/java/com/evolveum/midpoint/model/api/context/SynchronizationPolicyDecision.java
+++ b/model/model-api/src/main/java/com/evolveum/midpoint/model/api/context/SynchronizationPolicyDecision.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/model/model-api/src/main/java/com/evolveum/midpoint/model/api/util/DeputyUtils.java
+++ b/model/model-api/src/main/java/com/evolveum/midpoint/model/api/util/DeputyUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/model/model-api/src/main/java/com/evolveum/midpoint/model/api/util/ResourceUtils.java
+++ b/model/model-api/src/main/java/com/evolveum/midpoint/model/api/util/ResourceUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/model/model-api/src/main/java/com/evolveum/midpoint/model/api/validator/Issue.java
+++ b/model/model-api/src/main/java/com/evolveum/midpoint/model/api/validator/Issue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/model/model-api/src/main/java/com/evolveum/midpoint/model/api/validator/ResourceValidator.java
+++ b/model/model-api/src/main/java/com/evolveum/midpoint/model/api/validator/ResourceValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/model/model-api/src/main/java/com/evolveum/midpoint/model/api/validator/Scope.java
+++ b/model/model-api/src/main/java/com/evolveum/midpoint/model/api/validator/Scope.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/model/model-api/src/main/java/com/evolveum/midpoint/model/api/validator/ValidationResult.java
+++ b/model/model-api/src/main/java/com/evolveum/midpoint/model/api/validator/ValidationResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/model/model-api/src/main/java/com/evolveum/midpoint/model/api/visualizer/Name.java
+++ b/model/model-api/src/main/java/com/evolveum/midpoint/model/api/visualizer/Name.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/model/model-api/src/main/java/com/evolveum/midpoint/model/api/visualizer/Scene.java
+++ b/model/model-api/src/main/java/com/evolveum/midpoint/model/api/visualizer/Scene.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/model/model-api/src/main/java/com/evolveum/midpoint/model/api/visualizer/SceneDeltaItem.java
+++ b/model/model-api/src/main/java/com/evolveum/midpoint/model/api/visualizer/SceneDeltaItem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/model/model-api/src/main/java/com/evolveum/midpoint/model/api/visualizer/SceneItem.java
+++ b/model/model-api/src/main/java/com/evolveum/midpoint/model/api/visualizer/SceneItem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/model/model-api/src/main/java/com/evolveum/midpoint/model/api/visualizer/SceneItemValue.java
+++ b/model/model-api/src/main/java/com/evolveum/midpoint/model/api/visualizer/SceneItemValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/model/model-api/testng-unit.xml
+++ b/model/model-api/testng-unit.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-client/pom.xml
+++ b/model/model-client/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-client/src/compile/resources/jax-ws-catalog.xml
+++ b/model/model-client/src/compile/resources/jax-ws-catalog.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-client/src/main/resources/META-INF/jax-ws-catalog.xml
+++ b/model/model-client/src/main/resources/META-INF/jax-ws-catalog.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-client/testng-unit.xml
+++ b/model/model-client/testng-unit.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-common/src/main/resources/ctx-model-common.xml
+++ b/model/model-common/src/main/resources/ctx-model-common.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-common/src/test/java/com/evolveum/midpoint/model/common/expression/script/TestExpressionFunctions.java
+++ b/model/model-common/src/test/java/com/evolveum/midpoint/model/common/expression/script/TestExpressionFunctions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/model/model-common/src/test/java/com/evolveum/midpoint/model/common/mapping/TestMappingComplex.java
+++ b/model/model-common/src/test/java/com/evolveum/midpoint/model/common/mapping/TestMappingComplex.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/model/model-common/src/test/resources/expression/expression/account-jack-dummy.xml
+++ b/model/model-common/src/test/resources/expression/expression/account-jack-dummy.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-common/src/test/resources/expression/expression/user-jack.xml
+++ b/model/model-common/src/test/resources/expression/expression/user-jack.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-common/src/test/resources/expression/functions/account-jack.xml
+++ b/model/model-common/src/test/resources/expression/functions/account-jack.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-common/src/test/resources/expression/functions/resource-opendj.xml
+++ b/model/model-common/src/test/resources/expression/functions/resource-opendj.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-common/src/test/resources/expression/functions/user-jack.xml
+++ b/model/model-common/src/test/resources/expression/functions/user-jack.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-common/src/test/resources/expression/groovy/expression-func-concatname.xml
+++ b/model/model-common/src/test/resources/expression/groovy/expression-func-concatname.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-common/src/test/resources/expression/groovy/expression-func.xml
+++ b/model/model-common/src/test/resources/expression/groovy/expression-func.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-common/src/test/resources/expression/groovy/expression-list.xml
+++ b/model/model-common/src/test/resources/expression/groovy/expression-list.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-common/src/test/resources/expression/groovy/expression-objectref-variables-polystring.xml
+++ b/model/model-common/src/test/resources/expression/groovy/expression-objectref-variables-polystring.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-common/src/test/resources/expression/groovy/expression-objectref-variables.xml
+++ b/model/model-common/src/test/resources/expression/groovy/expression-objectref-variables.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-common/src/test/resources/expression/groovy/expression-polystring-equals-1.xml
+++ b/model/model-common/src/test/resources/expression/groovy/expression-polystring-equals-1.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-common/src/test/resources/expression/groovy/expression-polystring-equals-2.xml
+++ b/model/model-common/src/test/resources/expression/groovy/expression-polystring-equals-2.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-common/src/test/resources/expression/groovy/expression-polystring-equals-stringify-1.xml
+++ b/model/model-common/src/test/resources/expression/groovy/expression-polystring-equals-stringify-1.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-common/src/test/resources/expression/groovy/expression-polystring-equals-stringify-2.xml
+++ b/model/model-common/src/test/resources/expression/groovy/expression-polystring-equals-stringify-2.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-common/src/test/resources/expression/groovy/expression-simple.xml
+++ b/model/model-common/src/test/resources/expression/groovy/expression-simple.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-common/src/test/resources/expression/groovy/expression-string-variables.xml
+++ b/model/model-common/src/test/resources/expression/groovy/expression-string-variables.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-common/src/test/resources/expression/groovy/expression-user-extension-ship-path.xml
+++ b/model/model-common/src/test/resources/expression/groovy/expression-user-extension-ship-path.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-common/src/test/resources/expression/groovy/expression-user-extension-ship.xml
+++ b/model/model-common/src/test/resources/expression/groovy/expression-user-extension-ship.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-common/src/test/resources/expression/groovy/expression-user-given-name.xml
+++ b/model/model-common/src/test/resources/expression/groovy/expression-user-given-name.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-common/src/test/resources/expression/groovy/expression-user-stringify-full-name.xml
+++ b/model/model-common/src/test/resources/expression/groovy/expression-user-stringify-full-name.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-common/src/test/resources/expression/javascript/expression-func-concatname.xml
+++ b/model/model-common/src/test/resources/expression/javascript/expression-func-concatname.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-common/src/test/resources/expression/javascript/expression-func.xml
+++ b/model/model-common/src/test/resources/expression/javascript/expression-func.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-common/src/test/resources/expression/javascript/expression-list.xml
+++ b/model/model-common/src/test/resources/expression/javascript/expression-list.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-common/src/test/resources/expression/javascript/expression-objectref-variables-polystring.xml
+++ b/model/model-common/src/test/resources/expression/javascript/expression-objectref-variables-polystring.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-common/src/test/resources/expression/javascript/expression-objectref-variables.xml
+++ b/model/model-common/src/test/resources/expression/javascript/expression-objectref-variables.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-common/src/test/resources/expression/javascript/expression-simple.xml
+++ b/model/model-common/src/test/resources/expression/javascript/expression-simple.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-common/src/test/resources/expression/javascript/expression-string-variables.xml
+++ b/model/model-common/src/test/resources/expression/javascript/expression-string-variables.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-common/src/test/resources/expression/javascript/expression-user-extension-ship-path.xml
+++ b/model/model-common/src/test/resources/expression/javascript/expression-user-extension-ship-path.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-common/src/test/resources/expression/javascript/expression-user-extension-ship.xml
+++ b/model/model-common/src/test/resources/expression/javascript/expression-user-extension-ship.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-common/src/test/resources/expression/javascript/expression-user-given-name.xml
+++ b/model/model-common/src/test/resources/expression/javascript/expression-user-given-name.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-common/src/test/resources/expression/javascript/expression-user-stringify-full-name.xml
+++ b/model/model-common/src/test/resources/expression/javascript/expression-user-stringify-full-name.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-common/src/test/resources/expression/python/expression-func.xml
+++ b/model/model-common/src/test/resources/expression/python/expression-func.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-common/src/test/resources/expression/python/expression-list.xml
+++ b/model/model-common/src/test/resources/expression/python/expression-list.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-common/src/test/resources/expression/python/expression-objectref-variables-polystring.xml
+++ b/model/model-common/src/test/resources/expression/python/expression-objectref-variables-polystring.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-common/src/test/resources/expression/python/expression-objectref-variables.xml
+++ b/model/model-common/src/test/resources/expression/python/expression-objectref-variables.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-common/src/test/resources/expression/python/expression-simple.xml
+++ b/model/model-common/src/test/resources/expression/python/expression-simple.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-common/src/test/resources/expression/python/expression-string-variables.xml
+++ b/model/model-common/src/test/resources/expression/python/expression-string-variables.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-common/src/test/resources/expression/python/expression-user-extension-ship-path.xml
+++ b/model/model-common/src/test/resources/expression/python/expression-user-extension-ship-path.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-common/src/test/resources/expression/python/expression-user-extension-ship.xml
+++ b/model/model-common/src/test/resources/expression/python/expression-user-extension-ship.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-common/src/test/resources/expression/python/expression-user-given-name.xml
+++ b/model/model-common/src/test/resources/expression/python/expression-user-given-name.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-common/src/test/resources/expression/python/expression-user-stringify-full-name.xml
+++ b/model/model-common/src/test/resources/expression/python/expression-user-stringify-full-name.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-common/src/test/resources/expression/velocity/expression-func-concatname.xml
+++ b/model/model-common/src/test/resources/expression/velocity/expression-func-concatname.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-common/src/test/resources/expression/velocity/expression-func.xml
+++ b/model/model-common/src/test/resources/expression/velocity/expression-func.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-common/src/test/resources/expression/velocity/expression-list.xml
+++ b/model/model-common/src/test/resources/expression/velocity/expression-list.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-common/src/test/resources/expression/velocity/expression-objectref-variables-polystring.xml
+++ b/model/model-common/src/test/resources/expression/velocity/expression-objectref-variables-polystring.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-common/src/test/resources/expression/velocity/expression-objectref-variables.xml
+++ b/model/model-common/src/test/resources/expression/velocity/expression-objectref-variables.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-common/src/test/resources/expression/velocity/expression-polystring-equals-1.xml
+++ b/model/model-common/src/test/resources/expression/velocity/expression-polystring-equals-1.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-common/src/test/resources/expression/velocity/expression-polystring-equals-2.xml
+++ b/model/model-common/src/test/resources/expression/velocity/expression-polystring-equals-2.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-common/src/test/resources/expression/velocity/expression-polystring-equals-stringify-1.xml
+++ b/model/model-common/src/test/resources/expression/velocity/expression-polystring-equals-stringify-1.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-common/src/test/resources/expression/velocity/expression-polystring-equals-stringify-2.xml
+++ b/model/model-common/src/test/resources/expression/velocity/expression-polystring-equals-stringify-2.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-common/src/test/resources/expression/velocity/expression-simple.xml
+++ b/model/model-common/src/test/resources/expression/velocity/expression-simple.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-common/src/test/resources/expression/velocity/expression-string-variables.xml
+++ b/model/model-common/src/test/resources/expression/velocity/expression-string-variables.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-common/src/test/resources/expression/velocity/expression-user-extension-ship-path.xml
+++ b/model/model-common/src/test/resources/expression/velocity/expression-user-extension-ship-path.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-common/src/test/resources/expression/velocity/expression-user-extension-ship.xml
+++ b/model/model-common/src/test/resources/expression/velocity/expression-user-extension-ship.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-common/src/test/resources/expression/velocity/expression-user-given-name.xml
+++ b/model/model-common/src/test/resources/expression/velocity/expression-user-given-name.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-common/src/test/resources/expression/velocity/expression-user-stringify-full-name.xml
+++ b/model/model-common/src/test/resources/expression/velocity/expression-user-stringify-full-name.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-common/src/test/resources/expression/xpath/expression-func-concatname.xml
+++ b/model/model-common/src/test/resources/expression/xpath/expression-func-concatname.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-common/src/test/resources/expression/xpath/expression-func.xml
+++ b/model/model-common/src/test/resources/expression/xpath/expression-func.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-common/src/test/resources/expression/xpath/expression-list.xml
+++ b/model/model-common/src/test/resources/expression/xpath/expression-list.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-common/src/test/resources/expression/xpath/expression-objectref-variables-polystring.xml
+++ b/model/model-common/src/test/resources/expression/xpath/expression-objectref-variables-polystring.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-common/src/test/resources/expression/xpath/expression-objectref-variables.xml
+++ b/model/model-common/src/test/resources/expression/xpath/expression-objectref-variables.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-common/src/test/resources/expression/xpath/expression-root-node.xml
+++ b/model/model-common/src/test/resources/expression/xpath/expression-root-node.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-common/src/test/resources/expression/xpath/expression-simple.xml
+++ b/model/model-common/src/test/resources/expression/xpath/expression-simple.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-common/src/test/resources/expression/xpath/expression-string-variables.xml
+++ b/model/model-common/src/test/resources/expression/xpath/expression-string-variables.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-common/src/test/resources/expression/xpath/expression-user-extension-ship-path.xml
+++ b/model/model-common/src/test/resources/expression/xpath/expression-user-extension-ship-path.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-common/src/test/resources/expression/xpath/expression-user-extension-ship.xml
+++ b/model/model-common/src/test/resources/expression/xpath/expression-user-extension-ship.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-common/src/test/resources/expression/xpath/expression-user-given-name.xml
+++ b/model/model-common/src/test/resources/expression/xpath/expression-user-given-name.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-common/src/test/resources/expression/xpath/expression-user-stringify-full-name.xml
+++ b/model/model-common/src/test/resources/expression/xpath/expression-user-stringify-full-name.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-common/src/test/resources/logback-test.xml
+++ b/model/model-common/src/test/resources/logback-test.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2014 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-common/src/test/resources/mapping/account-inbound-mapping.xml
+++ b/model/model-common/src/test/resources/mapping/account-inbound-mapping.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-common/src/test/resources/mapping/account-jack.xml
+++ b/model/model-common/src/test/resources/mapping/account-jack.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-common/src/test/resources/mapping/mapping-asis-password.xml
+++ b/model/model-common/src/test/resources/mapping/mapping-asis-password.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-common/src/test/resources/mapping/mapping-asis-system-variables-polystring-norm.xml
+++ b/model/model-common/src/test/resources/mapping/mapping-asis-system-variables-polystring-norm.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-common/src/test/resources/mapping/mapping-asis-system-variables-polystring-orig.xml
+++ b/model/model-common/src/test/resources/mapping/mapping-asis-system-variables-polystring-orig.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-common/src/test/resources/mapping/mapping-asis.xml
+++ b/model/model-common/src/test/resources/mapping/mapping-asis.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-common/src/test/resources/mapping/mapping-complex-captain.xml
+++ b/model/model-common/src/test/resources/mapping/mapping-complex-captain.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-common/src/test/resources/mapping/mapping-condition-nonempty.xml
+++ b/model/model-common/src/test/resources/mapping/mapping-condition-nonempty.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-common/src/test/resources/mapping/mapping-generate-policy-bad.xml
+++ b/model/model-common/src/test/resources/mapping/mapping-generate-policy-bad.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-common/src/test/resources/mapping/mapping-generate-policy-empty.xml
+++ b/model/model-common/src/test/resources/mapping/mapping-generate-policy-empty.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-common/src/test/resources/mapping/mapping-generate-policy-numeric.xml
+++ b/model/model-common/src/test/resources/mapping/mapping-generate-policy-numeric.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-common/src/test/resources/mapping/mapping-generate-policy.xml
+++ b/model/model-common/src/test/resources/mapping/mapping-generate-policy.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-common/src/test/resources/mapping/mapping-generate.xml
+++ b/model/model-common/src/test/resources/mapping/mapping-generate.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-common/src/test/resources/mapping/mapping-inbound.xml
+++ b/model/model-common/src/test/resources/mapping/mapping-inbound.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- ~ Copyright (c) 2010-2013 Evolveum ~ ~ Licensed under the Apache License, 
+<!-- ~ Copyright (c) 2010-2017 Evolveum ~ ~ Licensed under the Apache License,
 	Version 2.0 (the "License"); ~ you may not use this file except in compliance 
 	with the License. ~ You may obtain a copy of the License at ~ ~ http://www.apache.org/licenses/LICENSE-2.0 
 	~ ~ Unless required by applicable law or agreed to in writing, software ~ 

--- a/model/model-common/src/test/resources/mapping/mapping-npe.xml
+++ b/model/model-common/src/test/resources/mapping/mapping-npe.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-common/src/test/resources/mapping/mapping-path-enum.xml
+++ b/model/model-common/src/test/resources/mapping/mapping-path-enum.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-common/src/test/resources/mapping/mapping-path-extension-variable.xml
+++ b/model/model-common/src/test/resources/mapping/mapping-path-extension-variable.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-common/src/test/resources/mapping/mapping-path-system-variables-namespace.xml
+++ b/model/model-common/src/test/resources/mapping/mapping-path-system-variables-namespace.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-common/src/test/resources/mapping/mapping-path-system-variables-nosource.xml
+++ b/model/model-common/src/test/resources/mapping/mapping-path-system-variables-nosource.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-common/src/test/resources/mapping/mapping-path-system-variables-polystring-long.xml
+++ b/model/model-common/src/test/resources/mapping/mapping-path-system-variables-polystring-long.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-common/src/test/resources/mapping/mapping-path-system-variables-polystring-short.xml
+++ b/model/model-common/src/test/resources/mapping/mapping-path-system-variables-polystring-short.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-common/src/test/resources/mapping/mapping-path-system-variables.xml
+++ b/model/model-common/src/test/resources/mapping/mapping-path-system-variables.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-common/src/test/resources/mapping/mapping-script-custom-enum.xml
+++ b/model/model-common/src/test/resources/mapping/mapping-script-custom-enum.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-common/src/test/resources/mapping/mapping-script-extra-variables.xml
+++ b/model/model-common/src/test/resources/mapping/mapping-script-extra-variables.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-common/src/test/resources/mapping/mapping-script-fullname.xml
+++ b/model/model-common/src/test/resources/mapping/mapping-script-fullname.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-common/src/test/resources/mapping/mapping-script-list-absolute-groovy.xml
+++ b/model/model-common/src/test/resources/mapping/mapping-script-list-absolute-groovy.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-common/src/test/resources/mapping/mapping-script-list-absolute-xpath.xml
+++ b/model/model-common/src/test/resources/mapping/mapping-script-list-absolute-xpath.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-common/src/test/resources/mapping/mapping-script-list-relative-groovy.xml
+++ b/model/model-common/src/test/resources/mapping/mapping-script-list-relative-groovy.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-common/src/test/resources/mapping/mapping-script-list-relative-xpath.xml
+++ b/model/model-common/src/test/resources/mapping/mapping-script-list-relative-xpath.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-common/src/test/resources/mapping/mapping-script-root-node.xml
+++ b/model/model-common/src/test/resources/mapping/mapping-script-root-node.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-common/src/test/resources/mapping/mapping-script-simple-groovy.xml
+++ b/model/model-common/src/test/resources/mapping/mapping-script-simple-groovy.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-common/src/test/resources/mapping/mapping-script-simple-xpath.xml
+++ b/model/model-common/src/test/resources/mapping/mapping-script-simple-xpath.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-common/src/test/resources/mapping/mapping-script-system-variables-condition-empty-function.xml
+++ b/model/model-common/src/test/resources/mapping/mapping-script-system-variables-condition-empty-function.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-common/src/test/resources/mapping/mapping-script-system-variables-condition-empty-single-function.xml
+++ b/model/model-common/src/test/resources/mapping/mapping-script-system-variables-condition-empty-single-function.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-common/src/test/resources/mapping/mapping-script-system-variables-condition-empty-single.xml
+++ b/model/model-common/src/test/resources/mapping/mapping-script-system-variables-condition-empty-single.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-common/src/test/resources/mapping/mapping-script-system-variables-condition-empty.xml
+++ b/model/model-common/src/test/resources/mapping/mapping-script-system-variables-condition-empty.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-common/src/test/resources/mapping/mapping-script-system-variables-condition-groovy.xml
+++ b/model/model-common/src/test/resources/mapping/mapping-script-system-variables-condition-groovy.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-common/src/test/resources/mapping/mapping-script-system-variables-condition-sourcecontext-groovy.xml
+++ b/model/model-common/src/test/resources/mapping/mapping-script-system-variables-condition-sourcecontext-groovy.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-common/src/test/resources/mapping/mapping-script-system-variables-condition-xpath.xml
+++ b/model/model-common/src/test/resources/mapping/mapping-script-system-variables-condition-xpath.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-common/src/test/resources/mapping/mapping-script-system-variables-employee-number.xml
+++ b/model/model-common/src/test/resources/mapping/mapping-script-system-variables-employee-number.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-common/src/test/resources/mapping/mapping-script-system-variables-employee-type.xml
+++ b/model/model-common/src/test/resources/mapping/mapping-script-system-variables-employee-type.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-common/src/test/resources/mapping/mapping-script-system-variables-password-decrypt.xml
+++ b/model/model-common/src/test/resources/mapping/mapping-script-system-variables-password-decrypt.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-common/src/test/resources/mapping/mapping-script-system-variables-password.xml
+++ b/model/model-common/src/test/resources/mapping/mapping-script-system-variables-password.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-common/src/test/resources/mapping/mapping-script-system-variables-polystring-groovy-norm.xml
+++ b/model/model-common/src/test/resources/mapping/mapping-script-system-variables-polystring-groovy-norm.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-common/src/test/resources/mapping/mapping-script-system-variables-polystring-groovy-op.xml
+++ b/model/model-common/src/test/resources/mapping/mapping-script-system-variables-polystring-groovy-op.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-common/src/test/resources/mapping/mapping-script-system-variables-polystring-groovy-orig.xml
+++ b/model/model-common/src/test/resources/mapping/mapping-script-system-variables-polystring-groovy-orig.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-common/src/test/resources/mapping/mapping-script-system-variables-polystring-groovy.xml
+++ b/model/model-common/src/test/resources/mapping/mapping-script-system-variables-polystring-groovy.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-common/src/test/resources/mapping/mapping-script-system-variables-polystring-xpath.xml
+++ b/model/model-common/src/test/resources/mapping/mapping-script-system-variables-polystring-xpath.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-common/src/test/resources/mapping/mapping-script-variables-groovy.xml
+++ b/model/model-common/src/test/resources/mapping/mapping-script-variables-groovy.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-common/src/test/resources/mapping/mapping-script-variables-xpath.xml
+++ b/model/model-common/src/test/resources/mapping/mapping-script-variables-xpath.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-common/src/test/resources/mapping/mapping-value-boolean-false.xml
+++ b/model/model-common/src/test/resources/mapping/mapping-value-boolean-false.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-common/src/test/resources/mapping/mapping-value-boolean-true.xml
+++ b/model/model-common/src/test/resources/mapping/mapping-value-boolean-true.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-common/src/test/resources/mapping/mapping-value-condition-false.xml
+++ b/model/model-common/src/test/resources/mapping/mapping-value-condition-false.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-common/src/test/resources/mapping/mapping-value-condition-true.xml
+++ b/model/model-common/src/test/resources/mapping/mapping-value-condition-true.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-common/src/test/resources/mapping/mapping-value-multi-deep.xml
+++ b/model/model-common/src/test/resources/mapping/mapping-value-multi-deep.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-common/src/test/resources/mapping/mapping-value-multi-shallow.xml
+++ b/model/model-common/src/test/resources/mapping/mapping-value-multi-shallow.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-common/src/test/resources/mapping/mapping-value-single-deep.xml
+++ b/model/model-common/src/test/resources/mapping/mapping-value-single-deep.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-common/src/test/resources/mapping/mapping-value-single-enum.xml
+++ b/model/model-common/src/test/resources/mapping/mapping-value-single-enum.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-common/src/test/resources/mapping/mapping-value-single-shallow.xml
+++ b/model/model-common/src/test/resources/mapping/mapping-value-single-shallow.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-common/src/test/resources/mapping/password-policy.xml
+++ b/model/model-common/src/test/resources/mapping/password-policy.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-common/src/test/resources/mapping/user-jack.xml
+++ b/model/model-common/src/test/resources/mapping/user-jack.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-common/src/test/resources/objects/c0c010c0-d34d-b33f-f00d-111111111111.xml
+++ b/model/model-common/src/test/resources/objects/c0c010c0-d34d-b33f-f00d-111111111111.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-common/src/test/resources/objects/c0c010c0-d34d-b33f-f00d-111111111112.xml
+++ b/model/model-common/src/test/resources/objects/c0c010c0-d34d-b33f-f00d-111111111112.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-common/src/test/resources/objects/c0c010c0-d34d-b33f-f00d-999111111122.xml
+++ b/model/model-common/src/test/resources/objects/c0c010c0-d34d-b33f-f00d-999111111122.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-common/src/test/resources/objects/c0c010c0-d34d-b33f-f00d-999888111111.xml
+++ b/model/model-common/src/test/resources/objects/c0c010c0-d34d-b33f-f00d-999888111111.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-common/src/test/resources/objects/c0c010c0-d34d-b33f-f00d-999888111112.xml
+++ b/model/model-common/src/test/resources/objects/c0c010c0-d34d-b33f-f00d-999888111112.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-common/src/test/resources/objects/c0c010c0-d34d-b33f-f00d-999888111113.xml
+++ b/model/model-common/src/test/resources/objects/c0c010c0-d34d-b33f-f00d-999888111113.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-common/src/test/resources/objects/c0c010c0-d34d-b33f-f00d-999888111114.xml
+++ b/model/model-common/src/test/resources/objects/c0c010c0-d34d-b33f-f00d-999888111114.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-impl/src/main/java/com/evolveum/midpoint/model/impl/UserComputer.java
+++ b/model/model-impl/src/main/java/com/evolveum/midpoint/model/impl/UserComputer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/model/model-impl/src/main/java/com/evolveum/midpoint/model/impl/lens/AssignmentPathImpl.java
+++ b/model/model-impl/src/main/java/com/evolveum/midpoint/model/impl/lens/AssignmentPathImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/model/model-impl/src/main/java/com/evolveum/midpoint/model/impl/lens/AssignmentPathSegmentImpl.java
+++ b/model/model-impl/src/main/java/com/evolveum/midpoint/model/impl/lens/AssignmentPathSegmentImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/model/model-impl/src/main/java/com/evolveum/midpoint/model/impl/lens/SimpleOperationName.java
+++ b/model/model-impl/src/main/java/com/evolveum/midpoint/model/impl/lens/SimpleOperationName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/model/model-impl/src/main/java/com/evolveum/midpoint/model/impl/lens/projector/OutboundProcessor.java
+++ b/model/model-impl/src/main/java/com/evolveum/midpoint/model/impl/lens/projector/OutboundProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/model/model-impl/src/main/java/com/evolveum/midpoint/model/impl/lens/projector/ProjectionValuesProcessor.java
+++ b/model/model-impl/src/main/java/com/evolveum/midpoint/model/impl/lens/projector/ProjectionValuesProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/model/model-impl/src/main/java/com/evolveum/midpoint/model/impl/scripting/ScriptExecutionTaskHandler.java
+++ b/model/model-impl/src/main/java/com/evolveum/midpoint/model/impl/scripting/ScriptExecutionTaskHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/model/model-impl/src/main/java/com/evolveum/midpoint/model/impl/scripting/actions/NotifyExecutor.java
+++ b/model/model-impl/src/main/java/com/evolveum/midpoint/model/impl/scripting/actions/NotifyExecutor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/model/model-impl/src/main/java/com/evolveum/midpoint/model/impl/scripting/actions/ScriptExecutor.java
+++ b/model/model-impl/src/main/java/com/evolveum/midpoint/model/impl/scripting/actions/ScriptExecutor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/model/model-impl/src/main/java/com/evolveum/midpoint/model/impl/scripting/actions/ValidateExecutor.java
+++ b/model/model-impl/src/main/java/com/evolveum/midpoint/model/impl/scripting/actions/ValidateExecutor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/model/model-impl/src/main/java/com/evolveum/midpoint/model/impl/security/PasswordCallback.java
+++ b/model/model-impl/src/main/java/com/evolveum/midpoint/model/impl/security/PasswordCallback.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/model/model-impl/src/main/java/com/evolveum/midpoint/model/impl/sync/Action.java
+++ b/model/model-impl/src/main/java/com/evolveum/midpoint/model/impl/sync/Action.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/model/model-impl/src/main/java/com/evolveum/midpoint/model/impl/sync/SynchronizationService.java
+++ b/model/model-impl/src/main/java/com/evolveum/midpoint/model/impl/sync/SynchronizationService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/model/model-impl/src/main/java/com/evolveum/midpoint/model/impl/sync/SynchronizationServiceRegisterAgent.java
+++ b/model/model-impl/src/main/java/com/evolveum/midpoint/model/impl/sync/SynchronizationServiceRegisterAgent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/model/model-impl/src/main/java/com/evolveum/midpoint/model/impl/util/DataModelUtil.java
+++ b/model/model-impl/src/main/java/com/evolveum/midpoint/model/impl/util/DataModelUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/model/model-impl/src/main/java/com/evolveum/midpoint/model/impl/util/RestServiceUtil.java
+++ b/model/model-impl/src/main/java/com/evolveum/midpoint/model/impl/util/RestServiceUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/model/model-impl/src/main/java/com/evolveum/midpoint/model/impl/util/Utils.java
+++ b/model/model-impl/src/main/java/com/evolveum/midpoint/model/impl/util/Utils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/model/model-impl/src/main/java/com/evolveum/midpoint/model/impl/validator/DuplicateObjectTypeDetector.java
+++ b/model/model-impl/src/main/java/com/evolveum/midpoint/model/impl/validator/DuplicateObjectTypeDetector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/model/model-impl/src/main/java/com/evolveum/midpoint/model/impl/validator/ObjectTypeRecord.java
+++ b/model/model-impl/src/main/java/com/evolveum/midpoint/model/impl/validator/ObjectTypeRecord.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/model/model-impl/src/main/java/com/evolveum/midpoint/model/impl/visualizer/VisualizationContext.java
+++ b/model/model-impl/src/main/java/com/evolveum/midpoint/model/impl/visualizer/VisualizationContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/model/model-impl/src/main/java/com/evolveum/midpoint/model/impl/visualizer/output/NameImpl.java
+++ b/model/model-impl/src/main/java/com/evolveum/midpoint/model/impl/visualizer/output/NameImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/model/model-impl/src/main/java/com/evolveum/midpoint/model/impl/visualizer/output/SceneDeltaItemImpl.java
+++ b/model/model-impl/src/main/java/com/evolveum/midpoint/model/impl/visualizer/output/SceneDeltaItemImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/model/model-impl/src/main/java/com/evolveum/midpoint/model/impl/visualizer/output/SceneImpl.java
+++ b/model/model-impl/src/main/java/com/evolveum/midpoint/model/impl/visualizer/output/SceneImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/model/model-impl/src/main/java/com/evolveum/midpoint/model/impl/visualizer/output/SceneItemImpl.java
+++ b/model/model-impl/src/main/java/com/evolveum/midpoint/model/impl/visualizer/output/SceneItemImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/model/model-impl/src/main/java/com/evolveum/midpoint/model/impl/visualizer/output/SceneItemValueImpl.java
+++ b/model/model-impl/src/main/java/com/evolveum/midpoint/model/impl/visualizer/output/SceneItemValueImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/model/model-impl/src/test/java/com/evolveum/midpoint/model/impl/sync/TestCorrelationConfiramtionEvaluator.java
+++ b/model/model-impl/src/test/java/com/evolveum/midpoint/model/impl/sync/TestCorrelationConfiramtionEvaluator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/model/model-impl/src/test/resources/account-custom-function.xml
+++ b/model/model-impl/src/test/resources/account-custom-function.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-impl/src/test/resources/account-origin-password-change.xml
+++ b/model/model-impl/src/test/resources/account-origin-password-change.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-impl/src/test/resources/account-resource-schema-handling-custom-variables.xml
+++ b/model/model-impl/src/test/resources/account-resource-schema-handling-custom-variables.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-impl/src/test/resources/account-target-password-change.xml
+++ b/model/model-impl/src/test/resources/account-target-password-change.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-impl/src/test/resources/account-xpath-evaluation-extension.xml
+++ b/model/model-impl/src/test/resources/account-xpath-evaluation-extension.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-impl/src/test/resources/account-xpath-evaluation-filter.xml
+++ b/model/model-impl/src/test/resources/account-xpath-evaluation-filter.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-impl/src/test/resources/account-xpath2.xml
+++ b/model/model-impl/src/test/resources/account-xpath2.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-impl/src/test/resources/common/account-elaine-dummy.xml
+++ b/model/model-impl/src/test/resources/common/account-elaine-dummy.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-impl/src/test/resources/common/account-guybrush-dummy.xml
+++ b/model/model-impl/src/test/resources/common/account-guybrush-dummy.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-impl/src/test/resources/common/account-hbarbossa-dummy.xml
+++ b/model/model-impl/src/test/resources/common/account-hbarbossa-dummy.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-impl/src/test/resources/common/account-herman-dummy.xml
+++ b/model/model-impl/src/test/resources/common/account-herman-dummy.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-impl/src/test/resources/common/account-herman-opendj.xml
+++ b/model/model-impl/src/test/resources/common/account-herman-opendj.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-impl/src/test/resources/common/account-shadow-guybrush-dummy.xml
+++ b/model/model-impl/src/test/resources/common/account-shadow-guybrush-dummy.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-impl/src/test/resources/common/account-shadow-jack-dummy.xml
+++ b/model/model-impl/src/test/resources/common/account-shadow-jack-dummy.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-impl/src/test/resources/common/entitlement-shadow-pirate-dummy.xml
+++ b/model/model-impl/src/test/resources/common/entitlement-shadow-pirate-dummy.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-impl/src/test/resources/common/resource-dummy-deprecated.xml
+++ b/model/model-impl/src/test/resources/common/resource-dummy-deprecated.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2014 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-impl/src/test/resources/common/resource-dummy.xml
+++ b/model/model-impl/src/test/resources/common/resource-dummy.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-impl/src/test/resources/common/role-superuser.xml
+++ b/model/model-impl/src/test/resources/common/role-superuser.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-impl/src/test/resources/common/system-configuration.xml
+++ b/model/model-impl/src/test/resources/common/system-configuration.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-impl/src/test/resources/common/task-reconcile-dummy.xml
+++ b/model/model-impl/src/test/resources/common/task-reconcile-dummy.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-impl/src/test/resources/common/user-administrator.xml
+++ b/model/model-impl/src/test/resources/common/user-administrator.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2014 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-impl/src/test/resources/common/user-barbossa.xml
+++ b/model/model-impl/src/test/resources/common/user-barbossa.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-impl/src/test/resources/common/user-elaine.xml
+++ b/model/model-impl/src/test/resources/common/user-elaine.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-impl/src/test/resources/common/user-guybrush.xml
+++ b/model/model-impl/src/test/resources/common/user-guybrush.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-impl/src/test/resources/common/user-jack.xml
+++ b/model/model-impl/src/test/resources/common/user-jack.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-impl/src/test/resources/common/user-largo.xml
+++ b/model/model-impl/src/test/resources/common/user-largo.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-impl/src/test/resources/common/user-template.xml
+++ b/model/model-impl/src/test/resources/common/user-template.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-impl/src/test/resources/controller/account-no-schema-handling.xml
+++ b/model/model-impl/src/test/resources/controller/account-no-schema-handling.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-impl/src/test/resources/controller/account-no-schema-handling2.xml
+++ b/model/model-impl/src/test/resources/controller/account-no-schema-handling2.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-impl/src/test/resources/controller/account-schema-handling.xml
+++ b/model/model-impl/src/test/resources/controller/account-schema-handling.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-impl/src/test/resources/controller/account-with-pwd.xml
+++ b/model/model-impl/src/test/resources/controller/account-with-pwd.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-impl/src/test/resources/controller/account-without-pwd.xml
+++ b/model/model-impl/src/test/resources/controller/account-without-pwd.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-impl/src/test/resources/controller/addObject/add-resource-correct.xml
+++ b/model/model-impl/src/test/resources/controller/addObject/add-resource-correct.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-impl/src/test/resources/controller/addObject/add-user-correct.xml
+++ b/model/model-impl/src/test/resources/controller/addObject/add-user-correct.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-impl/src/test/resources/controller/addObject/add-user-default-accounts.xml
+++ b/model/model-impl/src/test/resources/controller/addObject/add-user-default-accounts.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-impl/src/test/resources/controller/addObject/add-user-with-oid.xml
+++ b/model/model-impl/src/test/resources/controller/addObject/add-user-with-oid.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-impl/src/test/resources/controller/addObject/add-user-without-name.xml
+++ b/model/model-impl/src/test/resources/controller/addObject/add-user-without-name.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-impl/src/test/resources/controller/addObject/expected-account.xml
+++ b/model/model-impl/src/test/resources/controller/addObject/expected-account.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-impl/src/test/resources/controller/addObject/expected-add-user-default-accounts.xml
+++ b/model/model-impl/src/test/resources/controller/addObject/expected-add-user-default-accounts.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-impl/src/test/resources/controller/addObject/expected-modify-user-default-accounts.xml
+++ b/model/model-impl/src/test/resources/controller/addObject/expected-modify-user-default-accounts.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-impl/src/test/resources/controller/addUser/empty-user.xml
+++ b/model/model-impl/src/test/resources/controller/addUser/empty-user.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-impl/src/test/resources/controller/addUser/expected-account.xml
+++ b/model/model-impl/src/test/resources/controller/addUser/expected-account.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-impl/src/test/resources/controller/addUser/expected-user.xml
+++ b/model/model-impl/src/test/resources/controller/addUser/expected-user.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-impl/src/test/resources/controller/deleteObject/delete-user.xml
+++ b/model/model-impl/src/test/resources/controller/deleteObject/delete-user.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-impl/src/test/resources/controller/getObject/get-user-correct.xml
+++ b/model/model-impl/src/test/resources/controller/getObject/get-user-correct.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-impl/src/test/resources/controller/listObjects/list-account-shadow-owner.xml
+++ b/model/model-impl/src/test/resources/controller/listObjects/list-account-shadow-owner.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-impl/src/test/resources/controller/listObjects/resource-object-shadow-list.xml
+++ b/model/model-impl/src/test/resources/controller/listObjects/resource-object-shadow-list.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-impl/src/test/resources/controller/listObjects/user-list.xml
+++ b/model/model-impl/src/test/resources/controller/listObjects/user-list.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-impl/src/test/resources/controller/modify/account.xml
+++ b/model/model-impl/src/test/resources/controller/modify/account.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-impl/src/test/resources/controller/modify/change.xml
+++ b/model/model-impl/src/test/resources/controller/modify/change.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-impl/src/test/resources/controller/modify/user.xml
+++ b/model/model-impl/src/test/resources/controller/modify/user.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-impl/src/test/resources/controller/property-list-type.xml
+++ b/model/model-impl/src/test/resources/controller/property-list-type.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-impl/src/test/resources/controller/schema/expected-user-default.xml
+++ b/model/model-impl/src/test/resources/controller/schema/expected-user-default.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-impl/src/test/resources/controller/schema/expected-user.xml
+++ b/model/model-impl/src/test/resources/controller/schema/expected-user.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-impl/src/test/resources/controller/schema/template.xml
+++ b/model/model-impl/src/test/resources/controller/schema/template.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-impl/src/test/resources/controller/schema/user-with-fullname.xml
+++ b/model/model-impl/src/test/resources/controller/schema/user-with-fullname.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-impl/src/test/resources/controller/schema/user-without-fullname.xml
+++ b/model/model-impl/src/test/resources/controller/schema/user-without-fullname.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-impl/src/test/resources/ctx-model-test-main.xml
+++ b/model/model-impl/src/test/resources/ctx-model-test-main.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-impl/src/test/resources/ctx-model-test-no-repo.xml
+++ b/model/model-impl/src/test/resources/ctx-model-test-no-repo.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-impl/src/test/resources/ctx-model-unit-test.xml
+++ b/model/model-impl/src/test/resources/ctx-model-unit-test.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-impl/src/test/resources/expr/account-xpath-evaluation-without-resource.xml
+++ b/model/model-impl/src/test/resources/expr/account-xpath-evaluation-without-resource.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-impl/src/test/resources/expr/account-xpath-evaluation.xml
+++ b/model/model-impl/src/test/resources/expr/account-xpath-evaluation.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-impl/src/test/resources/expr/account.xml
+++ b/model/model-impl/src/test/resources/expr/account.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-impl/src/test/resources/expr/expression-employeeType-all-filter.xml
+++ b/model/model-impl/src/test/resources/expr/expression-employeeType-all-filter.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-impl/src/test/resources/expr/expression-employeeType-empty-filter.xml
+++ b/model/model-impl/src/test/resources/expr/expression-employeeType-empty-filter.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-impl/src/test/resources/expr/expression-employeeType-error.xml
+++ b/model/model-impl/src/test/resources/expr/expression-employeeType-error.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-impl/src/test/resources/expr/expression-employeeType-filter-defaults.xml
+++ b/model/model-impl/src/test/resources/expr/expression-employeeType-filter-defaults.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-impl/src/test/resources/expr/expression-employeeType-none-filter.xml
+++ b/model/model-impl/src/test/resources/expr/expression-employeeType-none-filter.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-impl/src/test/resources/expr/expression-employeeType-undefined-filter.xml
+++ b/model/model-impl/src/test/resources/expr/expression-employeeType-undefined-filter.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-impl/src/test/resources/expr/expression-testGetLinkedShadowKindIntentFullname.xml
+++ b/model/model-impl/src/test/resources/expr/expression-testGetLinkedShadowKindIntentFullname.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2016 Evolveum
+  ~ Copyright (c) 2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-impl/src/test/resources/expr/expression-testGetLinkedShadowKindIntentFullnameRepo.xml
+++ b/model/model-impl/src/test/resources/expr/expression-testGetLinkedShadowKindIntentFullnameRepo.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2016 Evolveum
+  ~ Copyright (c) 2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-impl/src/test/resources/expr/expression-testGetLinkedShadowKindIntentUsername.xml
+++ b/model/model-impl/src/test/resources/expr/expression-testGetLinkedShadowKindIntentUsername.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2016 Evolveum
+  ~ Copyright (c) 2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-impl/src/test/resources/expr/expression-testGetLinkedShadowKindIntentUsernameRepo.xml
+++ b/model/model-impl/src/test/resources/expr/expression-testGetLinkedShadowKindIntentUsernameRepo.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2016 Evolveum
+  ~ Copyright (c) 2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-impl/src/test/resources/expr/expression-testGetLinkedShadowName.xml
+++ b/model/model-impl/src/test/resources/expr/expression-testGetLinkedShadowName.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2016 Evolveum
+  ~ Copyright (c) 2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-impl/src/test/resources/expr/expression-testGetLinkedShadowNameRepo.xml
+++ b/model/model-impl/src/test/resources/expr/expression-testGetLinkedShadowNameRepo.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2016 Evolveum
+  ~ Copyright (c) 2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-impl/src/test/resources/expr/expression-testGetManagersOids.xml
+++ b/model/model-impl/src/test/resources/expr/expression-testGetManagersOids.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-impl/src/test/resources/expr/expression-testGetOrgByName.xml
+++ b/model/model-impl/src/test/resources/expr/expression-testGetOrgByName.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-impl/src/test/resources/expr/expression-testGetUserByOid.xml
+++ b/model/model-impl/src/test/resources/expr/expression-testGetUserByOid.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-impl/src/test/resources/expr/expression-testHello.xml
+++ b/model/model-impl/src/test/resources/expr/expression-testHello.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-impl/src/test/resources/expr/expression-testIsUniquePropertyValue.xml
+++ b/model/model-impl/src/test/resources/expr/expression-testIsUniquePropertyValue.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-impl/src/test/resources/expr/orgstruct.xml
+++ b/model/model-impl/src/test/resources/expr/orgstruct.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-impl/src/test/resources/expr/user-new.xml
+++ b/model/model-impl/src/test/resources/expr/user-new.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-impl/src/test/resources/lens/account-before-script.xml
+++ b/model/model-impl/src/test/resources/lens/account-before-script.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-impl/src/test/resources/lens/assignment-direct-expression.xml
+++ b/model/model-impl/src/test/resources/lens/assignment-direct-expression.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2014 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-impl/src/test/resources/lens/assignment-direct.xml
+++ b/model/model-impl/src/test/resources/lens/assignment-direct.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-impl/src/test/resources/lens/assignment-role-engineer.xml
+++ b/model/model-impl/src/test/resources/lens/assignment-role-engineer.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-impl/src/test/resources/lens/assignment-role-manager.xml
+++ b/model/model-impl/src/test/resources/lens/assignment-role-manager.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-impl/src/test/resources/lens/assignment-role-visitor.xml
+++ b/model/model-impl/src/test/resources/lens/assignment-role-visitor.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-impl/src/test/resources/lens/dependencies/account-elaine-template.xml
+++ b/model/model-impl/src/test/resources/lens/dependencies/account-elaine-template.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-impl/src/test/resources/lens/dependencies/resource-dummy-a.xml
+++ b/model/model-impl/src/test/resources/lens/dependencies/resource-dummy-a.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-impl/src/test/resources/lens/dependencies/resource-dummy-p.xml
+++ b/model/model-impl/src/test/resources/lens/dependencies/resource-dummy-p.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-impl/src/test/resources/lens/password-policy-history.xml
+++ b/model/model-impl/src/test/resources/lens/password-policy-history.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-impl/src/test/resources/lens/password-policy-no-history.xml
+++ b/model/model-impl/src/test/resources/lens/password-policy-no-history.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-impl/src/test/resources/lens/ppolicy/password-policy-complex.xml
+++ b/model/model-impl/src/test/resources/lens/ppolicy/password-policy-complex.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-impl/src/test/resources/lens/ppolicy/password-policy-long.xml
+++ b/model/model-impl/src/test/resources/lens/ppolicy/password-policy-long.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-impl/src/test/resources/lens/ppolicy/password-policy-minimal.xml
+++ b/model/model-impl/src/test/resources/lens/ppolicy/password-policy-minimal.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-impl/src/test/resources/lens/ppolicy/password-policy-numeric.xml
+++ b/model/model-impl/src/test/resources/lens/ppolicy/password-policy-numeric.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-impl/src/test/resources/lens/ppolicy/value-policy-generate-empty.xml
+++ b/model/model-impl/src/test/resources/lens/ppolicy/value-policy-generate-empty.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-impl/src/test/resources/lens/ppolicy/value-policy-generate.xml
+++ b/model/model-impl/src/test/resources/lens/ppolicy/value-policy-generate.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-impl/src/test/resources/lens/ppolicy/value-policy-must-be-first.xml
+++ b/model/model-impl/src/test/resources/lens/ppolicy/value-policy-must-be-first.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 	<!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-impl/src/test/resources/lens/ppolicy/value-policy-random-pin.xml
+++ b/model/model-impl/src/test/resources/lens/ppolicy/value-policy-random-pin.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-impl/src/test/resources/lens/resource-dummy-empty.xml
+++ b/model/model-impl/src/test/resources/lens/resource-dummy-empty.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-impl/src/test/resources/lens/role-corp-auth.xml
+++ b/model/model-impl/src/test/resources/lens/role-corp-auth.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-impl/src/test/resources/lens/role-corp-contractor.xml
+++ b/model/model-impl/src/test/resources/lens/role-corp-contractor.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-impl/src/test/resources/lens/role-corp-customer.xml
+++ b/model/model-impl/src/test/resources/lens/role-corp-customer.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-impl/src/test/resources/lens/role-corp-employee.xml
+++ b/model/model-impl/src/test/resources/lens/role-corp-employee.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-impl/src/test/resources/lens/role-corp-engineer.xml
+++ b/model/model-impl/src/test/resources/lens/role-corp-engineer.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-impl/src/test/resources/lens/role-corp-generic-metarole-dynamic.xml
+++ b/model/model-impl/src/test/resources/lens/role-corp-generic-metarole-dynamic.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-impl/src/test/resources/lens/role-corp-generic-metarole.xml
+++ b/model/model-impl/src/test/resources/lens/role-corp-generic-metarole.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-impl/src/test/resources/lens/role-corp-job-metarole-dynamic.xml
+++ b/model/model-impl/src/test/resources/lens/role-corp-job-metarole-dynamic.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-impl/src/test/resources/lens/role-corp-job-metarole.xml
+++ b/model/model-impl/src/test/resources/lens/role-corp-job-metarole.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-impl/src/test/resources/lens/role-corp-manager.xml
+++ b/model/model-impl/src/test/resources/lens/role-corp-manager.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-impl/src/test/resources/lens/role-corp-visitor.xml
+++ b/model/model-impl/src/test/resources/lens/role-corp-visitor.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-impl/src/test/resources/lens/role-mutinier.xml
+++ b/model/model-impl/src/test/resources/lens/role-mutinier.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2014 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-impl/src/test/resources/lens/role-pirate.xml
+++ b/model/model-impl/src/test/resources/lens/role-pirate.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-impl/src/test/resources/lens/user-barbossa-modify-add-assignment-account-dummy-attr.xml
+++ b/model/model-impl/src/test/resources/lens/user-barbossa-modify-add-assignment-account-dummy-attr.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2014 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-impl/src/test/resources/lens/user-barbossa-modify-assignment-replace-ac.xml
+++ b/model/model-impl/src/test/resources/lens/user-barbossa-modify-assignment-replace-ac.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2014 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-impl/src/test/resources/lens/user-barbossa-modify-delete-assignment-account-dummy-attr.xml
+++ b/model/model-impl/src/test/resources/lens/user-barbossa-modify-delete-assignment-account-dummy-attr.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2014 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-impl/src/test/resources/lens/user-drake.xml
+++ b/model/model-impl/src/test/resources/lens/user-drake.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-impl/src/test/resources/lens/user-jack-modify-add-assignment-account-dummy-attr.xml
+++ b/model/model-impl/src/test/resources/lens/user-jack-modify-add-assignment-account-dummy-attr.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-impl/src/test/resources/lens/user-jack-modify-add-assignment-account-dummy.xml
+++ b/model/model-impl/src/test/resources/lens/user-jack-modify-add-assignment-account-dummy.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-impl/src/test/resources/lens/user-jack-modify-add-assignment-role-engineer.xml
+++ b/model/model-impl/src/test/resources/lens/user-jack-modify-add-assignment-role-engineer.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-impl/src/test/resources/lens/user-jack-modify-delete-assignment-account-dummy.xml
+++ b/model/model-impl/src/test/resources/lens/user-jack-modify-delete-assignment-account-dummy.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-impl/src/test/resources/lens/user-jack-modify-set-cost-center.xml
+++ b/model/model-impl/src/test/resources/lens/user-jack-modify-set-cost-center.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-impl/src/test/resources/logback-test.xml
+++ b/model/model-impl/src/test/resources/logback-test.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-impl/src/test/resources/migrator/after/object-template.xml
+++ b/model/model-impl/src/test/resources/migrator/after/object-template.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-impl/src/test/resources/migrator/after/resource.xml
+++ b/model/model-impl/src/test/resources/migrator/after/resource.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-impl/src/test/resources/migrator/before/object-template.xml
+++ b/model/model-impl/src/test/resources/migrator/before/object-template.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-impl/src/test/resources/migrator/before/resource.xml
+++ b/model/model-impl/src/test/resources/migrator/before/resource.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-impl/src/test/resources/migrator/user-migrate-credentials.xml
+++ b/model/model-impl/src/test/resources/migrator/user-migrate-credentials.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-impl/src/test/resources/refinedschema/task-reconcile-dummy-kind-intent-objectclass.xml
+++ b/model/model-impl/src/test/resources/refinedschema/task-reconcile-dummy-kind-intent-objectclass.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2016 Evolveum
+  ~ Copyright (c) 2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-impl/src/test/resources/refinedschema/task-reconcile-dummy-kind-intent.xml
+++ b/model/model-impl/src/test/resources/refinedschema/task-reconcile-dummy-kind-intent.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2016 Evolveum
+  ~ Copyright (c) 2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-impl/src/test/resources/refinedschema/task-reconcile-dummy-objectclass.xml
+++ b/model/model-impl/src/test/resources/refinedschema/task-reconcile-dummy-objectclass.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2016 Evolveum
+  ~ Copyright (c) 2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-impl/src/test/resources/service/model/modify/modify-user-correct.xml
+++ b/model/model-impl/src/test/resources/service/model/modify/modify-user-correct.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-impl/src/test/resources/sync/action/account/group-change.xml
+++ b/model/model-impl/src/test/resources/sync/action/account/group-change.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-impl/src/test/resources/sync/action/account/user.xml
+++ b/model/model-impl/src/test/resources/sync/action/account/user.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-impl/src/test/resources/sync/action/user/existing-user-change.xml
+++ b/model/model-impl/src/test/resources/sync/action/user/existing-user-change.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-impl/src/test/resources/sync/action/user/existing-user.xml
+++ b/model/model-impl/src/test/resources/sync/action/user/existing-user.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-impl/src/test/resources/sync/action/user/new-user.xml
+++ b/model/model-impl/src/test/resources/sync/action/user/new-user.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-impl/src/test/resources/sync/action/user/user-template.xml
+++ b/model/model-impl/src/test/resources/sync/action/user/user-template.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-impl/src/test/resources/sync/change-correct.xml
+++ b/model/model-impl/src/test/resources/sync/change-correct.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-impl/src/test/resources/sync/change-without-object.xml
+++ b/model/model-impl/src/test/resources/sync/change-without-object.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-impl/src/test/resources/sync/change-without-resource.xml
+++ b/model/model-impl/src/test/resources/sync/change-without-resource.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-impl/src/test/resources/sync/correlation-case-insensitive.xml
+++ b/model/model-impl/src/test/resources/sync/correlation-case-insensitive.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-impl/src/test/resources/sync/correlation-case-insensitive_empl_number.xml
+++ b/model/model-impl/src/test/resources/sync/correlation-case-insensitive_empl_number.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-impl/src/test/resources/sync/correlation-first-filter.xml
+++ b/model/model-impl/src/test/resources/sync/correlation-first-filter.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-impl/src/test/resources/sync/correlation-or-filter.xml
+++ b/model/model-impl/src/test/resources/sync/correlation-or-filter.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-impl/src/test/resources/sync/correlation-second-filter.xml
+++ b/model/model-impl/src/test/resources/sync/correlation-second-filter.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-impl/src/test/resources/sync/correlation-with-condition-emplNumber.xml
+++ b/model/model-impl/src/test/resources/sync/correlation-with-condition-emplNumber.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-impl/src/test/resources/sync/correlation-with-condition.xml
+++ b/model/model-impl/src/test/resources/sync/correlation-with-condition.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-impl/src/test/resources/sync/shadow-pirates-dummy.xml
+++ b/model/model-impl/src/test/resources/sync/shadow-pirates-dummy.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-impl/src/test/resources/user-custom-function.xml
+++ b/model/model-impl/src/test/resources/user-custom-function.xml
@@ -1,6 +1,6 @@
 
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-impl/src/test/resources/user-default-accounts.xml
+++ b/model/model-impl/src/test/resources/user-default-accounts.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-impl/src/test/resources/user-modify-action.xml
+++ b/model/model-impl/src/test/resources/user-modify-action.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-impl/src/test/resources/user-password-change.xml
+++ b/model/model-impl/src/test/resources/user-password-change.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-impl/src/test/resources/user-template-create-account.xml
+++ b/model/model-impl/src/test/resources/user-template-create-account.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-impl/src/test/resources/user-unlink-account-action.xml
+++ b/model/model-impl/src/test/resources/user-unlink-account-action.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-impl/src/test/resources/user-xpath2.xml
+++ b/model/model-impl/src/test/resources/user-xpath2.xml
@@ -1,6 +1,6 @@
 
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-impl/src/test/resources/user.xml
+++ b/model/model-impl/src/test/resources/user.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/pom.xml
+++ b/model/model-intest/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/java/com/evolveum/midpoint/model/intest/TestConsistencySimple.java
+++ b/model/model-intest/src/test/java/com/evolveum/midpoint/model/intest/TestConsistencySimple.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/java/com/evolveum/midpoint/model/intest/TestIteration.java
+++ b/model/model-intest/src/test/java/com/evolveum/midpoint/model/intest/TestIteration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/java/com/evolveum/midpoint/model/intest/TestModelCrudService.java
+++ b/model/model-intest/src/test/java/com/evolveum/midpoint/model/intest/TestModelCrudService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/java/com/evolveum/midpoint/model/intest/TestModelVisualization.java
+++ b/model/model-intest/src/test/java/com/evolveum/midpoint/model/intest/TestModelVisualization.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/java/com/evolveum/midpoint/model/intest/TestUserTemplateWithRanges.java
+++ b/model/model-intest/src/test/java/com/evolveum/midpoint/model/intest/TestUserTemplateWithRanges.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/java/com/evolveum/midpoint/model/intest/rbac/TestRbacDeprecated.java
+++ b/model/model-intest/src/test/java/com/evolveum/midpoint/model/intest/rbac/TestRbacDeprecated.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/java/com/evolveum/midpoint/model/intest/sync/AbstractInboundSyncTest.java
+++ b/model/model-intest/src/test/java/com/evolveum/midpoint/model/intest/sync/AbstractInboundSyncTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/java/com/evolveum/midpoint/model/intest/sync/TestLiveSyncTask.java
+++ b/model/model-intest/src/test/java/com/evolveum/midpoint/model/intest/sync/TestLiveSyncTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/activation/resource-dummy-coral.xml
+++ b/model/model-intest/src/test/resources/activation/resource-dummy-coral.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/activation/resource-dummy-khaki.xml
+++ b/model/model-intest/src/test/resources/activation/resource-dummy-khaki.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2014 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/caseignore/role-fool.xml
+++ b/model/model-intest/src/test/resources/caseignore/role-fool.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 Evolveum
+  ~ Copyright (c) 2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/common/account-elaine-dummy-blue.xml
+++ b/model/model-intest/src/test/resources/common/account-elaine-dummy-blue.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/common/account-elaine-dummy-red.xml
+++ b/model/model-intest/src/test/resources/common/account-elaine-dummy-red.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/common/account-elaine-dummy.xml
+++ b/model/model-intest/src/test/resources/common/account-elaine-dummy.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/common/account-guybrush-dummy-red.xml
+++ b/model/model-intest/src/test/resources/common/account-guybrush-dummy-red.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/common/account-guybrush-dummy.xml
+++ b/model/model-intest/src/test/resources/common/account-guybrush-dummy.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/common/account-herman-dummy.xml
+++ b/model/model-intest/src/test/resources/common/account-herman-dummy.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/common/account-herman-opendj.xml
+++ b/model/model-intest/src/test/resources/common/account-herman-opendj.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/common/account-jack-dummy-black.xml
+++ b/model/model-intest/src/test/resources/common/account-jack-dummy-black.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/common/account-jack-dummy-red.xml
+++ b/model/model-intest/src/test/resources/common/account-jack-dummy-red.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2014 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/common/account-jack-dummy.xml
+++ b/model/model-intest/src/test/resources/common/account-jack-dummy.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/common/account-shadow-guybrush-dummy.xml
+++ b/model/model-intest/src/test/resources/common/account-shadow-guybrush-dummy.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/common/account-shadow-jack-dummy.xml
+++ b/model/model-intest/src/test/resources/common/account-shadow-jack-dummy.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/common/connector-dbtable.xml
+++ b/model/model-intest/src/test/resources/common/connector-dbtable.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/common/connector-dummy.xml
+++ b/model/model-intest/src/test/resources/common/connector-dummy.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/common/connector-ldap.xml
+++ b/model/model-intest/src/test/resources/common/connector-ldap.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/common/generic-object-my-config.xml
+++ b/model/model-intest/src/test/resources/common/generic-object-my-config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>   
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/common/org-monkey-island.xml
+++ b/model/model-intest/src/test/resources/common/org-monkey-island.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/common/resource-derby.xml
+++ b/model/model-intest/src/test/resources/common/resource-derby.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/common/resource-dummy-caching.xml
+++ b/model/model-intest/src/test/resources/common/resource-dummy-caching.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/common/resource-dummy-cyan.xml
+++ b/model/model-intest/src/test/resources/common/resource-dummy-cyan.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/common/resource-dummy-deprecated.xml
+++ b/model/model-intest/src/test/resources/common/resource-dummy-deprecated.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/common/resource-dummy-emerald-deprecated.xml
+++ b/model/model-intest/src/test/resources/common/resource-dummy-emerald-deprecated.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/common/resource-dummy-emerald.xml
+++ b/model/model-intest/src/test/resources/common/resource-dummy-emerald.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/common/resource-dummy-fake.xml
+++ b/model/model-intest/src/test/resources/common/resource-dummy-fake.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/common/resource-dummy-schemaless-no-schema.xml
+++ b/model/model-intest/src/test/resources/common/resource-dummy-schemaless-no-schema.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/common/resource-dummy-upcase.xml
+++ b/model/model-intest/src/test/resources/common/resource-dummy-upcase.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/common/resource-dummy-white.xml
+++ b/model/model-intest/src/test/resources/common/resource-dummy-white.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/common/resource-dummy.xml
+++ b/model/model-intest/src/test/resources/common/resource-dummy.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/common/resource-opendj.xml
+++ b/model/model-intest/src/test/resources/common/resource-opendj.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2014 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/common/role-buccaneer-green.xml
+++ b/model/model-intest/src/test/resources/common/role-buccaneer-green.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/common/role-captain.xml
+++ b/model/model-intest/src/test/resources/common/role-captain.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/common/role-judge-deprecated.xml
+++ b/model/model-intest/src/test/resources/common/role-judge-deprecated.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/common/role-nice-pirate.xml
+++ b/model/model-intest/src/test/resources/common/role-nice-pirate.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/common/role-pirate-green.xml
+++ b/model/model-intest/src/test/resources/common/role-pirate-green.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/common/role-pirate.xml
+++ b/model/model-intest/src/test/resources/common/role-pirate.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/common/role-superuser.xml
+++ b/model/model-intest/src/test/resources/common/role-superuser.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/common/service-ship-sea-monkey.xml
+++ b/model/model-intest/src/test/resources/common/service-ship-sea-monkey.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2016 Evolveum
+  ~ Copyright (c) 2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/common/system-configuration-with-template.xml
+++ b/model/model-intest/src/test/resources/common/system-configuration-with-template.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/common/task-dumy-blue-livesync.xml
+++ b/model/model-intest/src/test/resources/common/task-dumy-blue-livesync.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/common/task-dumy-green-livesync.xml
+++ b/model/model-intest/src/test/resources/common/task-dumy-green-livesync.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/common/task-dumy-livesync.xml
+++ b/model/model-intest/src/test/resources/common/task-dumy-livesync.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/common/task-mock-jack.xml
+++ b/model/model-intest/src/test/resources/common/task-mock-jack.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/common/task-reconcile-dummy-blue.xml
+++ b/model/model-intest/src/test/resources/common/task-reconcile-dummy-blue.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/common/task-reconcile-dummy-green.xml
+++ b/model/model-intest/src/test/resources/common/task-reconcile-dummy-green.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/common/task-reconcile-dummy.xml
+++ b/model/model-intest/src/test/resources/common/task-reconcile-dummy.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/common/task-trigger-scanner.xml
+++ b/model/model-intest/src/test/resources/common/task-trigger-scanner.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/common/task-validity-scanner.xml
+++ b/model/model-intest/src/test/resources/common/task-validity-scanner.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/common/user-administrator.xml
+++ b/model/model-intest/src/test/resources/common/user-administrator.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/common/user-barbossa.xml
+++ b/model/model-intest/src/test/resources/common/user-barbossa.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2014 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/common/user-capsize.xml
+++ b/model/model-intest/src/test/resources/common/user-capsize.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/common/user-drake.xml
+++ b/model/model-intest/src/test/resources/common/user-drake.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/common/user-elaine.xml
+++ b/model/model-intest/src/test/resources/common/user-elaine.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/common/user-guybrush.xml
+++ b/model/model-intest/src/test/resources/common/user-guybrush.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/common/user-herman.xml
+++ b/model/model-intest/src/test/resources/common/user-herman.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/common/user-jack.xml
+++ b/model/model-intest/src/test/resources/common/user-jack.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2014 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/common/user-largo.xml
+++ b/model/model-intest/src/test/resources/common/user-largo.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/common/user-rapp.xml
+++ b/model/model-intest/src/test/resources/common/user-rapp.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/common/user-template-complex-include.xml
+++ b/model/model-intest/src/test/resources/common/user-template-complex-include.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/common/user-template-complex.xml
+++ b/model/model-intest/src/test/resources/common/user-template-complex.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/common/user-template-inbounds.xml
+++ b/model/model-intest/src/test/resources/common/user-template-inbounds.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/common/user-template-org-assignment.xml
+++ b/model/model-intest/src/test/resources/common/user-template-org-assignment.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/common/user-template-sync.xml
+++ b/model/model-intest/src/test/resources/common/user-template-sync.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/common/user-template.xml
+++ b/model/model-intest/src/test/resources/common/user-template.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/common/user-three-headed-monkey.xml
+++ b/model/model-intest/src/test/resources/common/user-three-headed-monkey.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/contract/user-blackbeard-account-dummy.xml
+++ b/model/model-intest/src/test/resources/contract/user-blackbeard-account-dummy.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/contract/user-morgan-assignment-dummy.xml
+++ b/model/model-intest/src/test/resources/contract/user-morgan-assignment-dummy.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/crud/resource-dummy-maroon.xml
+++ b/model/model-intest/src/test/resources/crud/resource-dummy-maroon.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/ctx-model-intest-test-main.xml
+++ b/model/model-intest/src/test/resources/ctx-model-intest-test-main.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/entitlements/role-brute.xml
+++ b/model/model-intest/src/test/resources/entitlements/role-brute.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 Evolveum
+  ~ Copyright (c) 2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/entitlements/role-swashbuckler.xml
+++ b/model/model-intest/src/test/resources/entitlements/role-swashbuckler.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2014 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/entitlements/role-thug.xml
+++ b/model/model-intest/src/test/resources/entitlements/role-thug.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 Evolveum
+  ~ Copyright (c) 2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/gensync/lookup-languages-replacement.xml
+++ b/model/model-intest/src/test/resources/gensync/lookup-languages-replacement.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/gensync/role-meta-dummygroup.xml
+++ b/model/model-intest/src/test/resources/gensync/role-meta-dummygroup.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/gensync/role-swashbuckler.xml
+++ b/model/model-intest/src/test/resources/gensync/role-swashbuckler.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/gensync/system-configuration.xml
+++ b/model/model-intest/src/test/resources/gensync/system-configuration.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/importer/import-bad.xml
+++ b/model/model-intest/src/test/resources/importer/import-bad.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/importer/import-ref.xml
+++ b/model/model-intest/src/test/resources/importer/import-ref.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/importer/import-task.xml
+++ b/model/model-intest/src/test/resources/importer/import-task.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/importer/import-users-overwrite.xml
+++ b/model/model-intest/src/test/resources/importer/import-users-overwrite.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/importer/import-users.xml
+++ b/model/model-intest/src/test/resources/importer/import-users.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/importer/resource-derby.xml
+++ b/model/model-intest/src/test/resources/importer/resource-derby.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/importer/resource-dummy-changed.xml
+++ b/model/model-intest/src/test/resources/importer/resource-dummy-changed.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/importer/resource-dummy-runtime-resolution.xml
+++ b/model/model-intest/src/test/resources/importer/resource-dummy-runtime-resolution.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/iteration/resource-dummy-fuchsia.xml
+++ b/model/model-intest/src/test/resources/iteration/resource-dummy-fuchsia.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/iteration/resource-dummy-magenta.xml
+++ b/model/model-intest/src/test/resources/iteration/resource-dummy-magenta.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/iteration/resource-dummy-pink.xml
+++ b/model/model-intest/src/test/resources/iteration/resource-dummy-pink.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/iteration/resource-dummy-violet.xml
+++ b/model/model-intest/src/test/resources/iteration/resource-dummy-violet.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2014 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/iteration/task-dumy-dark-violet-livesync.xml
+++ b/model/model-intest/src/test/resources/iteration/task-dumy-dark-violet-livesync.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/iteration/user-alfred.xml
+++ b/model/model-intest/src/test/resources/iteration/user-alfred.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  ~ Copyright (c) 2010-2014 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/iteration/user-jupiter.xml
+++ b/model/model-intest/src/test/resources/iteration/user-jupiter.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2014 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/mapping-inbound/resource-dummy-tea-green.xml
+++ b/model/model-intest/src/test/resources/mapping-inbound/resource-dummy-tea-green.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/mapping-inbound/task-dumy-tea-green-livesync.xml
+++ b/model/model-intest/src/test/resources/mapping-inbound/task-dumy-tea-green-livesync.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/multi/resource-dummy-beige.xml
+++ b/model/model-intest/src/test/resources/multi/resource-dummy-beige.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/multi/resource-dummy-david.xml
+++ b/model/model-intest/src/test/resources/multi/resource-dummy-david.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/multi/resource-dummy-goliath.xml
+++ b/model/model-intest/src/test/resources/multi/resource-dummy-goliath.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/multi/resource-dummy-ivory.xml
+++ b/model/model-intest/src/test/resources/multi/resource-dummy-ivory.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/multi/resource-dummy-lavender.xml
+++ b/model/model-intest/src/test/resources/multi/resource-dummy-lavender.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/multi/resource-dummy-peru.xml
+++ b/model/model-intest/src/test/resources/multi/resource-dummy-peru.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/multi/role-dummies-beige.xml
+++ b/model/model-intest/src/test/resources/multi/role-dummies-beige.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/multi/role-dummies-ivory.xml
+++ b/model/model-intest/src/test/resources/multi/role-dummies-ivory.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/multi/role-dummies.xml
+++ b/model/model-intest/src/test/resources/multi/role-dummies.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/negative/connector-dummy-nojars.xml
+++ b/model/model-intest/src/test/resources/negative/connector-dummy-nojars.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/negative/resource-dummy-nojars.xml
+++ b/model/model-intest/src/test/resources/negative/resource-dummy-nojars.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/negative/resource-dummy-unaccessible.xml
+++ b/model/model-intest/src/test/resources/negative/resource-dummy-unaccessible.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2014 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/notifications/system-configuration.xml
+++ b/model/model-intest/src/test/resources/notifications/system-configuration.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/object-template-ranges/org-monkey-island-local.xml
+++ b/model/model-intest/src/test/resources/object-template-ranges/org-monkey-island-local.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/object-template/role-rastaman.xml
+++ b/model/model-intest/src/test/resources/object-template/role-rastaman.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 Evolveum
+  ~ Copyright (c) 2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/object-template/user-template-marooned.xml
+++ b/model/model-intest/src/test/resources/object-template/user-template-marooned.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2016 Evolveum
+  ~ Copyright (c) 2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/orgstruct/org-caribbean.xml
+++ b/model/model-intest/src/test/resources/orgstruct/org-caribbean.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2016 Evolveum
+  ~ Copyright (c) 2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/orgstruct/org-fictional.xml
+++ b/model/model-intest/src/test/resources/orgstruct/org-fictional.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/orgstruct/org-temp.xml
+++ b/model/model-intest/src/test/resources/orgstruct/org-temp.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/orgstruct/role-meta-piracy-org.xml
+++ b/model/model-intest/src/test/resources/orgstruct/role-meta-piracy-org.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 Evolveum
+  ~ Copyright (c) 2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/orgstruct/user-gibbs.xml
+++ b/model/model-intest/src/test/resources/orgstruct/user-gibbs.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2016 Evolveum
+  ~ Copyright (c) 2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/orgstruct/user-pintel.xml
+++ b/model/model-intest/src/test/resources/orgstruct/user-pintel.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2016 Evolveum
+  ~ Copyright (c) 2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/preview/user-rogers.xml
+++ b/model/model-intest/src/test/resources/preview/user-rogers.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/rbac/role-adriatic-pirate.xml
+++ b/model/model-intest/src/test/resources/rbac/role-adriatic-pirate.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/rbac/role-black-sea-pirate.xml
+++ b/model/model-intest/src/test/resources/rbac/role-black-sea-pirate.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/rbac/role-bloody-fool.xml
+++ b/model/model-intest/src/test/resources/rbac/role-bloody-fool.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 Evolveum
+  ~ Copyright (c) 2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/rbac/role-cannibal.xml
+++ b/model/model-intest/src/test/resources/rbac/role-cannibal.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 Evolveum
+  ~ Copyright (c) 2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/rbac/role-cleric.xml
+++ b/model/model-intest/src/test/resources/rbac/role-cleric.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2014 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/rbac/role-honorable-wannabe.xml
+++ b/model/model-intest/src/test/resources/rbac/role-honorable-wannabe.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2014 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/rbac/role-indian-ocean-pirate.xml
+++ b/model/model-intest/src/test/resources/rbac/role-indian-ocean-pirate.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/rbac/role-meta-fool.xml
+++ b/model/model-intest/src/test/resources/rbac/role-meta-fool.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 Evolveum
+  ~ Copyright (c) 2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/rbac/role-non-assignable.xml
+++ b/model/model-intest/src/test/resources/rbac/role-non-assignable.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 Evolveum
+  ~ Copyright (c) 2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/rbac/role-non-createable.xml
+++ b/model/model-intest/src/test/resources/rbac/role-non-createable.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 Evolveum
+  ~ Copyright (c) 2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/rbac/role-project-omnimanager.xml
+++ b/model/model-intest/src/test/resources/rbac/role-project-omnimanager.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 Evolveum
+  ~ Copyright (c) 2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/rbac/role-screaming.xml
+++ b/model/model-intest/src/test/resources/rbac/role-screaming.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 Evolveum
+  ~ Copyright (c) 2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/rbac/role-wannabe.xml
+++ b/model/model-intest/src/test/resources/rbac/role-wannabe.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2014 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/rbac/role-weak-gossiper.xml
+++ b/model/model-intest/src/test/resources/rbac/role-weak-gossiper.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 Evolveum
+  ~ Copyright (c) 2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/schema/managers.xsd
+++ b/model/model-intest/src/test/resources/schema/managers.xsd
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/scripting/assign-to-jack-2.xml
+++ b/model/model-intest/src/test/resources/scripting/assign-to-jack-2.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <!--
-  ~ Copyright (c) 2010-2014 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/scripting/assign-to-jack.xml
+++ b/model/model-intest/src/test/resources/scripting/assign-to-jack.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <!--
-  ~ Copyright (c) 2010-2014 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/scripting/delete-and-add-jack.xml
+++ b/model/model-intest/src/test/resources/scripting/delete-and-add-jack.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <!--
-  ~ Copyright (c) 2010-2014 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/scripting/disable-jack.xml
+++ b/model/model-intest/src/test/resources/scripting/disable-jack.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <!--
-  ~ Copyright (c) 2010-2014 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/scripting/enable-jack.xml
+++ b/model/model-intest/src/test/resources/scripting/enable-jack.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <!--
-  ~ Copyright (c) 2010-2014 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/scripting/log.xml
+++ b/model/model-intest/src/test/resources/scripting/log.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <!--
-  ~ Copyright (c) 2010-2014 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/scripting/modify-jack-back.xml
+++ b/model/model-intest/src/test/resources/scripting/modify-jack-back.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <!--
-  ~ Copyright (c) 2010-2014 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/scripting/modify-jack.xml
+++ b/model/model-intest/src/test/resources/scripting/modify-jack.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <!--
-  ~ Copyright (c) 2010-2014 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/scripting/notification-about-jack-type2.xml
+++ b/model/model-intest/src/test/resources/scripting/notification-about-jack-type2.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/scripting/notification-about-jack.xml
+++ b/model/model-intest/src/test/resources/scripting/notification-about-jack.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/scripting/purge-dummy-black-schema.xml
+++ b/model/model-intest/src/test/resources/scripting/purge-dummy-black-schema.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <!--
-  ~ Copyright (c) 2010-2014 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/scripting/recompute-jack.xml
+++ b/model/model-intest/src/test/resources/scripting/recompute-jack.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <!--
-  ~ Copyright (c) 2010-2014 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/scripting/scripting-users.xml
+++ b/model/model-intest/src/test/resources/scripting/scripting-users.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/scripting/search-for-resources.xml
+++ b/model/model-intest/src/test/resources/scripting/search-for-resources.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <!--
-  ~ Copyright (c) 2010-2014 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/scripting/search-for-roles.xml
+++ b/model/model-intest/src/test/resources/scripting/search-for-roles.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <!--
-  ~ Copyright (c) 2010-2014 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/scripting/search-for-shadows-nofetch.xml
+++ b/model/model-intest/src/test/resources/scripting/search-for-shadows-nofetch.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <!--
-  ~ Copyright (c) 2010-2014 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/scripting/search-for-shadows.xml
+++ b/model/model-intest/src/test/resources/scripting/search-for-shadows.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <!--
-  ~ Copyright (c) 2010-2014 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/scripting/search-for-users-accounts-nofetch.xml
+++ b/model/model-intest/src/test/resources/scripting/search-for-users-accounts-nofetch.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 
 <!--
-  ~ Copyright (c) 2010-2014 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/scripting/search-for-users-accounts.xml
+++ b/model/model-intest/src/test/resources/scripting/search-for-users-accounts.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <!--
-  ~ Copyright (c) 2010-2014 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/scripting/search-for-users.xml
+++ b/model/model-intest/src/test/resources/scripting/search-for-users.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <!--
-  ~ Copyright (c) 2010-2014 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/scripting/test-dummy-resource.xml
+++ b/model/model-intest/src/test/resources/scripting/test-dummy-resource.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <!--
-  ~ Copyright (c) 2010-2014 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/security/campaigns.xml
+++ b/model/model-intest/src/test/resources/security/campaigns.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/security/role-auditor.xml
+++ b/model/model-intest/src/test/resources/security/role-auditor.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2016 Evolveum
+  ~ Copyright (c) 2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/security/role-conditional.xml
+++ b/model/model-intest/src/test/resources/security/role-conditional.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/security/role-end-user.xml
+++ b/model/model-intest/src/test/resources/security/role-end-user.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/security/role-manager-full-control.xml
+++ b/model/model-intest/src/test/resources/security/role-manager-full-control.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 Evolveum
+  ~ Copyright (c) 2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/security/role-modify-user.xml
+++ b/model/model-intest/src/test/resources/security/role-modify-user.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2014 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/security/role-role-owner-assign.xml
+++ b/model/model-intest/src/test/resources/security/role-role-owner-assign.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 Evolveum
+  ~ Copyright (c) 2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/security/role-role-owner-full-control.xml
+++ b/model/model-intest/src/test/resources/security/role-role-owner-full-control.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 Evolveum
+  ~ Copyright (c) 2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/security/user-angelica.xml
+++ b/model/model-intest/src/test/resources/security/user-angelica.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/strange/resource-dummy-circus.xml
+++ b/model/model-intest/src/test/resources/strange/resource-dummy-circus.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2016 Evolveum
+  ~ Copyright (c) 2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/strange/role-bad-construction-resource-ref.xml
+++ b/model/model-intest/src/test/resources/strange/role-bad-construction-resource-ref.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 Evolveum
+  ~ Copyright (c) 2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/strange/role-meta-bad-construction-resource-ref.xml
+++ b/model/model-intest/src/test/resources/strange/role-meta-bad-construction-resource-ref.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 Evolveum
+  ~ Copyright (c) 2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/strange/role-target-bad-construction-resource-ref.xml
+++ b/model/model-intest/src/test/resources/strange/role-target-bad-construction-resource-ref.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 Evolveum
+  ~ Copyright (c) 2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/strange/user-deghoulash.xml
+++ b/model/model-intest/src/test/resources/strange/user-deghoulash.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/sync/account-andre-dummy.xml
+++ b/model/model-intest/src/test/resources/sync/account-andre-dummy.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2014 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/sync/account-augustus-dummy.xml
+++ b/model/model-intest/src/test/resources/sync/account-augustus-dummy.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2014 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/sync/account-cruff-dummy.xml
+++ b/model/model-intest/src/test/resources/sync/account-cruff-dummy.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2014 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/sync/account-kenny-dummy.xml
+++ b/model/model-intest/src/test/resources/sync/account-kenny-dummy.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2014 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/sync/account-lechimp-dummy.xml
+++ b/model/model-intest/src/test/resources/sync/account-lechimp-dummy.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2014 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/sync/account-stan-dummy.xml
+++ b/model/model-intest/src/test/resources/sync/account-stan-dummy.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/sync/account-tandre-dummy.xml
+++ b/model/model-intest/src/test/resources/sync/account-tandre-dummy.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2014 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/sync/account-taugustus-dummy.xml
+++ b/model/model-intest/src/test/resources/sync/account-taugustus-dummy.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2014 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/sync/account-tlafoot-dummy.xml
+++ b/model/model-intest/src/test/resources/sync/account-tlafoot-dummy.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2014 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/sync/account-tlechimp-dummy.xml
+++ b/model/model-intest/src/test/resources/sync/account-tlechimp-dummy.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2014 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/sync/account-tpalido-dummy.xml
+++ b/model/model-intest/src/test/resources/sync/account-tpalido-dummy.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2014 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/sync/resource-dummy-azure-deprecated.xml
+++ b/model/model-intest/src/test/resources/sync/resource-dummy-azure-deprecated.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/sync/resource-dummy-azure.xml
+++ b/model/model-intest/src/test/resources/sync/resource-dummy-azure.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/sync/resource-dummy-byzantine.xml
+++ b/model/model-intest/src/test/resources/sync/resource-dummy-byzantine.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/sync/role-big-judge.xml
+++ b/model/model-intest/src/test/resources/sync/role-big-judge.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/sync/role-corpse.xml
+++ b/model/model-intest/src/test/resources/sync/role-corpse.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 Evolveum
+  ~ Copyright (c) 2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/sync/role-red-judge.xml
+++ b/model/model-intest/src/test/resources/sync/role-red-judge.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/sync/system-configuration-byzantine.xml
+++ b/model/model-intest/src/test/resources/sync/system-configuration-byzantine.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/sync/task-dummy-byzantine-livesync.xml
+++ b/model/model-intest/src/test/resources/sync/task-dummy-byzantine-livesync.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/sync/task-dummy-byzantine-recon.xml
+++ b/model/model-intest/src/test/resources/sync/task-dummy-byzantine-recon.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/sync/task-dummy-emerald-livesync.xml
+++ b/model/model-intest/src/test/resources/sync/task-dummy-emerald-livesync.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/sync/task-dummy-emerald-recon.xml
+++ b/model/model-intest/src/test/resources/sync/task-dummy-emerald-recon.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/sync/task-reconcile-dummy-azure.xml
+++ b/model/model-intest/src/test/resources/sync/task-reconcile-dummy-azure.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/sync/task-reconcile-dummy-single.xml
+++ b/model/model-intest/src/test/resources/sync/task-reconcile-dummy-single.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/sync/task-reconcile-dummy-uuid.xml
+++ b/model/model-intest/src/test/resources/sync/task-reconcile-dummy-uuid.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/sync/task-user-recompute-captain.xml
+++ b/model/model-intest/src/test/resources/sync/task-user-recompute-captain.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2014 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/sync/task-user-recompute-herman-by-expression.xml
+++ b/model/model-intest/src/test/resources/sync/task-user-recompute-herman-by-expression.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/sync/task-user-recompute.xml
+++ b/model/model-intest/src/test/resources/sync/task-user-recompute.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/sync/user-template-byzantine.xml
+++ b/model/model-intest/src/test/resources/sync/user-template-byzantine.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/sync/user-template-lime.xml
+++ b/model/model-intest/src/test/resources/sync/user-template-lime.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
 <!--
-  ~ Copyright (c) 2016 Evolveum
+  ~ Copyright (c) 2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/volatility/resource-dummy-volatile.xml
+++ b/model/model-intest/src/test/resources/volatility/resource-dummy-volatile.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/volatility/task-dummy-hr-livesync.xml
+++ b/model/model-intest/src/test/resources/volatility/task-dummy-hr-livesync.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/volatility/user-largo-with-assignment.xml
+++ b/model/model-intest/src/test/resources/volatility/user-largo-with-assignment.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-intest/src/test/resources/volatility/user-template-import-hr.xml
+++ b/model/model-intest/src/test/resources/volatility/user-template-import-hr.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-test/pom.xml
+++ b/model/model-test/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-test/src/main/resources/ctx-model-test.xml
+++ b/model/model-test/src/main/resources/ctx-model-test.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  ~ Copyright (c) 2010-2014 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/model-test/testng-unit.xml
+++ b/model/model-test/testng-unit.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/notifications-api/pom.xml
+++ b/model/notifications-api/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/notifications-api/src/main/java/com/evolveum/midpoint/notifications/api/NotificationFunctions.java
+++ b/model/notifications-api/src/main/java/com/evolveum/midpoint/notifications/api/NotificationFunctions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/model/notifications-api/testng-unit.xml
+++ b/model/notifications-api/testng-unit.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/notifications-impl/src/main/java/com/evolveum/midpoint/notifications/impl/NotificationTaskListener.java
+++ b/model/notifications-impl/src/main/java/com/evolveum/midpoint/notifications/impl/NotificationTaskListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/model/notifications-impl/src/main/java/com/evolveum/midpoint/notifications/impl/notifiers/SimpleTaskNotifier.java
+++ b/model/notifications-impl/src/main/java/com/evolveum/midpoint/notifications/impl/notifiers/SimpleTaskNotifier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/model/notifications-impl/src/main/resources/ctx-notifications.xml
+++ b/model/notifications-impl/src/main/resources/ctx-notifications.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/notifications-impl/src/test/java/com/evolveum/midpoint/notifications/impl/TestTextFormatter.java
+++ b/model/notifications-impl/src/test/java/com/evolveum/midpoint/notifications/impl/TestTextFormatter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/model/notifications-impl/src/test/resources/changes/user-jack-modification.xml
+++ b/model/notifications-impl/src/test/resources/changes/user-jack-modification.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/notifications-impl/src/test/resources/ctx-notifications-test.xml
+++ b/model/notifications-impl/src/test/resources/ctx-notifications-test.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/notifications-impl/src/test/resources/logback-test.xml
+++ b/model/notifications-impl/src/test/resources/logback-test.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/notifications-impl/src/test/resources/objects/account-jack.xml
+++ b/model/notifications-impl/src/test/resources/objects/account-jack.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/notifications-impl/src/test/resources/objects/user-jack.xml
+++ b/model/notifications-impl/src/test/resources/objects/user-jack.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/notifications-impl/testng-unit.xml
+++ b/model/notifications-impl/testng-unit.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/pom.xml
+++ b/model/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/report-api/pom.xml
+++ b/model/report-api/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/report-api/testng-unit.xml
+++ b/model/report-api/testng-unit.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2014 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/report-impl/pom.xml
+++ b/model/report-impl/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/report-impl/src/main/java/com/evolveum/midpoint/report/impl/CustomDataWriter.java
+++ b/model/report-impl/src/main/java/com/evolveum/midpoint/report/impl/CustomDataWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/model/report-impl/src/main/resources/ctx-report.xml
+++ b/model/report-impl/src/main/resources/ctx-report.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/report-impl/src/test/resources/common/connector-dummy.xml
+++ b/model/report-impl/src/test/resources/common/connector-dummy.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/report-impl/src/test/resources/common/connector-ldap.xml
+++ b/model/report-impl/src/test/resources/common/connector-ldap.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/report-impl/src/test/resources/common/report-outputs-for-cleanup.xml
+++ b/model/report-impl/src/test/resources/common/report-outputs-for-cleanup.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/report-impl/src/test/resources/common/resource-dummy.xml
+++ b/model/report-impl/src/test/resources/common/resource-dummy.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2014 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/report-impl/src/test/resources/common/resource-opendj.xml
+++ b/model/report-impl/src/test/resources/common/resource-opendj.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2014 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/report-impl/src/test/resources/common/role-superuser.xml
+++ b/model/report-impl/src/test/resources/common/role-superuser.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/report-impl/src/test/resources/common/system-configuration.xml
+++ b/model/report-impl/src/test/resources/common/system-configuration.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/report-impl/src/test/resources/common/task-report.xml
+++ b/model/report-impl/src/test/resources/common/task-report.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/report-impl/src/test/resources/common/user-administrator.xml
+++ b/model/report-impl/src/test/resources/common/user-administrator.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/report-impl/src/test/resources/common/user-jack.xml
+++ b/model/report-impl/src/test/resources/common/user-jack.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/report-impl/src/test/resources/ctx-report-test-main.xml
+++ b/model/report-impl/src/test/resources/ctx-report-test-main.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/report-impl/src/test/resources/logback-test.xml
+++ b/model/report-impl/src/test/resources/logback-test.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/report-impl/src/test/resources/reports/report-sample.xml
+++ b/model/report-impl/src/test/resources/reports/report-sample.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2014 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/report-impl/src/test/resources/reports/report-test-valid.xml
+++ b/model/report-impl/src/test/resources/reports/report-test-valid.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/report-impl/src/test/resources/reports/report-test-without-design.xml
+++ b/model/report-impl/src/test/resources/reports/report-test-without-design.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/report-impl/src/test/resources/reports/report-test.xml
+++ b/model/report-impl/src/test/resources/reports/report-test.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2014 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/report-impl/src/test/resources/reports/reportAuditLogs-with-datasource.xml
+++ b/model/report-impl/src/test/resources/reports/reportAuditLogs-with-datasource.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2014 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/report-impl/src/test/resources/reports/reportAuditLogs.xml
+++ b/model/report-impl/src/test/resources/reports/reportAuditLogs.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2014 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/report-impl/src/test/resources/reports/reportReconciliation.xml
+++ b/model/report-impl/src/test/resources/reports/reportReconciliation.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2014 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/report-impl/src/test/resources/reports/reportUserAccounts.xml
+++ b/model/report-impl/src/test/resources/reports/reportUserAccounts.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2014 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/report-impl/src/test/resources/reports/reportUserList.xml
+++ b/model/report-impl/src/test/resources/reports/reportUserList.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2014 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/report-impl/src/test/resources/reports/reportUserOrgs.xml
+++ b/model/report-impl/src/test/resources/reports/reportUserOrgs.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2014 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/report-impl/src/test/resources/reports/reportUserRoles.xml
+++ b/model/report-impl/src/test/resources/reports/reportUserRoles.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2014 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/report-impl/testng-integration.xml
+++ b/model/report-impl/testng-integration.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/workflow-api/pom.xml
+++ b/model/workflow-api/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/workflow-api/src/main/java/com/evolveum/midpoint/wf/util/ChangesByState.java
+++ b/model/workflow-api/src/main/java/com/evolveum/midpoint/wf/util/ChangesByState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/model/workflow-api/src/main/java/com/evolveum/midpoint/wf/util/QueryUtils.java
+++ b/model/workflow-api/src/main/java/com/evolveum/midpoint/wf/util/QueryUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/model/workflow-api/testng-unit.xml
+++ b/model/workflow-api/testng-unit.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/workflow-impl/pom.xml
+++ b/model/workflow-impl/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/workflow-impl/src/main/java/com/evolveum/midpoint/wf/impl/activiti/MidPointStandaloneProcessEngineConfiguration.java
+++ b/model/workflow-impl/src/main/java/com/evolveum/midpoint/wf/impl/activiti/MidPointStandaloneProcessEngineConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/model/workflow-impl/src/main/java/com/evolveum/midpoint/wf/impl/activiti/dao/ProcessInstanceManager.java
+++ b/model/workflow-impl/src/main/java/com/evolveum/midpoint/wf/impl/activiti/dao/ProcessInstanceManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/model/workflow-impl/src/main/java/com/evolveum/midpoint/wf/impl/activiti/dao/WorkItemManager.java
+++ b/model/workflow-impl/src/main/java/com/evolveum/midpoint/wf/impl/activiti/dao/WorkItemManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/model/workflow-impl/src/main/java/com/evolveum/midpoint/wf/impl/processes/itemApproval/ItemApprovalSpecificContent.java
+++ b/model/workflow-impl/src/main/java/com/evolveum/midpoint/wf/impl/processes/itemApproval/ItemApprovalSpecificContent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/model/workflow-impl/src/main/java/com/evolveum/midpoint/wf/impl/processors/BaseConfigurationHelper.java
+++ b/model/workflow-impl/src/main/java/com/evolveum/midpoint/wf/impl/processors/BaseConfigurationHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/model/workflow-impl/src/main/java/com/evolveum/midpoint/wf/impl/processors/general/GeneralChangeProcessorSpecificContent.java
+++ b/model/workflow-impl/src/main/java/com/evolveum/midpoint/wf/impl/processors/general/GeneralChangeProcessorSpecificContent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/model/workflow-impl/src/main/java/com/evolveum/midpoint/wf/impl/processors/primary/PolicyRuleApplication.java
+++ b/model/workflow-impl/src/main/java/com/evolveum/midpoint/wf/impl/processors/primary/PolicyRuleApplication.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/model/workflow-impl/src/main/java/com/evolveum/midpoint/wf/impl/processors/primary/PrimaryChangeProcessorSpecificContent.java
+++ b/model/workflow-impl/src/main/java/com/evolveum/midpoint/wf/impl/processors/primary/PrimaryChangeProcessorSpecificContent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/model/workflow-impl/src/main/java/com/evolveum/midpoint/wf/impl/tasks/ProcessSpecificContent.java
+++ b/model/workflow-impl/src/main/java/com/evolveum/midpoint/wf/impl/tasks/ProcessSpecificContent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/model/workflow-impl/src/main/java/com/evolveum/midpoint/wf/impl/tasks/ProcessorSpecificContent.java
+++ b/model/workflow-impl/src/main/java/com/evolveum/midpoint/wf/impl/tasks/ProcessorSpecificContent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/model/workflow-impl/src/main/resources/ctx-workflow.xml
+++ b/model/workflow-impl/src/main/resources/ctx-workflow.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/workflow-impl/src/main/resources/mybatis/Task.xml
+++ b/model/workflow-impl/src/main/resources/mybatis/Task.xml
@@ -14,7 +14,7 @@
   ~ limitations under the License.
   ~
   ~ Adapted from sources of Activiti 5.22 by mederly.
-  ~ Portions Copyright (c) 2010-2016 Evolveum
+  ~ Portions Copyright (c) 2010-2017 Evolveum
   -->
 
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd"> 

--- a/model/workflow-impl/src/main/resources/mybatis/mappings.xml
+++ b/model/workflow-impl/src/main/resources/mybatis/mappings.xml
@@ -14,7 +14,7 @@
   ~ limitations under the License.
   ~
   ~ Adapted from sources of Activiti 5.22 by mederly.
-  ~ Portions Copyright (c) 2010-2016 Evolveum
+  ~ Portions Copyright (c) 2010-2017 Evolveum
   -->
 
 <!DOCTYPE configuration PUBLIC "-//mybatis.org//DTD Config 3.0//EN" "http://mybatis.org/dtd/mybatis-3-config.dtd">

--- a/model/workflow-impl/src/main/resources/processes/ItemApproval.bpmn20.xml
+++ b/model/workflow-impl/src/main/resources/processes/ItemApproval.bpmn20.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/workflow-impl/src/test/java/com/evolveum/midpoint/wf/impl/WfTestUtil.java
+++ b/model/workflow-impl/src/test/java/com/evolveum/midpoint/wf/impl/WfTestUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/model/workflow-impl/src/test/java/com/evolveum/midpoint/wf/impl/policy/ApprovalInstruction.java
+++ b/model/workflow-impl/src/test/java/com/evolveum/midpoint/wf/impl/policy/ApprovalInstruction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/model/workflow-impl/src/test/java/com/evolveum/midpoint/wf/impl/policy/ExpectedTask.java
+++ b/model/workflow-impl/src/test/java/com/evolveum/midpoint/wf/impl/policy/ExpectedTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/model/workflow-impl/src/test/java/com/evolveum/midpoint/wf/impl/policy/ExpectedWorkItem.java
+++ b/model/workflow-impl/src/test/java/com/evolveum/midpoint/wf/impl/policy/ExpectedWorkItem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/model/workflow-impl/src/test/java/com/evolveum/midpoint/wf/impl/policy/assignments/global/TestAssignmentApprovalGlobal.java
+++ b/model/workflow-impl/src/test/java/com/evolveum/midpoint/wf/impl/policy/assignments/global/TestAssignmentApprovalGlobal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/model/workflow-impl/src/test/java/com/evolveum/midpoint/wf/impl/policy/assignments/metarole/TestAssignmentApprovalMetaroleExplicit.java
+++ b/model/workflow-impl/src/test/java/com/evolveum/midpoint/wf/impl/policy/assignments/metarole/TestAssignmentApprovalMetaroleExplicit.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/model/workflow-impl/src/test/java/com/evolveum/midpoint/wf/impl/policy/assignments/metarole/TestAssignmentsWithDifferentMetaroles.java
+++ b/model/workflow-impl/src/test/java/com/evolveum/midpoint/wf/impl/policy/assignments/metarole/TestAssignmentsWithDifferentMetaroles.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/model/workflow-impl/src/test/java/com/evolveum/midpoint/wf/impl/policy/assignments/plain/TestAssignmentApprovalPlainExplicit.java
+++ b/model/workflow-impl/src/test/java/com/evolveum/midpoint/wf/impl/policy/assignments/plain/TestAssignmentApprovalPlainExplicit.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/model/workflow-impl/src/test/java/com/evolveum/midpoint/wf/impl/policy/assignments/plain/TestAssignmentApprovalPlainImplicit.java
+++ b/model/workflow-impl/src/test/java/com/evolveum/midpoint/wf/impl/policy/assignments/plain/TestAssignmentApprovalPlainImplicit.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/model/workflow-impl/src/test/java/com/evolveum/midpoint/wf/impl/policy/other/TestActivitiQuery.java
+++ b/model/workflow-impl/src/test/java/com/evolveum/midpoint/wf/impl/policy/other/TestActivitiQuery.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/model/workflow-impl/src/test/resources/activiti.cfg-mem.xml
+++ b/model/workflow-impl/src/test/resources/activiti.cfg-mem.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/workflow-impl/src/test/resources/common/account-elaine-dummy.xml
+++ b/model/workflow-impl/src/test/resources/common/account-elaine-dummy.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/workflow-impl/src/test/resources/common/account-guybrush-dummy.xml
+++ b/model/workflow-impl/src/test/resources/common/account-guybrush-dummy.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/workflow-impl/src/test/resources/common/account-hbarbossa-dummy.xml
+++ b/model/workflow-impl/src/test/resources/common/account-hbarbossa-dummy.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/workflow-impl/src/test/resources/common/account-herman-dummy.xml
+++ b/model/workflow-impl/src/test/resources/common/account-herman-dummy.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/workflow-impl/src/test/resources/common/account-herman-opendj.xml
+++ b/model/workflow-impl/src/test/resources/common/account-herman-opendj.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/workflow-impl/src/test/resources/common/account-shadow-guybrush-dummy.xml
+++ b/model/workflow-impl/src/test/resources/common/account-shadow-guybrush-dummy.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/workflow-impl/src/test/resources/common/account-shadow-jack-dummy.xml
+++ b/model/workflow-impl/src/test/resources/common/account-shadow-jack-dummy.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/workflow-impl/src/test/resources/common/connector-dummy.xml
+++ b/model/workflow-impl/src/test/resources/common/connector-dummy.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/workflow-impl/src/test/resources/common/password-policy-global.xml
+++ b/model/workflow-impl/src/test/resources/common/password-policy-global.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/workflow-impl/src/test/resources/common/resource-dummy.xml
+++ b/model/workflow-impl/src/test/resources/common/resource-dummy.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2014 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/workflow-impl/src/test/resources/common/role-superuser.xml
+++ b/model/workflow-impl/src/test/resources/common/role-superuser.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/workflow-impl/src/test/resources/common/system-configuration.xml
+++ b/model/workflow-impl/src/test/resources/common/system-configuration.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/workflow-impl/src/test/resources/common/user-administrator.xml
+++ b/model/workflow-impl/src/test/resources/common/user-administrator.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/workflow-impl/src/test/resources/common/user-barbossa.xml
+++ b/model/workflow-impl/src/test/resources/common/user-barbossa.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/workflow-impl/src/test/resources/common/user-elaine.xml
+++ b/model/workflow-impl/src/test/resources/common/user-elaine.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/workflow-impl/src/test/resources/common/user-guybrush.xml
+++ b/model/workflow-impl/src/test/resources/common/user-guybrush.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/workflow-impl/src/test/resources/common/user-jack.xml
+++ b/model/workflow-impl/src/test/resources/common/user-jack.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/workflow-impl/src/test/resources/common/user-largo.xml
+++ b/model/workflow-impl/src/test/resources/common/user-largo.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/workflow-impl/src/test/resources/common/user-template.xml
+++ b/model/workflow-impl/src/test/resources/common/user-template.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/workflow-impl/src/test/resources/ctx-workflow-test-main.xml
+++ b/model/workflow-impl/src/test/resources/ctx-workflow-test-main.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/workflow-impl/src/test/resources/legacy/account-shadow-elisabeth-dummy.xml
+++ b/model/workflow-impl/src/test/resources/legacy/account-shadow-elisabeth-dummy.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/workflow-impl/src/test/resources/legacy/group-guests-dummy.xml
+++ b/model/workflow-impl/src/test/resources/legacy/group-guests-dummy.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/workflow-impl/src/test/resources/legacy/group-testers-dummy.xml
+++ b/model/workflow-impl/src/test/resources/legacy/group-testers-dummy.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/workflow-impl/src/test/resources/legacy/org-test1.xml
+++ b/model/workflow-impl/src/test/resources/legacy/org-test1.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/workflow-impl/src/test/resources/legacy/role11.xml
+++ b/model/workflow-impl/src/test/resources/legacy/role11.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/workflow-impl/src/test/resources/legacy/role12.xml
+++ b/model/workflow-impl/src/test/resources/legacy/role12.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/workflow-impl/src/test/resources/legacy/role13.xml
+++ b/model/workflow-impl/src/test/resources/legacy/role13.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/workflow-impl/src/test/resources/legacy/shadow-modify-add-entitlement-guests.xml
+++ b/model/workflow-impl/src/test/resources/legacy/shadow-modify-add-entitlement-guests.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/workflow-impl/src/test/resources/legacy/shadow-modify-add-entitlement-testers.xml
+++ b/model/workflow-impl/src/test/resources/legacy/shadow-modify-add-entitlement-testers.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/workflow-impl/src/test/resources/legacy/user-bill.xml
+++ b/model/workflow-impl/src/test/resources/legacy/user-bill.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/workflow-impl/src/test/resources/legacy/user-elisabeth-modify-add-assignment-role3.xml
+++ b/model/workflow-impl/src/test/resources/legacy/user-elisabeth-modify-add-assignment-role3.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/workflow-impl/src/test/resources/legacy/user-elisabeth.xml
+++ b/model/workflow-impl/src/test/resources/legacy/user-elisabeth.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/workflow-impl/src/test/resources/legacy/user-jack-modify-activation-disable.xml
+++ b/model/workflow-impl/src/test/resources/legacy/user-jack-modify-activation-disable.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/workflow-impl/src/test/resources/legacy/user-jack-modify-activation-enable.xml
+++ b/model/workflow-impl/src/test/resources/legacy/user-jack-modify-activation-enable.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/workflow-impl/src/test/resources/legacy/user-jack-modify-add-assignment-dummy.xml
+++ b/model/workflow-impl/src/test/resources/legacy/user-jack-modify-add-assignment-dummy.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/workflow-impl/src/test/resources/legacy/user-jack-modify-add-assignment-role-r1.xml
+++ b/model/workflow-impl/src/test/resources/legacy/user-jack-modify-add-assignment-role-r1.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/workflow-impl/src/test/resources/legacy/user-jack-modify-add-assignment-role1.xml
+++ b/model/workflow-impl/src/test/resources/legacy/user-jack-modify-add-assignment-role1.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/workflow-impl/src/test/resources/legacy/user-jack-modify-add-assignment-role10.xml
+++ b/model/workflow-impl/src/test/resources/legacy/user-jack-modify-add-assignment-role10.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2014 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/workflow-impl/src/test/resources/legacy/user-jack-modify-add-assignment-role2-change-gn.xml
+++ b/model/workflow-impl/src/test/resources/legacy/user-jack-modify-add-assignment-role2-change-gn.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/workflow-impl/src/test/resources/legacy/user-jack-modify-add-assignment-role3-change-gn2.xml
+++ b/model/workflow-impl/src/test/resources/legacy/user-jack-modify-add-assignment-role3-change-gn2.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/workflow-impl/src/test/resources/legacy/user-jack-modify-add-assignment-roles2-3-4.xml
+++ b/model/workflow-impl/src/test/resources/legacy/user-jack-modify-add-assignment-roles2-3-4.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/workflow-impl/src/test/resources/legacy/user-jack-modify-change-password-2.xml
+++ b/model/workflow-impl/src/test/resources/legacy/user-jack-modify-change-password-2.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/workflow-impl/src/test/resources/legacy/user-jack-modify-change-password.xml
+++ b/model/workflow-impl/src/test/resources/legacy/user-jack-modify-change-password.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/workflow-impl/src/test/resources/legacy/users-and-roles.xml
+++ b/model/workflow-impl/src/test/resources/legacy/users-and-roles.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/workflow-impl/src/test/resources/logback-test.xml
+++ b/model/workflow-impl/src/test/resources/logback-test.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/workflow-impl/src/test/resources/policy/041-role-approver.xml
+++ b/model/workflow-impl/src/test/resources/policy/041-role-approver.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2016 Evolveum
+  ~ Copyright (c) 2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/workflow-impl/src/test/resources/policy/assignments/role-role21-standard.xml
+++ b/model/workflow-impl/src/test/resources/policy/assignments/role-role21-standard.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/workflow-impl/src/test/resources/policy/assignments/role-role22-special.xml
+++ b/model/workflow-impl/src/test/resources/policy/assignments/role-role22-special.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/workflow-impl/src/test/resources/policy/assignments/role-role23-special-and-security.xml
+++ b/model/workflow-impl/src/test/resources/policy/assignments/role-role23-special-and-security.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/workflow-impl/src/test/resources/policy/lifecycle/user-pirate-owner.xml
+++ b/model/workflow-impl/src/test/resources/policy/lifecycle/user-pirate-owner.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/workflow-impl/src/test/resources/policy/metarole-default.xml
+++ b/model/workflow-impl/src/test/resources/policy/metarole-default.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/workflow-impl/src/test/resources/policy/metarole-security.xml
+++ b/model/workflow-impl/src/test/resources/policy/metarole-security.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/workflow-impl/src/test/resources/policy/role-role1.xml
+++ b/model/workflow-impl/src/test/resources/policy/role-role1.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/workflow-impl/src/test/resources/policy/role-role10.xml
+++ b/model/workflow-impl/src/test/resources/policy/role-role10.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/workflow-impl/src/test/resources/policy/role-role10a.xml
+++ b/model/workflow-impl/src/test/resources/policy/role-role10a.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/workflow-impl/src/test/resources/policy/role-role10b.xml
+++ b/model/workflow-impl/src/test/resources/policy/role-role10b.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/workflow-impl/src/test/resources/policy/role-role1a.xml
+++ b/model/workflow-impl/src/test/resources/policy/role-role1a.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/workflow-impl/src/test/resources/policy/role-role1b.xml
+++ b/model/workflow-impl/src/test/resources/policy/role-role1b.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/workflow-impl/src/test/resources/policy/role-role2.xml
+++ b/model/workflow-impl/src/test/resources/policy/role-role2.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/workflow-impl/src/test/resources/policy/role-role2a.xml
+++ b/model/workflow-impl/src/test/resources/policy/role-role2a.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/workflow-impl/src/test/resources/policy/role-role2b.xml
+++ b/model/workflow-impl/src/test/resources/policy/role-role2b.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/workflow-impl/src/test/resources/policy/role-role3.xml
+++ b/model/workflow-impl/src/test/resources/policy/role-role3.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/workflow-impl/src/test/resources/policy/role-role3a.xml
+++ b/model/workflow-impl/src/test/resources/policy/role-role3a.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/workflow-impl/src/test/resources/policy/role-role3b.xml
+++ b/model/workflow-impl/src/test/resources/policy/role-role3b.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/workflow-impl/src/test/resources/policy/role-role4.xml
+++ b/model/workflow-impl/src/test/resources/policy/role-role4.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/workflow-impl/src/test/resources/policy/role-role4a.xml
+++ b/model/workflow-impl/src/test/resources/policy/role-role4a.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/workflow-impl/src/test/resources/policy/role-role4b.xml
+++ b/model/workflow-impl/src/test/resources/policy/role-role4b.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/workflow-impl/src/test/resources/policy/role-superuser.xml
+++ b/model/workflow-impl/src/test/resources/policy/role-superuser.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/workflow-impl/src/test/resources/policy/system-configuration.xml
+++ b/model/workflow-impl/src/test/resources/policy/system-configuration.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/workflow-impl/src/test/resources/policy/user-administrator.xml
+++ b/model/workflow-impl/src/test/resources/policy/user-administrator.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/workflow-impl/src/test/resources/policy/user-jack.xml
+++ b/model/workflow-impl/src/test/resources/policy/user-jack.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/workflow-impl/src/test/resources/policy/user-lead1-deputy1.xml
+++ b/model/workflow-impl/src/test/resources/policy/user-lead1-deputy1.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/workflow-impl/src/test/resources/policy/user-lead1-deputy2.xml
+++ b/model/workflow-impl/src/test/resources/policy/user-lead1-deputy2.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/workflow-impl/src/test/resources/policy/user-lead1.xml
+++ b/model/workflow-impl/src/test/resources/policy/user-lead1.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/workflow-impl/src/test/resources/policy/user-lead10.xml
+++ b/model/workflow-impl/src/test/resources/policy/user-lead10.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/workflow-impl/src/test/resources/policy/user-lead2.xml
+++ b/model/workflow-impl/src/test/resources/policy/user-lead2.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/workflow-impl/src/test/resources/policy/user-lead3.xml
+++ b/model/workflow-impl/src/test/resources/policy/user-lead3.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/workflow-impl/src/test/resources/policy/user-security-approver-deputy.xml
+++ b/model/workflow-impl/src/test/resources/policy/user-security-approver-deputy.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/workflow-impl/src/test/resources/policy/user-security-approver.xml
+++ b/model/workflow-impl/src/test/resources/policy/user-security-approver.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/workflow-impl/src/test/resources/processes/ApprovingDummyResourceChangesProcess.bpmn20.xml
+++ b/model/workflow-impl/src/test/resources/processes/ApprovingDummyResourceChangesProcess.bpmn20.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/workflow-impl/src/test/resources/processes/MyGreatPrimaryProcess.bpmn20.xml
+++ b/model/workflow-impl/src/test/resources/processes/MyGreatPrimaryProcess.bpmn20.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/workflow-impl/src/test/resources/test-config.xml
+++ b/model/workflow-impl/src/test/resources/test-config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/model/workflow-impl/testng-integration.xml
+++ b/model/workflow-impl/testng-integration.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/provisioning/provisioning-api/pom.xml
+++ b/provisioning/provisioning-api/pom.xml
@@ -1,6 +1,6 @@
 
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/provisioning/provisioning-api/src/main/java/com/evolveum/midpoint/provisioning/api/ProvisioningOperationOptions.java
+++ b/provisioning/provisioning-api/src/main/java/com/evolveum/midpoint/provisioning/api/ProvisioningOperationOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/provisioning/provisioning-api/src/main/java/com/evolveum/midpoint/provisioning/api/ResourceObjectShadowChangeDescription.java
+++ b/provisioning/provisioning-api/src/main/java/com/evolveum/midpoint/provisioning/api/ResourceObjectShadowChangeDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/provisioning/provisioning-api/testng-unit.xml
+++ b/provisioning/provisioning-api/testng-unit.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/provisioning/provisioning-impl/src/main/java/com/evolveum/midpoint/provisioning/consistency/impl/CommunicationExceptionHandler.java
+++ b/provisioning/provisioning-impl/src/main/java/com/evolveum/midpoint/provisioning/consistency/impl/CommunicationExceptionHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/provisioning/provisioning-impl/src/main/java/com/evolveum/midpoint/provisioning/consistency/impl/ConfigurationExceptionHandler.java
+++ b/provisioning/provisioning-impl/src/main/java/com/evolveum/midpoint/provisioning/consistency/impl/ConfigurationExceptionHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/provisioning/provisioning-impl/src/main/java/com/evolveum/midpoint/provisioning/impl/ConstraintsChecker.java
+++ b/provisioning/provisioning-impl/src/main/java/com/evolveum/midpoint/provisioning/impl/ConstraintsChecker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/provisioning/provisioning-impl/src/main/java/com/evolveum/midpoint/provisioning/impl/ResourceObjectDiscriminator.java
+++ b/provisioning/provisioning-impl/src/main/java/com/evolveum/midpoint/provisioning/impl/ResourceObjectDiscriminator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/provisioning/provisioning-impl/src/main/resources/ctx-provisioning.xml
+++ b/provisioning/provisioning-impl/src/main/resources/ctx-provisioning.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/provisioning/provisioning-impl/src/test/java/com/evolveum/midpoint/provisioning/impl/dummy/TestDummyCaseIgnoreUpcaseName.java
+++ b/provisioning/provisioning-impl/src/test/java/com/evolveum/midpoint/provisioning/impl/dummy/TestDummyCaseIgnoreUpcaseName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/provisioning/provisioning-impl/src/test/resources/common/admin.xml
+++ b/provisioning/provisioning-impl/src/test/resources/common/admin.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/provisioning/provisioning-impl/src/test/resources/common/resource-opendj.xml
+++ b/provisioning/provisioning-impl/src/test/resources/common/resource-opendj.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/provisioning/provisioning-impl/src/test/resources/ctx-provisioning-test.xml
+++ b/provisioning/provisioning-impl/src/test/resources/ctx-provisioning-test.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/provisioning/provisioning-impl/src/test/resources/db/account-derby.xml
+++ b/provisioning/provisioning-impl/src/test/resources/db/account-derby.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/provisioning/provisioning-impl/src/test/resources/db/resource-derby.xml
+++ b/provisioning/provisioning-impl/src/test/resources/db/resource-derby.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/provisioning/provisioning-impl/src/test/resources/dummy/account-daemon.xml
+++ b/provisioning/provisioning-impl/src/test/resources/dummy/account-daemon.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/provisioning/provisioning-impl/src/test/resources/dummy/account-elaine-resource-not-found.xml
+++ b/provisioning/provisioning-impl/src/test/resources/dummy/account-elaine-resource-not-found.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/provisioning/provisioning-impl/src/test/resources/dummy/account-lechuck.xml
+++ b/provisioning/provisioning-impl/src/test/resources/dummy/account-lechuck.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/provisioning/provisioning-impl/src/test/resources/dummy/account-morgan.xml
+++ b/provisioning/provisioning-impl/src/test/resources/dummy/account-morgan.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/provisioning/provisioning-impl/src/test/resources/dummy/account-script.xml
+++ b/provisioning/provisioning-impl/src/test/resources/dummy/account-script.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/provisioning/provisioning-impl/src/test/resources/dummy/account-will.xml
+++ b/provisioning/provisioning-impl/src/test/resources/dummy/account-will.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/provisioning/provisioning-impl/src/test/resources/dummy/dummy-caching/resource-dummy.xml
+++ b/provisioning/provisioning-impl/src/test/resources/dummy/dummy-caching/resource-dummy.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/provisioning/provisioning-impl/src/test/resources/dummy/dummy-case-ignore-upcase-name/resource-dummy.xml
+++ b/provisioning/provisioning-impl/src/test/resources/dummy/dummy-case-ignore-upcase-name/resource-dummy.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2014 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/provisioning/provisioning-impl/src/test/resources/dummy/dummy-case-ignore/resource-dummy.xml
+++ b/provisioning/provisioning-impl/src/test/resources/dummy/dummy-case-ignore/resource-dummy.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/provisioning/provisioning-impl/src/test/resources/dummy/dummy-hacks/connector-dummy.xml
+++ b/provisioning/provisioning-impl/src/test/resources/dummy/dummy-hacks/connector-dummy.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/provisioning/provisioning-impl/src/test/resources/dummy/dummy-hacks/resource-dummy.xml
+++ b/provisioning/provisioning-impl/src/test/resources/dummy/dummy-hacks/resource-dummy.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2014 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/provisioning/provisioning-impl/src/test/resources/dummy/dummy-no-activation/account-will.xml
+++ b/provisioning/provisioning-impl/src/test/resources/dummy/dummy-no-activation/account-will.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/provisioning/provisioning-impl/src/test/resources/dummy/dummy-no-activation/resource-dummy.xml
+++ b/provisioning/provisioning-impl/src/test/resources/dummy/dummy-no-activation/resource-dummy.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/provisioning/provisioning-impl/src/test/resources/dummy/dummy-priorities-read-replace/resource-dummy-all-read-replace.xml
+++ b/provisioning/provisioning-impl/src/test/resources/dummy/dummy-priorities-read-replace/resource-dummy-all-read-replace.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2014 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/provisioning/provisioning-impl/src/test/resources/dummy/dummy-priorities-read-replace/resource-dummy.xml
+++ b/provisioning/provisioning-impl/src/test/resources/dummy/dummy-priorities-read-replace/resource-dummy.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2014 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/provisioning/provisioning-impl/src/test/resources/dummy/dummy-schemaless/account-will.xml
+++ b/provisioning/provisioning-impl/src/test/resources/dummy/dummy-schemaless/account-will.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/provisioning/provisioning-impl/src/test/resources/dummy/dummy-schemaless/resource-dummy-schemaless-no-schema.xml
+++ b/provisioning/provisioning-impl/src/test/resources/dummy/dummy-schemaless/resource-dummy-schemaless-no-schema.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/provisioning/provisioning-impl/src/test/resources/dummy/group-pirates.xml
+++ b/provisioning/provisioning-impl/src/test/resources/dummy/group-pirates.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/provisioning/provisioning-impl/src/test/resources/dummy/modify-will-disable.xml
+++ b/provisioning/provisioning-impl/src/test/resources/dummy/modify-will-disable.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/provisioning/provisioning-impl/src/test/resources/dummy/modify-will-enable.xml
+++ b/provisioning/provisioning-impl/src/test/resources/dummy/modify-will-enable.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/provisioning/provisioning-impl/src/test/resources/dummy/modify-will-fullname.xml
+++ b/provisioning/provisioning-impl/src/test/resources/dummy/modify-will-fullname.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/provisioning/provisioning-impl/src/test/resources/dummy/privilege-bargain.xml
+++ b/provisioning/provisioning-impl/src/test/resources/dummy/privilege-bargain.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2014 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/provisioning/provisioning-impl/src/test/resources/dummy/privilege-pillage.xml
+++ b/provisioning/provisioning-impl/src/test/resources/dummy/privilege-pillage.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/provisioning/provisioning-impl/src/test/resources/dummy/resource-dummy.xml
+++ b/provisioning/provisioning-impl/src/test/resources/dummy/resource-dummy.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/provisioning/provisioning-impl/src/test/resources/dummy/scripts.xml
+++ b/provisioning/provisioning-impl/src/test/resources/dummy/scripts.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/provisioning/provisioning-impl/src/test/resources/logback-test.xml
+++ b/provisioning/provisioning-impl/src/test/resources/logback-test.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/provisioning/provisioning-impl/src/test/resources/opendj/account-bad.xml
+++ b/provisioning/provisioning-impl/src/test/resources/opendj/account-bad.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/provisioning/provisioning-impl/src/test/resources/opendj/account-change-password.xml
+++ b/provisioning/provisioning-impl/src/test/resources/opendj/account-change-password.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/provisioning/provisioning-impl/src/test/resources/opendj/account-disable-simulated-opendj.xml
+++ b/provisioning/provisioning-impl/src/test/resources/opendj/account-disable-simulated-opendj.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/provisioning/provisioning-impl/src/test/resources/opendj/account-jack-change.xml
+++ b/provisioning/provisioning-impl/src/test/resources/opendj/account-jack-change.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/provisioning/provisioning-impl/src/test/resources/opendj/account-jack-repo.xml
+++ b/provisioning/provisioning-impl/src/test/resources/opendj/account-jack-repo.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/provisioning/provisioning-impl/src/test/resources/opendj/account-jack.xml
+++ b/provisioning/provisioning-impl/src/test/resources/opendj/account-jack.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/provisioning/provisioning-impl/src/test/resources/opendj/account-jbond-repo.xml
+++ b/provisioning/provisioning-impl/src/test/resources/opendj/account-jbond-repo.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/provisioning/provisioning-impl/src/test/resources/opendj/account-modify-password.xml
+++ b/provisioning/provisioning-impl/src/test/resources/opendj/account-modify-password.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/provisioning/provisioning-impl/src/test/resources/opendj/account-new-disabled.xml
+++ b/provisioning/provisioning-impl/src/test/resources/opendj/account-new-disabled.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/provisioning/provisioning-impl/src/test/resources/opendj/account-new-enabled.xml
+++ b/provisioning/provisioning-impl/src/test/resources/opendj/account-new-enabled.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/provisioning/provisioning-impl/src/test/resources/opendj/account-new-with-password.xml
+++ b/provisioning/provisioning-impl/src/test/resources/opendj/account-new-with-password.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/provisioning/provisioning-impl/src/test/resources/opendj/account-opendj-no-sn.xml
+++ b/provisioning/provisioning-impl/src/test/resources/opendj/account-opendj-no-sn.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/provisioning/provisioning-impl/src/test/resources/opendj/account-search-iterative.xml
+++ b/provisioning/provisioning-impl/src/test/resources/opendj/account-search-iterative.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/provisioning/provisioning-impl/src/test/resources/opendj/account-search.xml
+++ b/provisioning/provisioning-impl/src/test/resources/opendj/account-search.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/provisioning/provisioning-impl/src/test/resources/opendj/account-sparrow-repo.xml
+++ b/provisioning/provisioning-impl/src/test/resources/opendj/account-sparrow-repo.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/provisioning/provisioning-impl/src/test/resources/opendj/account-sparrow.xml
+++ b/provisioning/provisioning-impl/src/test/resources/opendj/account-sparrow.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/provisioning/provisioning-impl/src/test/resources/opendj/account-will.xml
+++ b/provisioning/provisioning-impl/src/test/resources/opendj/account-will.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/provisioning/provisioning-impl/src/test/resources/opendj/disable-account-simulated.xml
+++ b/provisioning/provisioning-impl/src/test/resources/opendj/disable-account-simulated.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/provisioning/provisioning-impl/src/test/resources/opendj/group-specialists.xml
+++ b/provisioning/provisioning-impl/src/test/resources/opendj/group-specialists.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2016 Evolveum
+  ~ Copyright (c) 2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/provisioning/provisioning-impl/src/test/resources/opendj/query-complex-filter.xml
+++ b/provisioning/provisioning-impl/src/test/resources/opendj/query-complex-filter.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/provisioning/provisioning-impl/src/test/resources/opendj/query-filter-all-accounts.xml
+++ b/provisioning/provisioning-impl/src/test/resources/opendj/query-filter-all-accounts.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/provisioning/provisioning-impl/src/test/resources/opendj/resource-opendj-bad-bind-dn.xml
+++ b/provisioning/provisioning-impl/src/test/resources/opendj/resource-opendj-bad-bind-dn.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/provisioning/provisioning-impl/src/test/resources/opendj/resource-opendj-bad-credentials.xml
+++ b/provisioning/provisioning-impl/src/test/resources/opendj/resource-opendj-bad-credentials.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/provisioning/provisioning-impl/src/test/resources/opendj/resource-opendj-bad.xml
+++ b/provisioning/provisioning-impl/src/test/resources/opendj/resource-opendj-bad.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/provisioning/provisioning-impl/src/test/resources/opendj/resource-opendj-dumber.xml
+++ b/provisioning/provisioning-impl/src/test/resources/opendj/resource-opendj-dumber.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/provisioning/provisioning-impl/src/test/resources/opendj/resource-opendj-initialized.xml
+++ b/provisioning/provisioning-impl/src/test/resources/opendj/resource-opendj-initialized.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/provisioning/provisioning-impl/src/test/resources/opendj/resource-opendj-no-create.xml
+++ b/provisioning/provisioning-impl/src/test/resources/opendj/resource-opendj-no-create.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/provisioning/provisioning-impl/src/test/resources/opendj/resource-opendj-no-delete.xml
+++ b/provisioning/provisioning-impl/src/test/resources/opendj/resource-opendj-no-delete.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/provisioning/provisioning-impl/src/test/resources/opendj/resource-opendj-no-read.xml
+++ b/provisioning/provisioning-impl/src/test/resources/opendj/resource-opendj-no-read.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/provisioning/provisioning-impl/src/test/resources/opendj/resource-opendj-no-update.xml
+++ b/provisioning/provisioning-impl/src/test/resources/opendj/resource-opendj-no-update.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/provisioning/provisioning-impl/src/test/resources/synchronization/sync-task-example.xml
+++ b/provisioning/provisioning-impl/src/test/resources/synchronization/sync-task-example.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/provisioning/ucf-api/src/main/java/com/evolveum/midpoint/provisioning/ucf/api/Change.java
+++ b/provisioning/ucf-api/src/main/java/com/evolveum/midpoint/provisioning/ucf/api/Change.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/provisioning/ucf-api/src/main/java/com/evolveum/midpoint/provisioning/ucf/api/PasswordChangeOperation.java
+++ b/provisioning/ucf-api/src/main/java/com/evolveum/midpoint/provisioning/ucf/api/PasswordChangeOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/provisioning/ucf-api/src/main/java/com/evolveum/midpoint/provisioning/ucf/api/PropertyModificationOperation.java
+++ b/provisioning/ucf-api/src/main/java/com/evolveum/midpoint/provisioning/ucf/api/PropertyModificationOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/provisioning/ucf-impl-connid/src/test/resources/connector-dummy.xml
+++ b/provisioning/ucf-impl-connid/src/test/resources/connector-dummy.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/provisioning/ucf-impl-connid/src/test/resources/logback-test.xml
+++ b/provisioning/ucf-impl-connid/src/test/resources/logback-test.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/provisioning/ucf-impl-connid/src/test/resources/resource-dummy.xml
+++ b/provisioning/ucf-impl-connid/src/test/resources/resource-dummy.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/provisioning/ucf-impl-connid/src/test/resources/resource-opendj-bad.xml
+++ b/provisioning/ucf-impl-connid/src/test/resources/resource-opendj-bad.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/provisioning/ucf-impl-connid/src/test/resources/resource-opendj.xml
+++ b/provisioning/ucf-impl-connid/src/test/resources/resource-opendj.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/repo/audit-api/pom.xml
+++ b/repo/audit-api/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/repo/audit-api/src/main/java/com/evolveum/midpoint/audit/api/AuditEventRecord.java
+++ b/repo/audit-api/src/main/java/com/evolveum/midpoint/audit/api/AuditEventRecord.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/repo/audit-api/src/main/java/com/evolveum/midpoint/audit/api/AuditService.java
+++ b/repo/audit-api/src/main/java/com/evolveum/midpoint/audit/api/AuditService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/repo/audit-api/testng-unit.xml
+++ b/repo/audit-api/testng-unit.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/repo/audit-impl/pom.xml
+++ b/repo/audit-impl/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/repo/audit-impl/src/main/java/com/evolveum/midpoint/audit/impl/LoggerAuditServiceImpl.java
+++ b/repo/audit-impl/src/main/java/com/evolveum/midpoint/audit/impl/LoggerAuditServiceImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/repo/audit-impl/src/main/resources/ctx-audit.xml
+++ b/repo/audit-impl/src/main/resources/ctx-audit.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/repo/audit-impl/src/test/resources/ctx-audit-test.xml
+++ b/repo/audit-impl/src/test/resources/ctx-audit-test.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/repo/audit-impl/src/test/resources/logback-test.xml
+++ b/repo/audit-impl/src/test/resources/logback-test.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/repo/audit-impl/testng-integration.xml
+++ b/repo/audit-impl/testng-integration.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/repo/repo-api/pom.xml
+++ b/repo/repo-api/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/repo/repo-api/testng-unit.xml
+++ b/repo/repo-api/testng-unit.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/repo/repo-cache/pom.xml
+++ b/repo/repo-cache/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/repo/repo-cache/src/main/java/com/evolveum/midpoint/repo/cache/RepositoryCache.java
+++ b/repo/repo-cache/src/main/java/com/evolveum/midpoint/repo/cache/RepositoryCache.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/repo/repo-cache/src/main/resources/ctx-repo-cache.xml
+++ b/repo/repo-cache/src/main/resources/ctx-repo-cache.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/repo/repo-cache/testng-unit.xml
+++ b/repo/repo-cache/testng-unit.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/repo/repo-sql-impl-test/pom.xml
+++ b/repo/repo-sql-impl-test/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/repo/repo-sql-impl-test/src/main/java/com/evolveum/midpoint/repo/sql/testing/TestSqlAuditServiceFactory.java
+++ b/repo/repo-sql-impl-test/src/main/java/com/evolveum/midpoint/repo/sql/testing/TestSqlAuditServiceFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/repo/repo-sql-impl-test/src/main/resources/ctx-repository-session-test.xml
+++ b/repo/repo-sql-impl-test/src/main/resources/ctx-repository-session-test.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/repo/repo-sql-impl-test/src/main/resources/ctx-repository-test.xml
+++ b/repo/repo-sql-impl-test/src/main/resources/ctx-repository-test.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/repo/repo-sql-impl-test/src/test/java/com/evolveum/midpoint/repo/sql/CertificationTestReindex.java
+++ b/repo/repo-sql-impl-test/src/test/java/com/evolveum/midpoint/repo/sql/CertificationTestReindex.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/repo/repo-sql-impl-test/src/test/java/com/evolveum/midpoint/repo/sql/EncodingTest.java
+++ b/repo/repo-sql-impl-test/src/test/java/com/evolveum/midpoint/repo/sql/EncodingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/repo/repo-sql-impl-test/src/test/java/com/evolveum/midpoint/repo/sql/LookupTableTestReindex.java
+++ b/repo/repo-sql-impl-test/src/test/java/com/evolveum/midpoint/repo/sql/LookupTableTestReindex.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/repo/repo-sql-impl-test/src/test/java/com/evolveum/midpoint/repo/sql/ModifyTest.java
+++ b/repo/repo-sql-impl-test/src/test/java/com/evolveum/midpoint/repo/sql/ModifyTest.java
@@ -1,5 +1,5 @@
 /*
-  * Copyright (c) 2010-2016 Evolveum
+  * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/repo/repo-sql-impl-test/src/test/java/com/evolveum/midpoint/repo/sql/ModifyTestReindex.java
+++ b/repo/repo-sql-impl-test/src/test/java/com/evolveum/midpoint/repo/sql/ModifyTestReindex.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/repo/repo-sql-impl-test/src/test/resources/basic/account-accountTypeShadow.xml
+++ b/repo/repo-sql-impl-test/src/test/resources/basic/account-accountTypeShadow.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/repo/repo-sql-impl-test/src/test/resources/basic/account-full.xml
+++ b/repo/repo-sql-impl-test/src/test/resources/basic/account-full.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/repo/repo-sql-impl-test/src/test/resources/basic/account-shadow.xml
+++ b/repo/repo-sql-impl-test/src/test/resources/basic/account-shadow.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/repo/repo-sql-impl-test/src/test/resources/basic/import-overwrite.xml
+++ b/repo/repo-sql-impl-test/src/test/resources/basic/import-overwrite.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/repo/repo-sql-impl-test/src/test/resources/basic/objects-2.xml
+++ b/repo/repo-sql-impl-test/src/test/resources/basic/objects-2.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/repo/repo-sql-impl-test/src/test/resources/basic/objects-user.xml
+++ b/repo/repo-sql-impl-test/src/test/resources/basic/objects-user.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/repo/repo-sql-impl-test/src/test/resources/basic/objects.xml
+++ b/repo/repo-sql-impl-test/src/test/resources/basic/objects.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/repo/repo-sql-impl-test/src/test/resources/basic/password-policy.xml
+++ b/repo/repo-sql-impl-test/src/test/resources/basic/password-policy.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/repo/repo-sql-impl-test/src/test/resources/basic/resource-opendj.xml
+++ b/repo/repo-sql-impl-test/src/test/resources/basic/resource-opendj.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/repo/repo-sql-impl-test/src/test/resources/basic/role-resource-filter.xml
+++ b/repo/repo-sql-impl-test/src/test/resources/basic/role-resource-filter.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/repo/repo-sql-impl-test/src/test/resources/basic/systemConfiguration.xml
+++ b/repo/repo-sql-impl-test/src/test/resources/basic/systemConfiguration.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/repo/repo-sql-impl-test/src/test/resources/basic/t002.xml
+++ b/repo/repo-sql-impl-test/src/test/resources/basic/t002.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/repo/repo-sql-impl-test/src/test/resources/basic/t002a.xml
+++ b/repo/repo-sql-impl-test/src/test/resources/basic/t002a.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/repo/repo-sql-impl-test/src/test/resources/basic/t002b.xml
+++ b/repo/repo-sql-impl-test/src/test/resources/basic/t002b.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/repo/repo-sql-impl-test/src/test/resources/basic/t003.xml
+++ b/repo/repo-sql-impl-test/src/test/resources/basic/t003.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/repo/repo-sql-impl-test/src/test/resources/basic/t004.xml
+++ b/repo/repo-sql-impl-test/src/test/resources/basic/t004.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/repo/repo-sql-impl-test/src/test/resources/basic/tasks.xml
+++ b/repo/repo-sql-impl-test/src/test/resources/basic/tasks.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/repo/repo-sql-impl-test/src/test/resources/basic/user-assignment-extension.xml
+++ b/repo/repo-sql-impl-test/src/test/resources/basic/user-assignment-extension.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/repo/repo-sql-impl-test/src/test/resources/basic/user-big.xml
+++ b/repo/repo-sql-impl-test/src/test/resources/basic/user-big.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/repo/repo-sql-impl-test/src/test/resources/basic/user-same-ids.xml
+++ b/repo/repo-sql-impl-test/src/test/resources/basic/user-same-ids.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 
 <!--
-  ~ Copyright (c) 2010-2014 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/repo/repo-sql-impl-test/src/test/resources/basic/user.xml
+++ b/repo/repo-sql-impl-test/src/test/resources/basic/user.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/repo/repo-sql-impl-test/src/test/resources/cert/cert-campaign-1.xml
+++ b/repo/repo-sql-impl-test/src/test/resources/cert/cert-campaign-1.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/repo/repo-sql-impl-test/src/test/resources/cert/cert-campaign-2.xml
+++ b/repo/repo-sql-impl-test/src/test/resources/cert/cert-campaign-2.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/repo/repo-sql-impl-test/src/test/resources/concurrency/user.xml
+++ b/repo/repo-sql-impl-test/src/test/resources/concurrency/user.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/repo/repo-sql-impl-test/src/test/resources/config-test-datasource.xml
+++ b/repo/repo-sql-impl-test/src/test/resources/config-test-datasource.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/repo/repo-sql-impl-test/src/test/resources/config-test.xml
+++ b/repo/repo-sql-impl-test/src/test/resources/config-test.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/repo/repo-sql-impl-test/src/test/resources/ctx-configuration-sql-test.xml
+++ b/repo/repo-sql-impl-test/src/test/resources/ctx-configuration-sql-test.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/repo/repo-sql-impl-test/src/test/resources/delete/shadow.xml
+++ b/repo/repo-sql-impl-test/src/test/resources/delete/shadow.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/repo/repo-sql-impl-test/src/test/resources/get/expected-user.xml
+++ b/repo/repo-sql-impl-test/src/test/resources/get/expected-user.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/repo/repo-sql-impl-test/src/test/resources/get/user.xml
+++ b/repo/repo-sql-impl-test/src/test/resources/get/user.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/repo/repo-sql-impl-test/src/test/resources/logback-test.xml
+++ b/repo/repo-sql-impl-test/src/test/resources/logback-test.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/repo/repo-sql-impl-test/src/test/resources/lookup/table-0.xml
+++ b/repo/repo-sql-impl-test/src/test/resources/lookup/table-0.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/repo/repo-sql-impl-test/src/test/resources/lookup/table-1.xml
+++ b/repo/repo-sql-impl-test/src/test/resources/lookup/table-1.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/repo/repo-sql-impl-test/src/test/resources/modify/account-delete-object-change.xml
+++ b/repo/repo-sql-impl-test/src/test/resources/modify/account-delete-object-change.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/repo/repo-sql-impl-test/src/test/resources/modify/account-synchronization-situation.xml
+++ b/repo/repo-sql-impl-test/src/test/resources/modify/account-synchronization-situation.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/repo/repo-sql-impl-test/src/test/resources/modify/account.xml
+++ b/repo/repo-sql-impl-test/src/test/resources/modify/account.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/repo/repo-sql-impl-test/src/test/resources/modify/assignment/modify-add-assignment.xml
+++ b/repo/repo-sql-impl-test/src/test/resources/modify/assignment/modify-add-assignment.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/repo/repo-sql-impl-test/src/test/resources/modify/assignment/modify-add-inducement.xml
+++ b/repo/repo-sql-impl-test/src/test/resources/modify/assignment/modify-add-inducement.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/repo/repo-sql-impl-test/src/test/resources/modify/assignment/modify-assignment.xml
+++ b/repo/repo-sql-impl-test/src/test/resources/modify/assignment/modify-assignment.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/repo/repo-sql-impl-test/src/test/resources/modify/assignment/modify-delete-add-assignment.xml
+++ b/repo/repo-sql-impl-test/src/test/resources/modify/assignment/modify-delete-add-assignment.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/repo/repo-sql-impl-test/src/test/resources/modify/assignment/modify-delete-assignment.xml
+++ b/repo/repo-sql-impl-test/src/test/resources/modify/assignment/modify-delete-assignment.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/repo/repo-sql-impl-test/src/test/resources/modify/assignment/modify-delete-inducement.xml
+++ b/repo/repo-sql-impl-test/src/test/resources/modify/assignment/modify-delete-inducement.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/repo/repo-sql-impl-test/src/test/resources/modify/assignment/modify-inducement.xml
+++ b/repo/repo-sql-impl-test/src/test/resources/modify/assignment/modify-inducement.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/repo/repo-sql-impl-test/src/test/resources/modify/assignment/role.xml
+++ b/repo/repo-sql-impl-test/src/test/resources/modify/assignment/role.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/repo/repo-sql-impl-test/src/test/resources/modify/change-add-non-existing.xml
+++ b/repo/repo-sql-impl-test/src/test/resources/modify/change-add-non-existing.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/repo/repo-sql-impl-test/src/test/resources/modify/change-add.xml
+++ b/repo/repo-sql-impl-test/src/test/resources/modify/change-add.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/repo/repo-sql-impl-test/src/test/resources/modify/change-name.xml
+++ b/repo/repo-sql-impl-test/src/test/resources/modify/change-name.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/repo/repo-sql-impl-test/src/test/resources/modify/modify-orgStruct-add-orgref.xml
+++ b/repo/repo-sql-impl-test/src/test/resources/modify/modify-orgStruct-add-orgref.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/repo/repo-sql-impl-test/src/test/resources/modify/modify-orgStruct-add-user.xml
+++ b/repo/repo-sql-impl-test/src/test/resources/modify/modify-orgStruct-add-user.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/repo/repo-sql-impl-test/src/test/resources/modify/modify-orgStruct-replace.xml
+++ b/repo/repo-sql-impl-test/src/test/resources/modify/modify-orgStruct-replace.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/repo/repo-sql-impl-test/src/test/resources/modify/modify-user-add-roles.xml
+++ b/repo/repo-sql-impl-test/src/test/resources/modify/modify-user-add-roles.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/repo/repo-sql-impl-test/src/test/resources/modify/modify-user.xml
+++ b/repo/repo-sql-impl-test/src/test/resources/modify/modify-user.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/repo/repo-sql-impl-test/src/test/resources/modify/resource-csv.xml
+++ b/repo/repo-sql-impl-test/src/test/resources/modify/resource-csv.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/repo/repo-sql-impl-test/src/test/resources/modify/resource-opendj.xml
+++ b/repo/repo-sql-impl-test/src/test/resources/modify/resource-opendj.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/repo/repo-sql-impl-test/src/test/resources/modify/role-csv.xml
+++ b/repo/repo-sql-impl-test/src/test/resources/modify/role-csv.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/repo/repo-sql-impl-test/src/test/resources/modify/role-ldap.xml
+++ b/repo/repo-sql-impl-test/src/test/resources/modify/role-ldap.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/repo/repo-sql-impl-test/src/test/resources/modify/role-modify-change.xml
+++ b/repo/repo-sql-impl-test/src/test/resources/modify/role-modify-change.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/repo/repo-sql-impl-test/src/test/resources/modify/role-modify.xml
+++ b/repo/repo-sql-impl-test/src/test/resources/modify/role-modify.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/repo/repo-sql-impl-test/src/test/resources/modify/task.xml
+++ b/repo/repo-sql-impl-test/src/test/resources/modify/task.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/repo/repo-sql-impl-test/src/test/resources/modify/user-with-extension.xml
+++ b/repo/repo-sql-impl-test/src/test/resources/modify/user-with-extension.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/repo/repo-sql-impl-test/src/test/resources/modify/user.xml
+++ b/repo/repo-sql-impl-test/src/test/resources/modify/user.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/repo/repo-sql-impl-test/src/test/resources/orgstruct/modify-orgStruct-add-orgref.xml
+++ b/repo/repo-sql-impl-test/src/test/resources/orgstruct/modify-orgStruct-add-orgref.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/repo/repo-sql-impl-test/src/test/resources/orgstruct/modify-orgStruct-add-user.xml
+++ b/repo/repo-sql-impl-test/src/test/resources/orgstruct/modify-orgStruct-add-user.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/repo/repo-sql-impl-test/src/test/resources/orgstruct/modify-orgStruct-delete-ref.xml
+++ b/repo/repo-sql-impl-test/src/test/resources/orgstruct/modify-orgStruct-delete-ref.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/repo/repo-sql-impl-test/src/test/resources/orgstruct/modify-orgStruct-incorrect-add-orgref.xml
+++ b/repo/repo-sql-impl-test/src/test/resources/orgstruct/modify-orgStruct-incorrect-add-orgref.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/repo/repo-sql-impl-test/src/test/resources/orgstruct/modify-orgStruct-incorrect-delete-ref.xml
+++ b/repo/repo-sql-impl-test/src/test/resources/orgstruct/modify-orgStruct-incorrect-delete-ref.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/repo/repo-sql-impl-test/src/test/resources/orgstruct/modify-orgStruct-replace.xml
+++ b/repo/repo-sql-impl-test/src/test/resources/orgstruct/modify-orgStruct-replace.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/repo/repo-sql-impl-test/src/test/resources/orgstruct/org-monkey-island-incorrect.xml
+++ b/repo/repo-sql-impl-test/src/test/resources/orgstruct/org-monkey-island-incorrect.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/repo/repo-sql-impl-test/src/test/resources/orgstruct/org-monkey-island.xml
+++ b/repo/repo-sql-impl-test/src/test/resources/orgstruct/org-monkey-island.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/repo/repo-sql-impl-test/src/test/resources/orgstruct/query-org-struct-org-depth.xml
+++ b/repo/repo-sql-impl-test/src/test/resources/orgstruct/query-org-struct-org-depth.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/repo/repo-sql-impl-test/src/test/resources/orgstruct/query-org-struct-user-unbounded.xml
+++ b/repo/repo-sql-impl-test/src/test/resources/orgstruct/query-org-struct-user-unbounded.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/repo/repo-sql-impl-test/src/test/resources/photo/org.xml
+++ b/repo/repo-sql-impl-test/src/test/resources/photo/org.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/repo/repo-sql-impl-test/src/test/resources/photo/t001-add-employeeType.xml
+++ b/repo/repo-sql-impl-test/src/test/resources/photo/t001-add-employeeType.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/repo/repo-sql-impl-test/src/test/resources/photo/t002-remove-photo.xml
+++ b/repo/repo-sql-impl-test/src/test/resources/photo/t002-remove-photo.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/repo/repo-sql-impl-test/src/test/resources/photo/t003-re-add-photo.xml
+++ b/repo/repo-sql-impl-test/src/test/resources/photo/t003-re-add-photo.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/repo/repo-sql-impl-test/src/test/resources/photo/t004-change-photo.xml
+++ b/repo/repo-sql-impl-test/src/test/resources/photo/t004-change-photo.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/repo/repo-sql-impl-test/src/test/resources/photo/t005-add-photo-by-add.xml
+++ b/repo/repo-sql-impl-test/src/test/resources/photo/t005-add-photo-by-add.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/repo/repo-sql-impl-test/src/test/resources/photo/t006-add-photo-by-add-other.xml
+++ b/repo/repo-sql-impl-test/src/test/resources/photo/t006-add-photo-by-add-other.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/repo/repo-sql-impl-test/src/test/resources/photo/t007-remove-photo-by-delete.xml
+++ b/repo/repo-sql-impl-test/src/test/resources/photo/t007-remove-photo-by-delete.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/repo/repo-sql-impl-test/src/test/resources/photo/t008-remove-other-photo-by-delete.xml
+++ b/repo/repo-sql-impl-test/src/test/resources/photo/t008-remove-other-photo-by-delete.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/repo/repo-sql-impl-test/src/test/resources/photo/t101-add-org-type.xml
+++ b/repo/repo-sql-impl-test/src/test/resources/photo/t101-add-org-type.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/repo/repo-sql-impl-test/src/test/resources/photo/t102-remove-photo.xml
+++ b/repo/repo-sql-impl-test/src/test/resources/photo/t102-remove-photo.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/repo/repo-sql-impl-test/src/test/resources/photo/t103-re-add-photo.xml
+++ b/repo/repo-sql-impl-test/src/test/resources/photo/t103-re-add-photo.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/repo/repo-sql-impl-test/src/test/resources/photo/t104-change-photo.xml
+++ b/repo/repo-sql-impl-test/src/test/resources/photo/t104-change-photo.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/repo/repo-sql-impl-test/src/test/resources/photo/t105-add-photo-by-add.xml
+++ b/repo/repo-sql-impl-test/src/test/resources/photo/t105-add-photo-by-add.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/repo/repo-sql-impl-test/src/test/resources/photo/t106-add-photo-by-add-other.xml
+++ b/repo/repo-sql-impl-test/src/test/resources/photo/t106-add-photo-by-add-other.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/repo/repo-sql-impl-test/src/test/resources/photo/t107-remove-photo-by-delete.xml
+++ b/repo/repo-sql-impl-test/src/test/resources/photo/t107-remove-photo-by-delete.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/repo/repo-sql-impl-test/src/test/resources/photo/t108-remove-other-photo-by-delete.xml
+++ b/repo/repo-sql-impl-test/src/test/resources/photo/t108-remove-other-photo-by-delete.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/repo/repo-sql-impl-test/src/test/resources/photo/user.xml
+++ b/repo/repo-sql-impl-test/src/test/resources/photo/user.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/repo/repo-sql-impl-test/src/test/resources/query/query-account-by-attribute-and-extension-value.xml
+++ b/repo/repo-sql-impl-test/src/test/resources/query/query-account-by-attribute-and-extension-value.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/repo/repo-sql-impl-test/src/test/resources/query/query-account-by-attribute.xml
+++ b/repo/repo-sql-impl-test/src/test/resources/query/query-account-by-attribute.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/repo/repo-sql-impl-test/src/test/resources/query/query-account-by-attributes-and-resource-ref.xml
+++ b/repo/repo-sql-impl-test/src/test/resources/query/query-account-by-attributes-and-resource-ref.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/repo/repo-sql-impl-test/src/test/resources/query/query-and-generic.xml
+++ b/repo/repo-sql-impl-test/src/test/resources/query/query-and-generic.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/repo/repo-sql-impl-test/src/test/resources/query/query-connector-by-type.xml
+++ b/repo/repo-sql-impl-test/src/test/resources/query/query-connector-by-type.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/repo/repo-sql-impl-test/src/test/resources/query/query-or-composite.xml
+++ b/repo/repo-sql-impl-test/src/test/resources/query/query-or-composite.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/repo/repo-sql-impl-test/src/test/resources/query/query-user-by-enabled.xml
+++ b/repo/repo-sql-impl-test/src/test/resources/query/query-user-by-enabled.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/repo/repo-sql-impl-test/src/test/resources/query/query-user-by-fullName.xml
+++ b/repo/repo-sql-impl-test/src/test/resources/query/query-user-by-fullName.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/repo/repo-sql-impl-test/src/test/resources/query/query-user-by-name.xml
+++ b/repo/repo-sql-impl-test/src/test/resources/query/query-user-by-name.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/repo/repo-sql-impl-test/src/test/resources/query/query-user-substring-fullName.xml
+++ b/repo/repo-sql-impl-test/src/test/resources/query/query-user-substring-fullName.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/repo/repo-sql-impl-test/src/test/resources/sequence/sequence-bound-returned-wrapped.xml
+++ b/repo/repo-sql-impl-test/src/test/resources/sequence/sequence-bound-returned-wrapped.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/repo/repo-sql-impl-test/src/test/resources/sequence/sequence-bound.xml
+++ b/repo/repo-sql-impl-test/src/test/resources/sequence/sequence-bound.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/repo/repo-sql-impl-test/src/test/resources/sequence/sequence-unbound.xml
+++ b/repo/repo-sql-impl-test/src/test/resources/sequence/sequence-unbound.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/repo/repo-sql-impl-test/testng-db-specific.xml
+++ b/repo/repo-sql-impl-test/testng-db-specific.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  ~ Copyright (c) 2010-2014 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/repo/repo-sql-impl-test/testng-integration.xml
+++ b/repo/repo-sql-impl-test/testng-integration.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/repo/repo-sql-impl/pom.xml
+++ b/repo/repo-sql-impl/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/repo/repo-sql-impl/src/main/java/com/evolveum/midpoint/repo/sql/data/common/RService.java
+++ b/repo/repo-sql-impl/src/main/java/com/evolveum/midpoint/repo/sql/data/common/RService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/repo/repo-sql-impl/src/main/java/com/evolveum/midpoint/repo/sql/helpers/BaseHelper.java
+++ b/repo/repo-sql-impl/src/main/java/com/evolveum/midpoint/repo/sql/helpers/BaseHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/repo/repo-sql-impl/src/main/java/com/evolveum/midpoint/repo/sql/util/MidPointJoinedPersister.java
+++ b/repo/repo-sql-impl/src/main/java/com/evolveum/midpoint/repo/sql/util/MidPointJoinedPersister.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/repo/repo-sql-impl/src/main/java/com/evolveum/midpoint/repo/sql/util/MidPointSingleTablePersister.java
+++ b/repo/repo-sql-impl/src/main/java/com/evolveum/midpoint/repo/sql/util/MidPointSingleTablePersister.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/repo/repo-sql-impl/src/main/java/com/evolveum/midpoint/repo/sql/util/MidpointPersisterUtil.java
+++ b/repo/repo-sql-impl/src/main/java/com/evolveum/midpoint/repo/sql/util/MidpointPersisterUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/repo/repo-sql-impl/src/main/resources/ctx-repository-session.xml
+++ b/repo/repo-sql-impl/src/main/resources/ctx-repository-session.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/repo/repo-sql-impl/src/main/resources/ctx-repository.xml
+++ b/repo/repo-sql-impl/src/main/resources/ctx-repository.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/repo/repo-sql-impl/src/test/resources/logback-test.xml
+++ b/repo/repo-sql-impl/src/test/resources/logback-test.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/repo/repo-sql-impl/testng-integration.xml
+++ b/repo/repo-sql-impl/testng-integration.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/repo/repo-test-util/pom.xml
+++ b/repo/repo-test-util/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/repo/repo-test-util/src/main/java/com/evolveum/midpoint/test/DummyAuditService.java
+++ b/repo/repo-test-util/src/main/java/com/evolveum/midpoint/test/DummyAuditService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/repo/repo-test-util/src/main/resources/test-config-no-repo.xml
+++ b/repo/repo-test-util/src/main/resources/test-config-no-repo.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/repo/repo-test-util/testng-unit.xml
+++ b/repo/repo-test-util/testng-unit.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/repo/security-api/src/main/java/com/evolveum/midpoint/security/api/MidPointPrincipal.java
+++ b/repo/security-api/src/main/java/com/evolveum/midpoint/security/api/MidPointPrincipal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/repo/security-api/testng-unit.xml
+++ b/repo/security-api/testng-unit.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/repo/security-impl/src/test/java/com/evolveum/midpoint/security/impl/UserProfileServiceMock.java
+++ b/repo/security-impl/src/test/java/com/evolveum/midpoint/security/impl/UserProfileServiceMock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/repo/security-impl/src/test/resources/ctx-security-test-main.xml
+++ b/repo/security-impl/src/test/resources/ctx-security-test-main.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/repo/security-impl/src/test/resources/ctx-security-test.xml
+++ b/repo/security-impl/src/test/resources/ctx-security-test.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/repo/security-impl/src/test/resources/logback-test.xml
+++ b/repo/security-impl/src/test/resources/logback-test.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/repo/security-impl/src/test/resources/system-configuration.xml
+++ b/repo/security-impl/src/test/resources/system-configuration.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <!--
-  ~ Copyright (c) 2016 Evolveum
+  ~ Copyright (c) 2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/repo/security-impl/src/test/resources/user-jack.xml
+++ b/repo/security-impl/src/test/resources/user-jack.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/repo/security-impl/testng-unit.xml
+++ b/repo/security-impl/testng-unit.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2014 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/repo/system-init/pom.xml
+++ b/repo/system-init/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/repo/system-init/src/main/java/com/evolveum/midpoint/init/ApplicationHomeSetup.java
+++ b/repo/system-init/src/main/java/com/evolveum/midpoint/init/ApplicationHomeSetup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/repo/system-init/src/main/java/com/evolveum/midpoint/init/AuditServiceProxy.java
+++ b/repo/system-init/src/main/java/com/evolveum/midpoint/init/AuditServiceProxy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/repo/system-init/src/main/resources/config.xml
+++ b/repo/system-init/src/main/resources/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/repo/system-init/src/main/resources/ctx-configuration.xml
+++ b/repo/system-init/src/main/resources/ctx-configuration.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/repo/system-init/src/test/resources/logback-test.xml
+++ b/repo/system-init/src/test/resources/logback-test.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/repo/system-init/testng-unit.xml
+++ b/repo/system-init/testng-unit.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/repo/task-api/pom.xml
+++ b/repo/task-api/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/repo/task-api/src/main/java/com/evolveum/midpoint/task/api/TaskConstants.java
+++ b/repo/task-api/src/main/java/com/evolveum/midpoint/task/api/TaskConstants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/repo/task-api/src/main/java/com/evolveum/midpoint/task/api/TaskDeletionListener.java
+++ b/repo/task-api/src/main/java/com/evolveum/midpoint/task/api/TaskDeletionListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/repo/task-api/testng-unit.xml
+++ b/repo/task-api/testng-unit.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/repo/task-quartz-impl/pom.xml
+++ b/repo/task-quartz-impl/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/repo/task-quartz-impl/src/main/java/com/evolveum/midpoint/task/quartzimpl/TaskQuartzImpl.java
+++ b/repo/task-quartz-impl/src/main/java/com/evolveum/midpoint/task/quartzimpl/TaskQuartzImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/repo/task-quartz-impl/src/main/java/com/evolveum/midpoint/task/quartzimpl/execution/JobStarter.java
+++ b/repo/task-quartz-impl/src/main/java/com/evolveum/midpoint/task/quartzimpl/execution/JobStarter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/repo/task-quartz-impl/src/main/java/com/evolveum/midpoint/task/quartzimpl/handlers/JdbcPingTaskHandler.java
+++ b/repo/task-quartz-impl/src/main/java/com/evolveum/midpoint/task/quartzimpl/handlers/JdbcPingTaskHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/repo/task-quartz-impl/src/main/resources/ctx-task.xml
+++ b/repo/task-quartz-impl/src/main/resources/ctx-task.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/repo/task-quartz-impl/src/test/java/com/evolveum/midpoint/task/quartzimpl/MockLongTaskHandler.java
+++ b/repo/task-quartz-impl/src/test/java/com/evolveum/midpoint/task/quartzimpl/MockLongTaskHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/repo/task-quartz-impl/src/test/resources/ctx-task-test.xml
+++ b/repo/task-quartz-impl/src/test/resources/ctx-task-test.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/repo/task-quartz-impl/src/test/resources/logback-test.xml
+++ b/repo/task-quartz-impl/src/test/resources/logback-test.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/repo/task-quartz-impl/src/test/resources/repo/owner.xml
+++ b/repo/task-quartz-impl/src/test/resources/repo/owner.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/repo/task-quartz-impl/src/test/resources/repo/owner2.xml
+++ b/repo/task-quartz-impl/src/test/resources/repo/owner2.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/repo/task-quartz-impl/src/test/resources/repo/task-001TaskToken.xml
+++ b/repo/task-quartz-impl/src/test/resources/repo/task-001TaskToken.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/repo/task-quartz-impl/src/test/resources/repo/task-002OidPresence.xml
+++ b/repo/task-quartz-impl/src/test/resources/repo/task-002OidPresence.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/repo/task-quartz-impl/src/test/resources/repo/task-003GetProgress.xml
+++ b/repo/task-quartz-impl/src/test/resources/repo/task-003GetProgress.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/repo/task-quartz-impl/src/test/resources/repo/task-004TaskProperties.xml
+++ b/repo/task-quartz-impl/src/test/resources/repo/task-004TaskProperties.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/repo/task-quartz-impl/src/test/resources/repo/task-004aTaskBigProperty.xml
+++ b/repo/task-quartz-impl/src/test/resources/repo/task-004aTaskBigProperty.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/repo/task-quartz-impl/src/test/resources/repo/task-004bTaskBigProperty.xml
+++ b/repo/task-quartz-impl/src/test/resources/repo/task-004bTaskBigProperty.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/repo/task-quartz-impl/src/test/resources/repo/task-004cReferenceInExtension.xml
+++ b/repo/task-quartz-impl/src/test/resources/repo/task-004cReferenceInExtension.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/repo/task-quartz-impl/src/test/resources/repo/task-005Single.xml
+++ b/repo/task-quartz-impl/src/test/resources/repo/task-005Single.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/repo/task-quartz-impl/src/test/resources/repo/task-006Cycle.xml
+++ b/repo/task-quartz-impl/src/test/resources/repo/task-006Cycle.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/repo/task-quartz-impl/src/test/resources/repo/task-007Extension.xml
+++ b/repo/task-quartz-impl/src/test/resources/repo/task-007Extension.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/repo/task-quartz-impl/src/test/resources/repo/task-008MoreHandlers.xml
+++ b/repo/task-quartz-impl/src/test/resources/repo/task-008MoreHandlers.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/repo/task-quartz-impl/src/test/resources/repo/task-009CycleLoose.xml
+++ b/repo/task-quartz-impl/src/test/resources/repo/task-009CycleLoose.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/repo/task-quartz-impl/src/test/resources/repo/task-010CycleCronLoose.xml
+++ b/repo/task-quartz-impl/src/test/resources/repo/task-010CycleCronLoose.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/repo/task-quartz-impl/src/test/resources/repo/task-011MoreHandlersAndSchedules.xml
+++ b/repo/task-quartz-impl/src/test/resources/repo/task-011MoreHandlersAndSchedules.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/repo/task-quartz-impl/src/test/resources/repo/task-012Suspend.xml
+++ b/repo/task-quartz-impl/src/test/resources/repo/task-012Suspend.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/repo/task-quartz-impl/src/test/resources/repo/task-013ReleaseAndSuspendLooselyBound.xml
+++ b/repo/task-quartz-impl/src/test/resources/repo/task-013ReleaseAndSuspendLooselyBound.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/repo/task-quartz-impl/src/test/resources/repo/task-014SuspendLongRunning.xml
+++ b/repo/task-quartz-impl/src/test/resources/repo/task-014SuspendLongRunning.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/repo/task-quartz-impl/src/test/resources/repo/task-015DeleteTaskFromRepo.xml
+++ b/repo/task-quartz-impl/src/test/resources/repo/task-015DeleteTaskFromRepo.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/repo/task-quartz-impl/src/test/resources/repo/task-016WaitForSubtasks-child-1.xml
+++ b/repo/task-quartz-impl/src/test/resources/repo/task-016WaitForSubtasks-child-1.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/repo/task-quartz-impl/src/test/resources/repo/task-016WaitForSubtasks-prerequisite-1.xml
+++ b/repo/task-quartz-impl/src/test/resources/repo/task-016WaitForSubtasks-prerequisite-1.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/repo/task-quartz-impl/src/test/resources/repo/task-016WaitForSubtasks.xml
+++ b/repo/task-quartz-impl/src/test/resources/repo/task-016WaitForSubtasks.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/repo/task-quartz-impl/src/test/resources/repo/task-017WaitForSubtasksEmpty.xml
+++ b/repo/task-quartz-impl/src/test/resources/repo/task-017WaitForSubtasksEmpty.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/repo/task-quartz-impl/src/test/resources/repo/task-019FinishedHandler.xml
+++ b/repo/task-quartz-impl/src/test/resources/repo/task-019FinishedHandler.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/repo/task-quartz-impl/src/test/resources/repo/task-020QueryByExecutionStatus.xml
+++ b/repo/task-quartz-impl/src/test/resources/repo/task-020QueryByExecutionStatus.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/repo/task-quartz-impl/src/test/resources/repo/task-021DeleteTaskTree-child1.xml
+++ b/repo/task-quartz-impl/src/test/resources/repo/task-021DeleteTaskTree-child1.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/repo/task-quartz-impl/src/test/resources/repo/task-021DeleteTaskTree-child2.xml
+++ b/repo/task-quartz-impl/src/test/resources/repo/task-021DeleteTaskTree-child2.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/repo/task-quartz-impl/src/test/resources/repo/task-021DeleteTaskTree.xml
+++ b/repo/task-quartz-impl/src/test/resources/repo/task-021DeleteTaskTree.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/repo/task-quartz-impl/src/test/resources/repo/task-022ExecuteRecurringOnDemand.xml
+++ b/repo/task-quartz-impl/src/test/resources/repo/task-022ExecuteRecurringOnDemand.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/repo/task-quartz-impl/src/test/resources/repo/task-100LightweightSubtasks.xml
+++ b/repo/task-quartz-impl/src/test/resources/repo/task-100LightweightSubtasks.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2014 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/repo/task-quartz-impl/src/test/resources/repo/task-105LightweightSubtasksSuspension.xml
+++ b/repo/task-quartz-impl/src/test/resources/repo/task-105LightweightSubtasksSuspension.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2014 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/repo/task-quartz-impl/src/test/resources/repo/task-110GroupLimit-2.xml
+++ b/repo/task-quartz-impl/src/test/resources/repo/task-110GroupLimit-2.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/repo/task-quartz-impl/src/test/resources/repo/task-110GroupLimit.xml
+++ b/repo/task-quartz-impl/src/test/resources/repo/task-110GroupLimit.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/repo/task-quartz-impl/src/test/resources/repo/task-120NodeAllowed.xml
+++ b/repo/task-quartz-impl/src/test/resources/repo/task-120NodeAllowed.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/repo/task-quartz-impl/src/test/resources/repo/task-130NodeNotAllowed.xml
+++ b/repo/task-quartz-impl/src/test/resources/repo/task-130NodeNotAllowed.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/repo/task-quartz-impl/src/test/resources/repo/task-140NodeDisallowed.xml
+++ b/repo/task-quartz-impl/src/test/resources/repo/task-140NodeDisallowed.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/repo/task-quartz-impl/src/test/resources/repo/tasks-for-cleanup.xml
+++ b/repo/task-quartz-impl/src/test/resources/repo/tasks-for-cleanup.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/repo/task-quartz-impl/testng-integration.xml
+++ b/repo/task-quartz-impl/testng-integration.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/book/2/resource-crm.xml
+++ b/samples/book/2/resource-crm.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2016 Evolveum
+  ~ Copyright (c) 2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/book/2/resource-csv-hr-bare.xml
+++ b/samples/book/2/resource-csv-hr-bare.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/book/2/resource-csv-hr.xml
+++ b/samples/book/2/resource-csv-hr.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/book/2/resource-openldap-minimal.xml
+++ b/samples/book/2/resource-openldap-minimal.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2016 Evolveum
+  ~ Copyright (c) 2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/book/2/resource-openldap.xml
+++ b/samples/book/2/resource-openldap.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2016 Evolveum
+  ~ Copyright (c) 2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/book/2/resource-portal.xml
+++ b/samples/book/2/resource-portal.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2016 Evolveum
+  ~ Copyright (c) 2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/book/4/resource-openldap.xml
+++ b/samples/book/4/resource-openldap.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/book/5/resource-csv-hr.xml
+++ b/samples/book/5/resource-csv-hr.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/book/5/resource-openldap.xml
+++ b/samples/book/5/resource-openldap.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/certification/def-all-user-assignments.xml
+++ b/samples/certification/def-all-user-assignments.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/certification/def-role-inducements.xml
+++ b/samples/certification/def-role-inducements.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/certification/start-all-user-assignments.xml
+++ b/samples/certification/start-all-user-assignments.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/certification/start-role-inducements.xml
+++ b/samples/certification/start-role-inducements.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/demo-generic synchronization/object-template-user-GenSync.xml
+++ b/samples/demo-generic synchronization/object-template-user-GenSync.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/demo-generic synchronization/resource-GenSync-CSV.xml
+++ b/samples/demo-generic synchronization/resource-GenSync-CSV.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/demo-generic synchronization/resource-GenSync-OpenDJ.xml
+++ b/samples/demo-generic synchronization/resource-GenSync-OpenDJ.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/demo-generic synchronization/resource-GenSync-addressbook.xml
+++ b/samples/demo-generic synchronization/resource-GenSync-addressbook.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/demo-generic synchronization/role-gensync.xml
+++ b/samples/demo-generic synchronization/role-gensync.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2014 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/demo-generic synchronization/role-meta-replicated-org-GenSync.xml
+++ b/samples/demo-generic synchronization/role-meta-replicated-org-GenSync.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2014 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/demo-generic synchronization/role-meta-responsibility-GenSync.xml
+++ b/samples/demo-generic synchronization/role-meta-responsibility-GenSync.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2014 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/demo-rs/object-template-org.xml
+++ b/samples/demo-rs/object-template-org.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/demo-rs/object-template-user.xml
+++ b/samples/demo-rs/object-template-user.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/demo-rs/org-customers.xml
+++ b/samples/demo-rs/org-customers.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2014 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   -->
 
 <objects xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/samples/demo-rs/org-extern.xml
+++ b/samples/demo-rs/org-extern.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   -->
 
 <objects xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/samples/demo-rs/org.xml
+++ b/samples/demo-rs/org.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/demo-rs/resource-csv-source.xml
+++ b/samples/demo-rs/resource-csv-source.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/demo-rs/resource-csv-target.xml
+++ b/samples/demo-rs/resource-csv-target.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/demo-rs/resource-csv-xxx.xml
+++ b/samples/demo-rs/resource-csv-xxx.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/demo-rs/resource-ldap-opendj.xml
+++ b/samples/demo-rs/resource-ldap-opendj.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/demo-rs/resource-ldap-openldap.xml
+++ b/samples/demo-rs/resource-ldap-openldap.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2014 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/demo-rs/role-basic.xml
+++ b/samples/demo-rs/role-basic.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/demo-rs/role-boss.xml
+++ b/samples/demo-rs/role-boss.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/demo-rs/role-gold.xml
+++ b/samples/demo-rs/role-gold.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/demo-rs/role-meta-customer-project.xml
+++ b/samples/demo-rs/role-meta-customer-project.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2014 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/demo-rs/role-meta-customer.xml
+++ b/samples/demo-rs/role-meta-customer.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2014 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/demo-rs/role-meta-project.xml
+++ b/samples/demo-rs/role-meta-project.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2014 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/demo/PageBase.html
+++ b/samples/demo/PageBase.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/demo/addressbook.xml
+++ b/samples/demo/addressbook.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/demo/hr.xml
+++ b/samples/demo/hr.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/demo/opendj.xml
+++ b/samples/demo/opendj.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/demo/openldap.xml
+++ b/samples/demo/openldap.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/demo/org.xml
+++ b/samples/demo/org.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/demo/password-policy.xml
+++ b/samples/demo/password-policy.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/demo/role-contractor.xml
+++ b/samples/demo/role-contractor.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/demo/role-fte.xml
+++ b/samples/demo/role-fte.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/demo/role-patron.xml
+++ b/samples/demo/role-patron.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/demo/user-template.xml
+++ b/samples/demo/user-template.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/evolveum/object-template-org.xml
+++ b/samples/evolveum/object-template-org.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2016 Evolveum
+  ~ Copyright (c) 2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/evolveum/org-users.xml
+++ b/samples/evolveum/org-users.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2016 Evolveum
+  ~ Copyright (c) 2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/evolveum/resource-openldap.xml
+++ b/samples/evolveum/resource-openldap.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2016 Evolveum
+  ~ Copyright (c) 2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/evolveum/role-catalog.xml
+++ b/samples/evolveum/role-catalog.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2016 Evolveum
+  ~ Copyright (c) 2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/evolveum/role-meta-functional.xml
+++ b/samples/evolveum/role-meta-functional.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2016 Evolveum
+  ~ Copyright (c) 2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/evolveum/role-meta-project.xml
+++ b/samples/evolveum/role-meta-project.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2016 Evolveum
+  ~ Copyright (c) 2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/evolveum/roles.xml
+++ b/samples/evolveum/roles.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2016 Evolveum
+  ~ Copyright (c) 2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/misc/change-notification-1.xml
+++ b/samples/misc/change-notification-1.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/misc/changetype-1.xml
+++ b/samples/misc/changetype-1.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/misc/changetype-extension-1.xml
+++ b/samples/misc/changetype-extension-1.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/misc/objectmodification-jack-1.xml
+++ b/samples/misc/objectmodification-jack-1.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/misc/org-monkey-island-complex-experiment.xml
+++ b/samples/misc/org-monkey-island-complex-experiment.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/misc/query-1.xml
+++ b/samples/misc/query-1.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/misc/query-2.xml
+++ b/samples/misc/query-2.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/misc/query-3.xml
+++ b/samples/misc/query-3.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/model-client-sample/pom.xml
+++ b/samples/model-client-sample/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/model-client-sample/src/main/assembly/bin.xml
+++ b/samples/model-client-sample/src/main/assembly/bin.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2014 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/model-client-sample/src/main/bin/discover-rebind.xml
+++ b/samples/model-client-sample/src/main/bin/discover-rebind.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <!--
-  ~ Copyright (c) 2010-2014 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/model-client-sample/src/main/bin/discover.xml
+++ b/samples/model-client-sample/src/main/bin/discover.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <!--
-  ~ Copyright (c) 2010-2014 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/model-client-sample/src/main/bin/purge-schema.xml
+++ b/samples/model-client-sample/src/main/bin/purge-schema.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <!--
-  ~ Copyright (c) 2010-2014 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/model-client-sample/src/main/resources/role-sea-superuser.xml
+++ b/samples/model-client-sample/src/main/resources/role-sea-superuser.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/objects/account-jack.xml
+++ b/samples/objects/account-jack.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/objects/connector-dbtable.xml
+++ b/samples/objects/connector-dbtable.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/objects/connector-host-localhost.xml
+++ b/samples/objects/connector-host-localhost.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/objects/extended-notifications.xml
+++ b/samples/objects/extended-notifications.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/objects/object-template-action.xml
+++ b/samples/objects/object-template-action.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/objects/object-template-default.xml
+++ b/samples/objects/object-template-default.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/objects/object-template-user-nickname.xml
+++ b/samples/objects/object-template-user-nickname.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/objects/object-template-user.xml
+++ b/samples/objects/object-template-user.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/objects/sequence0-99.xml
+++ b/samples/objects/sequence0-99.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/objects/simple-notifications.xml
+++ b/samples/objects/simple-notifications.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/objects/user-ceresnickova.xml
+++ b/samples/objects/user-ceresnickova.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/objects/user-jack-with-password-no-oid.xml
+++ b/samples/objects/user-jack-with-password-no-oid.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/objects/user-jack-with-password.xml
+++ b/samples/objects/user-jack-with-password.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/objects/user-jack.xml
+++ b/samples/objects/user-jack.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/objects/user-template-complex.xml
+++ b/samples/objects/user-template-complex.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/objects/users-of-low-moral-fiber.xml
+++ b/samples/objects/users-of-low-moral-fiber.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/org/org-monkey-island-simple.xml
+++ b/samples/org/org-monkey-island-simple.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/policy/alphanumeric-password-policy.xml
+++ b/samples/policy/alphanumeric-password-policy.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/policy/complex-password-policy.xml
+++ b/samples/policy/complex-password-policy.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/policy/numeric-pin-first-nonzero-all-unique-policy.xml
+++ b/samples/policy/numeric-pin-first-nonzero-all-unique-policy.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/policy/numeric-pin-first-nonzero-policy.xml
+++ b/samples/policy/numeric-pin-first-nonzero-policy.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/policy/numeric-pin-policy.xml
+++ b/samples/policy/numeric-pin-policy.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/policy/permissive-password-policy.xml
+++ b/samples/policy/permissive-password-policy.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/pom.xml
+++ b/samples/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/reports/logins-in-last-24-hours.xml
+++ b/samples/reports/logins-in-last-24-hours.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/resources/389ds/389ds-legacy-connector.xml
+++ b/samples/resources/389ds/389ds-legacy-connector.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2014 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/resources/389ds/389ds-localhost-medium.xml
+++ b/samples/resources/389ds/389ds-localhost-medium.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/resources/ad-ldap/ad-ldap-medusa-exchange.xml
+++ b/samples/resources/ad-ldap/ad-ldap-medusa-exchange.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2016 Evolveum
+  ~ Copyright (c) 2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/resources/ad-ldap/ad-ldap-medusa-medium.xml
+++ b/samples/resources/ad-ldap/ad-ldap-medusa-medium.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2016 Evolveum
+  ~ Copyright (c) 2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/resources/ad/ad-resource-advanced-nosync.xml
+++ b/samples/resources/ad/ad-resource-advanced-nosync.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/resources/ad/ad-resource-advanced-sync.xml
+++ b/samples/resources/ad/ad-resource-advanced-sync.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/resources/ad/ad-resource-groups-advanced.xml
+++ b/samples/resources/ad/ad-resource-groups-advanced.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/resources/ad/ad-resource-groups-basic.xml
+++ b/samples/resources/ad/ad-resource-groups-basic.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/resources/ad/ad-resource-groups-medusa-advanced.xml
+++ b/samples/resources/ad/ad-resource-groups-medusa-advanced.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/resources/ad/ad-resource-simple.xml
+++ b/samples/resources/ad/ad-resource-simple.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/resources/cmd/CreateScript.sh
+++ b/samples/resources/cmd/CreateScript.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 #/*
- #* Copyright (c) 2010-2016 Evolveum
+ #* Copyright (c) 2010-2017 Evolveum
  #*
  #* Licensed under the Apache License, Version 2.0 (the "License");
  #* you may not use this file except in compliance with the License.

--- a/samples/resources/cmd/SearchScript.sh
+++ b/samples/resources/cmd/SearchScript.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 #/*
- #* Copyright (c) 2010-2016 Evolveum
+ #* Copyright (c) 2010-2017 Evolveum
  #*
  #* Licensed under the Apache License, Version 2.0 (the "License");
  #* you may not use this file except in compliance with the License.

--- a/samples/resources/cmd/UpdateScript.sh
+++ b/samples/resources/cmd/UpdateScript.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 #/*
- #* Copyright (c) 2010-2016 Evolveum
+ #* Copyright (c) 2010-2017 Evolveum
  #*
  #* Licensed under the Apache License, Version 2.0 (the "License");
  #* you may not use this file except in compliance with the License.

--- a/samples/resources/cmd/localhost-cmd-advanced-nosync.xml
+++ b/samples/resources/cmd/localhost-cmd-advanced-nosync.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/resources/csv/role-csvfile-groups-account.xml
+++ b/samples/resources/csv/role-csvfile-groups-account.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/resources/csv/role-csvfile-groups-basic-groups.xml
+++ b/samples/resources/csv/role-csvfile-groups-basic-groups.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/resources/csvfile/HR-csvfile-resource.xml
+++ b/samples/resources/csvfile/HR-csvfile-resource.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/resources/csvfile/localhost-csvfile-medium.xml
+++ b/samples/resources/csvfile/localhost-csvfile-medium.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/resources/csvfile/localhost-csvfile-resource-advanced-multi-nosync.xml
+++ b/samples/resources/csvfile/localhost-csvfile-resource-advanced-multi-nosync.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/resources/csvfile/localhost-csvfile-resource-advanced-nosync-2.xml
+++ b/samples/resources/csvfile/localhost-csvfile-resource-advanced-nosync-2.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/resources/csvfile/localhost-csvfile-resource-advanced-nosync-3.xml
+++ b/samples/resources/csvfile/localhost-csvfile-resource-advanced-nosync-3.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/resources/csvfile/localhost-csvfile-resource-advanced-nosync-4.xml
+++ b/samples/resources/csvfile/localhost-csvfile-resource-advanced-nosync-4.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/resources/csvfile/localhost-csvfile-resource-advanced-nosync-5.xml
+++ b/samples/resources/csvfile/localhost-csvfile-resource-advanced-nosync-5.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/resources/csvfile/localhost-csvfile-resource-advanced-nosync.xml
+++ b/samples/resources/csvfile/localhost-csvfile-resource-advanced-nosync.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/resources/csvfile/localhost-csvfile-resource-advanced-sync-2.xml
+++ b/samples/resources/csvfile/localhost-csvfile-resource-advanced-sync-2.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/resources/csvfile/localhost-csvfile-resource-advanced-sync.xml
+++ b/samples/resources/csvfile/localhost-csvfile-resource-advanced-sync.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/resources/csvfile/localhost-csvfile-resource-bulk-action.xml
+++ b/samples/resources/csvfile/localhost-csvfile-resource-bulk-action.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/resources/csvfile/localhost-csvfile-resource-import.xml
+++ b/samples/resources/csvfile/localhost-csvfile-resource-import.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/resources/csvfile/localhost-csvfile-resource-simple-remote.xml
+++ b/samples/resources/csvfile/localhost-csvfile-resource-simple-remote.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/resources/csvfile/localhost-csvfile-resource-simple.xml
+++ b/samples/resources/csvfile/localhost-csvfile-resource-simple.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/resources/csvfile/role-csvfile-groups.xml
+++ b/samples/resources/csvfile/role-csvfile-groups.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/resources/csvfile/role-csvfile-import.xml
+++ b/samples/resources/csvfile/role-csvfile-import.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/resources/csvfile/role-csvfile.xml
+++ b/samples/resources/csvfile/role-csvfile.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/resources/databasetable/localhost-dbtable-advanced-nosync-2.xml
+++ b/samples/resources/databasetable/localhost-dbtable-advanced-nosync-2.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/resources/databasetable/localhost-dbtable-advanced-nosync.xml
+++ b/samples/resources/databasetable/localhost-dbtable-advanced-nosync.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/resources/databasetable/localhost-dbtable-advanced-sync.xml
+++ b/samples/resources/databasetable/localhost-dbtable-advanced-sync.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/resources/databasetable/localhost-dbtable-simple.xml
+++ b/samples/resources/databasetable/localhost-dbtable-simple.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/resources/databasetable/postgresql/resource-dbtable-postgresql.xml
+++ b/samples/resources/databasetable/postgresql/resource-dbtable-postgresql.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2016 Evolveum
+  ~ Copyright (c) 2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/resources/dsee/odsee-localhost-advanced-nosync.xml
+++ b/samples/resources/dsee/odsee-localhost-advanced-nosync.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/resources/dsee/odsee-localhost-advanced-sync.xml
+++ b/samples/resources/dsee/odsee-localhost-advanced-sync.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/resources/edirectory/resource-edirectory-nosync.xml
+++ b/samples/resources/edirectory/resource-edirectory-nosync.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2016 Evolveum
+  ~ Copyright (c) 2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/resources/mysqluser/mysqluser-localhost-advanced-nosync.xml
+++ b/samples/resources/mysqluser/mysqluser-localhost-advanced-nosync.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/resources/mysqluser/mysqluser-localhost-simple.xml
+++ b/samples/resources/mysqluser/mysqluser-localhost-simple.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/resources/opendj/example-base-only.ldif
+++ b/samples/resources/opendj/example-base-only.ldif
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2010-2016 Evolveum
+# Copyright (c) 2010-2017 Evolveum
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/samples/resources/opendj/example.ldif
+++ b/samples/resources/opendj/example.ldif
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2010-2016 Evolveum
+# Copyright (c) 2010-2017 Evolveum
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/samples/resources/opendj/opendj-legacy-connector.xml
+++ b/samples/resources/opendj/opendj-legacy-connector.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/resources/opendj/opendj-localhost-basic.xml
+++ b/samples/resources/opendj/opendj-localhost-basic.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/resources/opendj/opendj-localhost-medium.xml
+++ b/samples/resources/opendj/opendj-localhost-medium.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/resources/opendj/opendj-localhost-resource-sync-advanced.xml
+++ b/samples/resources/opendj/opendj-localhost-resource-sync-advanced.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/resources/opendj/opendj-localhost-resource-sync-no-extension-advanced-2.xml
+++ b/samples/resources/opendj/opendj-localhost-resource-sync-no-extension-advanced-2.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/resources/opendj/opendj-localhost-resource-sync-no-extension-advanced-test.xml
+++ b/samples/resources/opendj/opendj-localhost-resource-sync-no-extension-advanced-test.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/resources/opendj/opendj-localhost-resource-sync-no-extension-advanced.xml
+++ b/samples/resources/opendj/opendj-localhost-resource-sync-no-extension-advanced.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/resources/opendj/opendj-resource-genericsync.xml
+++ b/samples/resources/opendj/opendj-resource-genericsync.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/resources/opendj/piracy/opendj-localhost-resource-sync-extension-pirates.xml
+++ b/samples/resources/opendj/piracy/opendj-localhost-resource-sync-extension-pirates.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/resources/openldap/openldap-localhost-advanced-sync-modifytimestamp.xml
+++ b/samples/resources/openldap/openldap-localhost-advanced-sync-modifytimestamp.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/resources/openldap/openldap-localhost-medium.xml
+++ b/samples/resources/openldap/openldap-localhost-medium.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/resources/sap/assignment/object-template-user.xml
+++ b/samples/resources/sap/assignment/object-template-user.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/resources/sap/assignment/sap-advanced.xml
+++ b/samples/resources/sap/assignment/sap-advanced.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/resources/scriptedrest/bitbucket/CreateScript.groovy
+++ b/samples/resources/scriptedrest/bitbucket/CreateScript.groovy
@@ -1,7 +1,7 @@
 import org.identityconnectors.framework.common.exceptions.AlreadyExistsException
 
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/samples/resources/scriptedrest/bitbucket/DeleteScript.groovy
+++ b/samples/resources/scriptedrest/bitbucket/DeleteScript.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/samples/resources/scriptedrest/bitbucket/SchemaScript.groovy
+++ b/samples/resources/scriptedrest/bitbucket/SchemaScript.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/samples/resources/scriptedrest/bitbucket/SearchScript.groovy
+++ b/samples/resources/scriptedrest/bitbucket/SearchScript.groovy
@@ -8,7 +8,7 @@ import static java.awt.RenderingHints.KEY_INTERPOLATION
 import static java.awt.RenderingHints.VALUE_INTERPOLATION_BICUBIC
 
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/samples/resources/scriptedrest/bitbucket/TestScript.groovy
+++ b/samples/resources/scriptedrest/bitbucket/TestScript.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/samples/resources/scriptedrest/bitbucket/UpdateScript.groovy
+++ b/samples/resources/scriptedrest/bitbucket/UpdateScript.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/samples/resources/scriptedrest/confluence-wiki/CreateScript.groovy
+++ b/samples/resources/scriptedrest/confluence-wiki/CreateScript.groovy
@@ -1,7 +1,7 @@
 import org.identityconnectors.framework.common.exceptions.AlreadyExistsException
 
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/samples/resources/scriptedrest/confluence-wiki/DeleteScript.groovy
+++ b/samples/resources/scriptedrest/confluence-wiki/DeleteScript.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/samples/resources/scriptedrest/confluence-wiki/SchemaScript.groovy
+++ b/samples/resources/scriptedrest/confluence-wiki/SchemaScript.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/samples/resources/scriptedrest/confluence-wiki/SearchScript.groovy
+++ b/samples/resources/scriptedrest/confluence-wiki/SearchScript.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/samples/resources/scriptedrest/confluence-wiki/TestScript.groovy
+++ b/samples/resources/scriptedrest/confluence-wiki/TestScript.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/samples/resources/scriptedrest/confluence-wiki/UpdateScript.groovy
+++ b/samples/resources/scriptedrest/confluence-wiki/UpdateScript.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/samples/resources/scriptedrest/jira/CreateScript.groovy
+++ b/samples/resources/scriptedrest/jira/CreateScript.groovy
@@ -1,7 +1,7 @@
 import org.identityconnectors.framework.common.exceptions.AlreadyExistsException
 
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/samples/resources/scriptedrest/jira/DeleteScript.groovy
+++ b/samples/resources/scriptedrest/jira/DeleteScript.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/samples/resources/scriptedrest/jira/SchemaScript.groovy
+++ b/samples/resources/scriptedrest/jira/SchemaScript.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/samples/resources/scriptedrest/jira/SearchScript.groovy
+++ b/samples/resources/scriptedrest/jira/SearchScript.groovy
@@ -1,7 +1,7 @@
 import groovyx.net.http.HttpResponseException
 
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/samples/resources/scriptedrest/jira/TestScript.groovy
+++ b/samples/resources/scriptedrest/jira/TestScript.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/samples/resources/scriptedrest/jira/UpdateScript.groovy
+++ b/samples/resources/scriptedrest/jira/UpdateScript.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/samples/resources/scriptedrest/thingspeak/CreateScript.groovy
+++ b/samples/resources/scriptedrest/thingspeak/CreateScript.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/samples/resources/scriptedrest/thingspeak/DeleteScript.groovy
+++ b/samples/resources/scriptedrest/thingspeak/DeleteScript.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/samples/resources/scriptedrest/thingspeak/SchemaScript.groovy
+++ b/samples/resources/scriptedrest/thingspeak/SchemaScript.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/samples/resources/scriptedrest/thingspeak/SearchScript.groovy
+++ b/samples/resources/scriptedrest/thingspeak/SearchScript.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/samples/resources/scriptedrest/thingspeak/TestScript.groovy
+++ b/samples/resources/scriptedrest/thingspeak/TestScript.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/samples/resources/scriptedrest/thingspeak/UpdateScript.groovy
+++ b/samples/resources/scriptedrest/thingspeak/UpdateScript.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/samples/resources/scriptedrest/thingspeak/resource.xml
+++ b/samples/resources/scriptedrest/thingspeak/resource.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/resources/scriptedsql/localhost-scriptedsql-advanced-nosync.xml
+++ b/samples/resources/scriptedsql/localhost-scriptedsql-advanced-nosync.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/resources/scriptedsql/localhost-scriptedsql-advanced-sync.xml
+++ b/samples/resources/scriptedsql/localhost-scriptedsql-advanced-sync.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/resources/scriptedsql/localhost-scriptedsql-simple.xml
+++ b/samples/resources/scriptedsql/localhost-scriptedsql-simple.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/resources/solaris/deimos-solaris-resource-redhat.xml
+++ b/samples/resources/solaris/deimos-solaris-resource-redhat.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/resources/solaris/radegast-solaris-resource-simple.xml
+++ b/samples/resources/solaris/radegast-solaris-resource-simple.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/rest/account-jack-csv.xml
+++ b/samples/rest/account-jack-csv.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/rest/account-jack-opendj.xml
+++ b/samples/rest/account-jack-opendj.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/rest/modification-assign-account.xml
+++ b/samples/rest/modification-assign-account.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/rest/modification-change-password.xml
+++ b/samples/rest/modification-change-password.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/rest/notify-change-modify-password.xml
+++ b/samples/rest/notify-change-modify-password.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-  ~ Copyright (c) 2010-2014 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/rest/notify-change-new-account.xml
+++ b/samples/rest/notify-change-new-account.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-  ~ Copyright (c) 2010-2014 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/rest/opendj-resource-sync.xml
+++ b/samples/rest/opendj-resource-sync.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/rest/query-all-accounts.xml
+++ b/samples/rest/query-all-accounts.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-  ~ Copyright (c) 2010-2014 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/rest/query-all-tasks.xml
+++ b/samples/rest/query-all-tasks.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-  ~ Copyright (c) 2010-2014 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/rest/query-all-users.xml
+++ b/samples/rest/query-all-users.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-  ~ Copyright (c) 2010-2014 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/rest/query-livesync-tasks.xml
+++ b/samples/rest/query-livesync-tasks.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-  ~ Copyright (c) 2010-2014 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/roles/approvals-complete.xml
+++ b/samples/roles/approvals-complete.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/roles/authorization-roles.xml
+++ b/samples/roles/authorization-roles.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/roles/role-basic-csv.xml
+++ b/samples/roles/role-basic-csv.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/roles/role-basic-user.xml
+++ b/samples/roles/role-basic-user.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/roles/role-basic.xml
+++ b/samples/roles/role-basic.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/roles/role-captain.xml
+++ b/samples/roles/role-captain.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/roles/role-domain-admin.xml
+++ b/samples/roles/role-domain-admin.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 Evolveum
+  ~ Copyright (c) 2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/roles/role-domain-auditor.xml
+++ b/samples/roles/role-domain-auditor.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 Evolveum
+  ~ Copyright (c) 2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/roles/role-domain-operator.xml
+++ b/samples/roles/role-domain-operator.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 Evolveum
+  ~ Copyright (c) 2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/roles/role-judge.xml
+++ b/samples/roles/role-judge.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/roles/role-manager-full-control.xml
+++ b/samples/roles/role-manager-full-control.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 Evolveum
+  ~ Copyright (c) 2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/roles/role-meta-replicated-org.xml
+++ b/samples/roles/role-meta-replicated-org.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2014 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/roles/role-meta-responsibility.xml
+++ b/samples/roles/role-meta-responsibility.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2014 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/roles/role-pirate-lord.xml
+++ b/samples/roles/role-pirate-lord.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/roles/role-pirate-opendj.xml
+++ b/samples/roles/role-pirate-opendj.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/roles/role-pirate.xml
+++ b/samples/roles/role-pirate.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/roles/role-sailor-opendj.xml
+++ b/samples/roles/role-sailor-opendj.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/roles/role-sailor.xml
+++ b/samples/roles/role-sailor.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/roles/role-smith.xml
+++ b/samples/roles/role-smith.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/roles/sensitive-role-1.xml
+++ b/samples/roles/sensitive-role-1.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/roles/sensitive-role-2.xml
+++ b/samples/roles/sensitive-role-2.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/roles/sensitive-role-3.xml
+++ b/samples/roles/sensitive-role-3.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/roles/users-for-approval-processes.xml
+++ b/samples/roles/users-for-approval-processes.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/samples-test/pom.xml
+++ b/samples/samples-test/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/samples-test/src/test/resources/ctx-samples-test-main.xml
+++ b/samples/samples-test/src/test/resources/ctx-samples-test-main.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/samples-test/src/test/resources/ctx-samples-test.xml
+++ b/samples/samples-test/src/test/resources/ctx-samples-test.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/samples-test/src/test/resources/logback-test.xml
+++ b/samples/samples-test/src/test/resources/logback-test.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/samples-test/src/test/resources/user-administrator.xml
+++ b/samples/samples-test/src/test/resources/user-administrator.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/samples-test/testng-integration.xml
+++ b/samples/samples-test/testng-integration.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/stories/multitenant-idm-saas/lookupTables/lookup-employee-type.xml
+++ b/samples/stories/multitenant-idm-saas/lookupTables/lookup-employee-type.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2016 Evolveum
+  ~ Copyright (c) 2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/stories/multitenant-idm-saas/objectTemplates/object-template-org.xml
+++ b/samples/stories/multitenant-idm-saas/objectTemplates/object-template-org.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2016 Evolveum
+  ~ Copyright (c) 2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/stories/multitenant-idm-saas/objectTemplates/object-template-user.xml
+++ b/samples/stories/multitenant-idm-saas/objectTemplates/object-template-user.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2016 Evolveum
+  ~ Copyright (c) 2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/stories/multitenant-idm-saas/org/org-top.xml
+++ b/samples/stories/multitenant-idm-saas/org/org-top.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2016 Evolveum
+  ~ Copyright (c) 2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/stories/multitenant-idm-saas/resources/crm-simulation-sync.xml
+++ b/samples/stories/multitenant-idm-saas/resources/crm-simulation-sync.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2016 Evolveum
+  ~ Copyright (c) 2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/stories/multitenant-idm-saas/resources/openldap-customers.xml
+++ b/samples/stories/multitenant-idm-saas/resources/openldap-customers.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/stories/multitenant-idm-saas/roles/metarole-org.xml
+++ b/samples/stories/multitenant-idm-saas/roles/metarole-org.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2016 Evolveum
+  ~ Copyright (c) 2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/stories/multitenant-idm-saas/roles/role-customer-authz-admin.xml
+++ b/samples/stories/multitenant-idm-saas/roles/role-customer-authz-admin.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2016 Evolveum
+  ~ Copyright (c) 2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/stories/multitenant-idm-saas/roles/role-customer-authz-enduser.xml
+++ b/samples/stories/multitenant-idm-saas/roles/role-customer-authz-enduser.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2016 Evolveum
+  ~ Copyright (c) 2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/stories/multitenant-idm-saas/roles/role-customer-basic-admin.xml
+++ b/samples/stories/multitenant-idm-saas/roles/role-customer-basic-admin.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2016 Evolveum
+  ~ Copyright (c) 2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/stories/multitenant-idm-saas/roles/role-customer-basic-poweruser.xml
+++ b/samples/stories/multitenant-idm-saas/roles/role-customer-basic-poweruser.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2016 Evolveum
+  ~ Copyright (c) 2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/stories/multitenant-idm-saas/roles/role-customer-basic-user.xml
+++ b/samples/stories/multitenant-idm-saas/roles/role-customer-basic-user.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2016 Evolveum
+  ~ Copyright (c) 2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/stories/multitenant-idm-saas/roles/role-meta-ldap-customer-group.xml
+++ b/samples/stories/multitenant-idm-saas/roles/role-meta-ldap-customer-group.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2016 Evolveum
+  ~ Copyright (c) 2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/stories/multitenant-idm-saas/valuePolicies/normal-password-policy.xml
+++ b/samples/stories/multitenant-idm-saas/valuePolicies/normal-password-policy.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2016 Evolveum
+  ~ Copyright (c) 2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/stories/multitenant-idm-saas/valuePolicies/stronger-password-policy.xml
+++ b/samples/stories/multitenant-idm-saas/valuePolicies/stronger-password-policy.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2016 Evolveum
+  ~ Copyright (c) 2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/stories/multitenant-idm-saas/valuePolicies/verystrong-password-policy.xml
+++ b/samples/stories/multitenant-idm-saas/valuePolicies/verystrong-password-policy.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2016 Evolveum
+  ~ Copyright (c) 2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/stories/unix-ldap/other/sequence-uidnumber.xml
+++ b/samples/stories/unix-ldap/other/sequence-uidnumber.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2015 Evolveum
+  ~ Copyright (c) 2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/stories/unix-ldap/resources/ldap-posix.xml
+++ b/samples/stories/unix-ldap/resources/ldap-posix.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2016 Evolveum
+  ~ Copyright (c) 2017 Evolveum
   -->
 
 <objects xmlns="http://midpoint.evolveum.com/xml/ns/public/common/common-3"

--- a/samples/tasks/advanced-task-scheduling.xml
+++ b/samples/tasks/advanced-task-scheduling.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/tasks/bulk-actions/assign-enduser-role-to-selected-users.xml
+++ b/samples/tasks/bulk-actions/assign-enduser-role-to-selected-users.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2014 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/tasks/bulk-actions/assign-resource-to-selected-users.xml
+++ b/samples/tasks/bulk-actions/assign-resource-to-selected-users.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2014 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/tasks/bulk-actions/disable-selected-users.xml
+++ b/samples/tasks/bulk-actions/disable-selected-users.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2014 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/tasks/bulk-actions/discover-rebind.xml
+++ b/samples/tasks/bulk-actions/discover-rebind.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2014 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/tasks/bulk-actions/list-selected-resource-objects-2.xml
+++ b/samples/tasks/bulk-actions/list-selected-resource-objects-2.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2014 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/tasks/bulk-actions/list-selected-resource-objects-3.xml
+++ b/samples/tasks/bulk-actions/list-selected-resource-objects-3.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2014 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/tasks/bulk-actions/list-selected-resource-objects.xml
+++ b/samples/tasks/bulk-actions/list-selected-resource-objects.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2014 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/tasks/bulk-actions/list-selected-users-ordered.xml
+++ b/samples/tasks/bulk-actions/list-selected-users-ordered.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/tasks/bulk-actions/list-selected-users.xml
+++ b/samples/tasks/bulk-actions/list-selected-users.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2014 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/tasks/bulk-actions/list-users-with-a-role.xml
+++ b/samples/tasks/bulk-actions/list-users-with-a-role.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2014 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/tasks/bulk-actions/modify-selected-users-unassign-role.xml
+++ b/samples/tasks/bulk-actions/modify-selected-users-unassign-role.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/tasks/bulk-actions/modify-selected-users.xml
+++ b/samples/tasks/bulk-actions/modify-selected-users.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2014 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/tasks/bulk-actions/purge-resource-schema.xml
+++ b/samples/tasks/bulk-actions/purge-resource-schema.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2014 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/tasks/bulk-actions/recompute-selected-orgs.xml
+++ b/samples/tasks/bulk-actions/recompute-selected-orgs.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/tasks/bulk-actions/recompute-selected-users.xml
+++ b/samples/tasks/bulk-actions/recompute-selected-users.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2014 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/tasks/bulk-actions/recompute-users-with-a-role.xml
+++ b/samples/tasks/bulk-actions/recompute-users-with-a-role.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2014 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/tasks/bulk-actions/recompute-users-without-fullname.xml
+++ b/samples/tasks/bulk-actions/recompute-users-without-fullname.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2014 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/tasks/bulk-actions/recompute-users-without-nickname-starting-on-b.xml
+++ b/samples/tasks/bulk-actions/recompute-users-without-nickname-starting-on-b.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2014 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/tasks/bulk-actions/recompute-users-without-nickname.xml
+++ b/samples/tasks/bulk-actions/recompute-users-without-nickname.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2014 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/tasks/bulk-actions/recompute-users.xml
+++ b/samples/tasks/bulk-actions/recompute-users.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2014 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/tasks/bulk-actions/script-orgs.xml
+++ b/samples/tasks/bulk-actions/script-orgs.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/tasks/bulk-actions/send-notifications-about-all-users.xml
+++ b/samples/tasks/bulk-actions/send-notifications-about-all-users.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/tasks/clustering-and-basic-failover.xml
+++ b/samples/tasks/clustering-and-basic-failover.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/tasks/limiting-parallel-execution-2.xml
+++ b/samples/tasks/limiting-parallel-execution-2.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/tasks/limiting-parallel-execution.xml
+++ b/samples/tasks/limiting-parallel-execution.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/tasks/non-resilient-tasks.xml
+++ b/samples/tasks/non-resilient-tasks.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/tasks/recon-task-csv-dry-run.xml
+++ b/samples/tasks/recon-task-csv-dry-run.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/tasks/recon-task-csv.xml
+++ b/samples/tasks/recon-task-csv.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/tasks/recon-task-opendj-test.xml
+++ b/samples/tasks/recon-task-opendj-test.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/tasks/recon-task-opendj.xml
+++ b/samples/tasks/recon-task-opendj.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/tasks/task-audit-cleanup.xml
+++ b/samples/tasks/task-audit-cleanup.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/tasks/task-check-shadow-integrity.xml
+++ b/samples/tasks/task-check-shadow-integrity.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/tasks/task-jdbc-ping-default.xml
+++ b/samples/tasks/task-jdbc-ping-default.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/tasks/task-jdbc-ping.xml
+++ b/samples/tasks/task-jdbc-ping.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/tasks/task-reindex-abstractRole.xml
+++ b/samples/tasks/task-reindex-abstractRole.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/tasks/task-reindex-audit-records.xml
+++ b/samples/tasks/task-reindex-audit-records.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/tasks/task-reindex.xml
+++ b/samples/tasks/task-reindex.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/tasks/task-scheduling.xml
+++ b/samples/tasks/task-scheduling.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/tasks/task-suspension.xml
+++ b/samples/tasks/task-suspension.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/tasks/task-tree.xml
+++ b/samples/tasks/task-tree.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/tasks/task-user-recompute-selected-users-only.xml
+++ b/samples/tasks/task-user-recompute-selected-users-only.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/samples/tasks/task-user-recompute.xml
+++ b/samples/tasks/task-user-recompute.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/conntest/pom.xml
+++ b/testing/conntest/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/conntest/src/test/resources/389ds/resource-dn-localhost.xml
+++ b/testing/conntest/src/test/resources/389ds/resource-dn-localhost.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/conntest/src/test/resources/389ds/resource-dn-phobos.xml
+++ b/testing/conntest/src/test/resources/389ds/resource-dn-phobos.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/conntest/src/test/resources/389ds/resource-nsuniqueid-localhost.xml
+++ b/testing/conntest/src/test/resources/389ds/resource-nsuniqueid-localhost.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/conntest/src/test/resources/389ds/resource-nsuniqueid-phobos.xml
+++ b/testing/conntest/src/test/resources/389ds/resource-nsuniqueid-phobos.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/conntest/src/test/resources/ad-ldap-multidomain/role-submissive.xml
+++ b/testing/conntest/src/test/resources/ad-ldap-multidomain/role-submissive.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 Evolveum
+  ~ Copyright (c) 2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/conntest/src/test/resources/ad-ldap-multidomain/user-subman.xml
+++ b/testing/conntest/src/test/resources/ad-ldap-multidomain/user-subman.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2016 Evolveum
+  ~ Copyright (c) 2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/conntest/src/test/resources/ad-ldap-multidomain/user-submarine.xml
+++ b/testing/conntest/src/test/resources/ad-ldap-multidomain/user-submarine.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2016 Evolveum
+  ~ Copyright (c) 2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/conntest/src/test/resources/common/role-evil.xml
+++ b/testing/conntest/src/test/resources/common/role-evil.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2016 Evolveum
+  ~ Copyright (c) 2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/conntest/src/test/resources/common/role-superuser.xml
+++ b/testing/conntest/src/test/resources/common/role-superuser.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/conntest/src/test/resources/common/role-undead.xml
+++ b/testing/conntest/src/test/resources/common/role-undead.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2016 Evolveum
+  ~ Copyright (c) 2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/conntest/src/test/resources/common/system-configuration.xml
+++ b/testing/conntest/src/test/resources/common/system-configuration.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/conntest/src/test/resources/common/user-administrator.xml
+++ b/testing/conntest/src/test/resources/common/user-administrator.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/conntest/src/test/resources/common/user-barbossa.xml
+++ b/testing/conntest/src/test/resources/common/user-barbossa.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2014 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/conntest/src/test/resources/common/user-guybrush.xml
+++ b/testing/conntest/src/test/resources/common/user-guybrush.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2014 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/conntest/src/test/resources/common/user-lechuck.xml
+++ b/testing/conntest/src/test/resources/common/user-lechuck.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2016 Evolveum
+  ~ Copyright (c) 2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/conntest/src/test/resources/ctx-conntest-test-main.xml
+++ b/testing/conntest/src/test/resources/ctx-conntest-test-main.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/conntest/src/test/resources/ctx-conntest-test.xml
+++ b/testing/conntest/src/test/resources/ctx-conntest-test.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2014 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/conntest/src/test/resources/logback-test.xml
+++ b/testing/conntest/src/test/resources/logback-test.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/conntest/src/test/resources/opendj-dumber/resource.xml
+++ b/testing/conntest/src/test/resources/opendj-dumber/resource.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/conntest/src/test/resources/opendj/resource-unsafe.xml
+++ b/testing/conntest/src/test/resources/opendj/resource-unsafe.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/conntest/src/test/resources/opendj/resource.xml
+++ b/testing/conntest/src/test/resources/opendj/resource.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/conntest/src/test/resources/openldap/resource.xml
+++ b/testing/conntest/src/test/resources/openldap/resource.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/consistency-mechanism/pom.xml
+++ b/testing/consistency-mechanism/pom.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/consistency-mechanism/src/test/resources/ctx-consistency-test-main.xml
+++ b/testing/consistency-mechanism/src/test/resources/ctx-consistency-test-main.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/consistency-mechanism/src/test/resources/ctx-consistency-test.xml
+++ b/testing/consistency-mechanism/src/test/resources/ctx-consistency-test.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/consistency-mechanism/src/test/resources/logback-test.xml
+++ b/testing/consistency-mechanism/src/test/resources/logback-test.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/consistency-mechanism/src/test/resources/repo/account-chuck.xml
+++ b/testing/consistency-mechanism/src/test/resources/repo/account-chuck.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/consistency-mechanism/src/test/resources/repo/account-deniels.xml
+++ b/testing/consistency-mechanism/src/test/resources/repo/account-deniels.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/consistency-mechanism/src/test/resources/repo/account-guybrush-not-found.xml
+++ b/testing/consistency-mechanism/src/test/resources/repo/account-guybrush-not-found.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/consistency-mechanism/src/test/resources/repo/account-guybrush.xml
+++ b/testing/consistency-mechanism/src/test/resources/repo/account-guybrush.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/consistency-mechanism/src/test/resources/repo/account-hector-not-found.xml
+++ b/testing/consistency-mechanism/src/test/resources/repo/account-hector-not-found.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/consistency-mechanism/src/test/resources/repo/account-herman.xml
+++ b/testing/consistency-mechanism/src/test/resources/repo/account-herman.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/consistency-mechanism/src/test/resources/repo/connector-broken.xml
+++ b/testing/consistency-mechanism/src/test/resources/repo/connector-broken.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/consistency-mechanism/src/test/resources/repo/resource-broken.xml
+++ b/testing/consistency-mechanism/src/test/resources/repo/resource-broken.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/consistency-mechanism/src/test/resources/repo/resource-derby.xml
+++ b/testing/consistency-mechanism/src/test/resources/repo/resource-derby.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/consistency-mechanism/src/test/resources/repo/resource-opendj.xml
+++ b/testing/consistency-mechanism/src/test/resources/repo/resource-opendj.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/consistency-mechanism/src/test/resources/repo/role-admins.xml
+++ b/testing/consistency-mechanism/src/test/resources/repo/role-admins.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/consistency-mechanism/src/test/resources/repo/role-captain.xml
+++ b/testing/consistency-mechanism/src/test/resources/repo/role-captain.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/consistency-mechanism/src/test/resources/repo/role-pirate.xml
+++ b/testing/consistency-mechanism/src/test/resources/repo/role-pirate.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/consistency-mechanism/src/test/resources/repo/role-sailor.xml
+++ b/testing/consistency-mechanism/src/test/resources/repo/role-sailor.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/consistency-mechanism/src/test/resources/repo/role-superuser.xml
+++ b/testing/consistency-mechanism/src/test/resources/repo/role-superuser.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/consistency-mechanism/src/test/resources/repo/sample-configuration-object.xml
+++ b/testing/consistency-mechanism/src/test/resources/repo/sample-configuration-object.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/consistency-mechanism/src/test/resources/repo/system-configuration.xml
+++ b/testing/consistency-mechanism/src/test/resources/repo/system-configuration.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/consistency-mechanism/src/test/resources/repo/task-derby-reconciliation.xml
+++ b/testing/consistency-mechanism/src/test/resources/repo/task-derby-reconciliation.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/consistency-mechanism/src/test/resources/repo/task-opendj-reconciliation.xml
+++ b/testing/consistency-mechanism/src/test/resources/repo/task-opendj-reconciliation.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/consistency-mechanism/src/test/resources/repo/task-user-recompute.xml
+++ b/testing/consistency-mechanism/src/test/resources/repo/task-user-recompute.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/consistency-mechanism/src/test/resources/repo/user-abom.xml
+++ b/testing/consistency-mechanism/src/test/resources/repo/user-abom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/consistency-mechanism/src/test/resources/repo/user-abomba.xml
+++ b/testing/consistency-mechanism/src/test/resources/repo/user-abomba.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/consistency-mechanism/src/test/resources/repo/user-administrator.xml
+++ b/testing/consistency-mechanism/src/test/resources/repo/user-administrator.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/consistency-mechanism/src/test/resources/repo/user-alice.xml
+++ b/testing/consistency-mechanism/src/test/resources/repo/user-alice.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/consistency-mechanism/src/test/resources/repo/user-angelika.xml
+++ b/testing/consistency-mechanism/src/test/resources/repo/user-angelika.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/consistency-mechanism/src/test/resources/repo/user-bob-no-given-name.xml
+++ b/testing/consistency-mechanism/src/test/resources/repo/user-bob-no-given-name.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/consistency-mechanism/src/test/resources/repo/user-deniels.xml
+++ b/testing/consistency-mechanism/src/test/resources/repo/user-deniels.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/consistency-mechanism/src/test/resources/repo/user-discovery.xml
+++ b/testing/consistency-mechanism/src/test/resources/repo/user-discovery.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/consistency-mechanism/src/test/resources/repo/user-donald.xml
+++ b/testing/consistency-mechanism/src/test/resources/repo/user-donald.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/consistency-mechanism/src/test/resources/repo/user-e.xml
+++ b/testing/consistency-mechanism/src/test/resources/repo/user-e.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/consistency-mechanism/src/test/resources/repo/user-elaine.xml
+++ b/testing/consistency-mechanism/src/test/resources/repo/user-elaine.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/consistency-mechanism/src/test/resources/repo/user-guybrush-modify-not-found.xml
+++ b/testing/consistency-mechanism/src/test/resources/repo/user-guybrush-modify-not-found.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/consistency-mechanism/src/test/resources/repo/user-guybrush.xml
+++ b/testing/consistency-mechanism/src/test/resources/repo/user-guybrush.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/consistency-mechanism/src/test/resources/repo/user-hector.xml
+++ b/testing/consistency-mechanism/src/test/resources/repo/user-hector.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/consistency-mechanism/src/test/resources/repo/user-herman.xml
+++ b/testing/consistency-mechanism/src/test/resources/repo/user-herman.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/consistency-mechanism/src/test/resources/repo/user-jack.xml
+++ b/testing/consistency-mechanism/src/test/resources/repo/user-jack.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/consistency-mechanism/src/test/resources/repo/user-jack2.xml
+++ b/testing/consistency-mechanism/src/test/resources/repo/user-jack2.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/consistency-mechanism/src/test/resources/repo/user-john.xml
+++ b/testing/consistency-mechanism/src/test/resources/repo/user-john.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/consistency-mechanism/src/test/resources/repo/user-template.xml
+++ b/testing/consistency-mechanism/src/test/resources/repo/user-template.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/consistency-mechanism/src/test/resources/repo/user-will.xml
+++ b/testing/consistency-mechanism/src/test/resources/repo/user-will.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/consistency-mechanism/src/test/resources/request/account-guybrush-modify-attributes.xml
+++ b/testing/consistency-mechanism/src/test/resources/request/account-guybrush-modify-attributes.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/consistency-mechanism/src/test/resources/request/account-modify-attrs-communication-problem.xml
+++ b/testing/consistency-mechanism/src/test/resources/request/account-modify-attrs-communication-problem.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/consistency-mechanism/src/test/resources/request/add-account-jack.xml
+++ b/testing/consistency-mechanism/src/test/resources/request/add-account-jack.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/consistency-mechanism/src/test/resources/request/resource-modify-resource-schema.xml
+++ b/testing/consistency-mechanism/src/test/resources/request/resource-modify-resource-schema.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/consistency-mechanism/src/test/resources/request/resource-modify-synchronization.xml
+++ b/testing/consistency-mechanism/src/test/resources/request/resource-modify-synchronization.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/consistency-mechanism/src/test/resources/request/user-chuck.xml
+++ b/testing/consistency-mechanism/src/test/resources/request/user-chuck.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/consistency-mechanism/src/test/resources/request/user-modify-activation-disable.xml
+++ b/testing/consistency-mechanism/src/test/resources/request/user-modify-activation-disable.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/consistency-mechanism/src/test/resources/request/user-modify-activation-enable.xml
+++ b/testing/consistency-mechanism/src/test/resources/request/user-modify-activation-enable.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/consistency-mechanism/src/test/resources/request/user-modify-add-account-already-exist-communication-problem.xml
+++ b/testing/consistency-mechanism/src/test/resources/request/user-modify-add-account-already-exist-communication-problem.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/consistency-mechanism/src/test/resources/request/user-modify-add-account-already-exist-linked.xml
+++ b/testing/consistency-mechanism/src/test/resources/request/user-modify-add-account-already-exist-linked.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/consistency-mechanism/src/test/resources/request/user-modify-add-account-already-exist-unlinked.xml
+++ b/testing/consistency-mechanism/src/test/resources/request/user-modify-add-account-already-exist-unlinked.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/consistency-mechanism/src/test/resources/request/user-modify-add-account-communication-problem.xml
+++ b/testing/consistency-mechanism/src/test/resources/request/user-modify-add-account-communication-problem.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/consistency-mechanism/src/test/resources/request/user-modify-add-account-deniels.xml
+++ b/testing/consistency-mechanism/src/test/resources/request/user-modify-add-account-deniels.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/consistency-mechanism/src/test/resources/request/user-modify-add-account-derby.xml
+++ b/testing/consistency-mechanism/src/test/resources/request/user-modify-add-account-derby.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/consistency-mechanism/src/test/resources/request/user-modify-add-account-directly.xml
+++ b/testing/consistency-mechanism/src/test/resources/request/user-modify-add-account-directly.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/consistency-mechanism/src/test/resources/request/user-modify-add-account.xml
+++ b/testing/consistency-mechanism/src/test/resources/request/user-modify-add-account.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/consistency-mechanism/src/test/resources/request/user-modify-add-role-captain-1.xml
+++ b/testing/consistency-mechanism/src/test/resources/request/user-modify-add-role-captain-1.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/consistency-mechanism/src/test/resources/request/user-modify-add-role-captain-2.xml
+++ b/testing/consistency-mechanism/src/test/resources/request/user-modify-add-role-captain-2.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/consistency-mechanism/src/test/resources/request/user-modify-add-role-pirate.xml
+++ b/testing/consistency-mechanism/src/test/resources/request/user-modify-add-role-pirate.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/consistency-mechanism/src/test/resources/request/user-modify-assign-account.xml
+++ b/testing/consistency-mechanism/src/test/resources/request/user-modify-assign-account.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/consistency-mechanism/src/test/resources/request/user-modify-assign-role-admin.xml
+++ b/testing/consistency-mechanism/src/test/resources/request/user-modify-assign-role-admin.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/consistency-mechanism/src/test/resources/request/user-modify-change-password-1.xml
+++ b/testing/consistency-mechanism/src/test/resources/request/user-modify-change-password-1.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/consistency-mechanism/src/test/resources/request/user-modify-change-password-2.xml
+++ b/testing/consistency-mechanism/src/test/resources/request/user-modify-change-password-2.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/consistency-mechanism/src/test/resources/request/user-modify-delete-account-communication-problem.xml
+++ b/testing/consistency-mechanism/src/test/resources/request/user-modify-delete-account-communication-problem.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/consistency-mechanism/src/test/resources/request/user-modify-delete-account.xml
+++ b/testing/consistency-mechanism/src/test/resources/request/user-modify-delete-account.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/consistency-mechanism/src/test/resources/request/user-modify-delete-role-captain-1.xml
+++ b/testing/consistency-mechanism/src/test/resources/request/user-modify-delete-role-captain-1.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/consistency-mechanism/src/test/resources/request/user-modify-delete-role-captain-2.xml
+++ b/testing/consistency-mechanism/src/test/resources/request/user-modify-delete-role-captain-2.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/consistency-mechanism/src/test/resources/request/user-modify-delete-role-pirate.xml
+++ b/testing/consistency-mechanism/src/test/resources/request/user-modify-delete-role-pirate.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/consistency-mechanism/src/test/resources/request/user-modify-employeeType-givenName.xml
+++ b/testing/consistency-mechanism/src/test/resources/request/user-modify-employeeType-givenName.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/consistency-mechanism/src/test/resources/request/user-modify-employeeType.xml
+++ b/testing/consistency-mechanism/src/test/resources/request/user-modify-employeeType.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/consistency-mechanism/src/test/resources/request/user-modify-fullname-locality.xml
+++ b/testing/consistency-mechanism/src/test/resources/request/user-modify-fullname-locality.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/consistency-mechanism/src/test/resources/request/user-modify-password.xml
+++ b/testing/consistency-mechanism/src/test/resources/request/user-modify-password.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/consistency-mechanism/src/test/resources/request/user-morgan.xml
+++ b/testing/consistency-mechanism/src/test/resources/request/user-morgan.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/consistency-mechanism/testng-integration.xml
+++ b/testing/consistency-mechanism/testng-integration.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/longtest/pom.xml
+++ b/testing/longtest/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/longtest/src/test/resources/common/resource-opendj-complex.xml
+++ b/testing/longtest/src/test/resources/common/resource-opendj-complex.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/longtest/src/test/resources/common/resource-opendj-generic-sync.xml
+++ b/testing/longtest/src/test/resources/common/resource-opendj-generic-sync.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/longtest/src/test/resources/common/resource-opendj-university.xml
+++ b/testing/longtest/src/test/resources/common/resource-opendj-university.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/longtest/src/test/resources/common/resource-opendj-vlv.xml
+++ b/testing/longtest/src/test/resources/common/resource-opendj-vlv.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/longtest/src/test/resources/common/resource-opendj.xml
+++ b/testing/longtest/src/test/resources/common/resource-opendj.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/longtest/src/test/resources/common/role-superuser.xml
+++ b/testing/longtest/src/test/resources/common/role-superuser.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/longtest/src/test/resources/common/system-configuration.xml
+++ b/testing/longtest/src/test/resources/common/system-configuration.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/longtest/src/test/resources/common/user-administrator.xml
+++ b/testing/longtest/src/test/resources/common/user-administrator.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/longtest/src/test/resources/common/user-barbossa.xml
+++ b/testing/longtest/src/test/resources/common/user-barbossa.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2014 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/longtest/src/test/resources/common/user-guybrush.xml
+++ b/testing/longtest/src/test/resources/common/user-guybrush.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2014 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/longtest/src/test/resources/ctx-longtest-test-main.xml
+++ b/testing/longtest/src/test/resources/ctx-longtest-test-main.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/longtest/src/test/resources/ctx-longtest-test.xml
+++ b/testing/longtest/src/test/resources/ctx-longtest-test.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/longtest/src/test/resources/ldap-complex/org.xml
+++ b/testing/longtest/src/test/resources/ldap-complex/org.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/longtest/src/test/resources/ldap-complex/role-captain.xml
+++ b/testing/longtest/src/test/resources/ldap-complex/role-captain.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2014 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/longtest/src/test/resources/ldap-complex/role-judge.xml
+++ b/testing/longtest/src/test/resources/ldap-complex/role-judge.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2014 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/longtest/src/test/resources/ldap-complex/role-pirate.xml
+++ b/testing/longtest/src/test/resources/ldap-complex/role-pirate.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2014 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/longtest/src/test/resources/ldap-complex/role-sailor.xml
+++ b/testing/longtest/src/test/resources/ldap-complex/role-sailor.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2014 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/longtest/src/test/resources/ldap-complex/user-template.xml
+++ b/testing/longtest/src/test/resources/ldap-complex/user-template.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-  ~ Copyright (c) 2010-2014 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/longtest/src/test/resources/ldap/role-pirate.xml
+++ b/testing/longtest/src/test/resources/ldap/role-pirate.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2014 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/longtest/src/test/resources/logback-test.xml
+++ b/testing/longtest/src/test/resources/logback-test.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/longtest/testng-integration.xml
+++ b/testing/longtest/testng-integration.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/minipoint/src/main/resources/ctx-minipoint-main.xml
+++ b/testing/minipoint/src/main/resources/ctx-minipoint-main.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/pom.xml
+++ b/testing/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/rest/src/test/resources/ctx-rest-test-main.xml
+++ b/testing/rest/src/test/resources/ctx-rest-test-main.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/rest/src/test/resources/ctx-rest-test.xml
+++ b/testing/rest/src/test/resources/ctx-rest-test.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/rest/src/test/resources/logback-test.xml
+++ b/testing/rest/src/test/resources/logback-test.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/rest/src/test/resources/repo/resource-opendj.xml
+++ b/testing/rest/src/test/resources/repo/resource-opendj.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/rest/src/test/resources/repo/role-enduser.xml
+++ b/testing/rest/src/test/resources/repo/role-enduser.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/rest/src/test/resources/repo/role-proxy.xml
+++ b/testing/rest/src/test/resources/repo/role-proxy.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/rest/src/test/resources/repo/role-reader.xml
+++ b/testing/rest/src/test/resources/repo/role-reader.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/rest/src/test/resources/repo/role-rest.xml
+++ b/testing/rest/src/test/resources/repo/role-rest.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/rest/src/test/resources/repo/role-superuser.xml
+++ b/testing/rest/src/test/resources/repo/role-superuser.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/rest/src/test/resources/repo/system-configuration.xml
+++ b/testing/rest/src/test/resources/repo/system-configuration.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/rest/src/test/resources/repo/user-administrator.xml
+++ b/testing/rest/src/test/resources/repo/user-administrator.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/rest/src/test/resources/repo/user-proxy.xml
+++ b/testing/rest/src/test/resources/repo/user-proxy.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/rest/src/test/resources/repo/value-policy-general.xml
+++ b/testing/rest/src/test/resources/repo/value-policy-general.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/rest/src/test/resources/repo/value-policy-numeric.xml
+++ b/testing/rest/src/test/resources/repo/value-policy-numeric.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/rest/src/test/resources/repo/value-policy-simple.xml
+++ b/testing/rest/src/test/resources/repo/value-policy-simple.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/rest/src/test/resources/repo/xml/account-chuck.xml
+++ b/testing/rest/src/test/resources/repo/xml/account-chuck.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/rest/src/test/resources/repo/xml/role-adder.xml
+++ b/testing/rest/src/test/resources/repo/xml/role-adder.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/rest/src/test/resources/repo/xml/role-modifier.xml
+++ b/testing/rest/src/test/resources/repo/xml/role-modifier.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/rest/src/test/resources/repo/xml/user-template.xml
+++ b/testing/rest/src/test/resources/repo/xml/user-template.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/rest/testng-integration.xml
+++ b/testing/rest/testng-integration.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/sanity/src/test/resources/ctx-sanity-test-main.xml
+++ b/testing/sanity/src/test/resources/ctx-sanity-test-main.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/sanity/src/test/resources/ctx-sanity-test.xml
+++ b/testing/sanity/src/test/resources/ctx-sanity-test.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/sanity/src/test/resources/logback-test.xml
+++ b/testing/sanity/src/test/resources/logback-test.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/sanity/src/test/resources/repo/connector-broken.xml
+++ b/testing/sanity/src/test/resources/repo/connector-broken.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/sanity/src/test/resources/repo/resource-broken.xml
+++ b/testing/sanity/src/test/resources/repo/resource-broken.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/sanity/src/test/resources/repo/resource-derby.xml
+++ b/testing/sanity/src/test/resources/repo/resource-derby.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/sanity/src/test/resources/repo/resource-dummy.xml
+++ b/testing/sanity/src/test/resources/repo/resource-dummy.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2014 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/sanity/src/test/resources/repo/resource-opendj-legacy.xml
+++ b/testing/sanity/src/test/resources/repo/resource-opendj-legacy.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/sanity/src/test/resources/repo/resource-opendj.xml
+++ b/testing/sanity/src/test/resources/repo/resource-opendj.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/sanity/src/test/resources/repo/role-captain.xml
+++ b/testing/sanity/src/test/resources/repo/role-captain.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/sanity/src/test/resources/repo/role-judge.xml
+++ b/testing/sanity/src/test/resources/repo/role-judge.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/sanity/src/test/resources/repo/role-pirate.xml
+++ b/testing/sanity/src/test/resources/repo/role-pirate.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/sanity/src/test/resources/repo/role-sailor.xml
+++ b/testing/sanity/src/test/resources/repo/role-sailor.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/sanity/src/test/resources/repo/role-superuser.xml
+++ b/testing/sanity/src/test/resources/repo/role-superuser.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/sanity/src/test/resources/repo/sample-configuration-object.xml
+++ b/testing/sanity/src/test/resources/repo/sample-configuration-object.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/sanity/src/test/resources/repo/system-configuration.xml
+++ b/testing/sanity/src/test/resources/repo/system-configuration.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/sanity/src/test/resources/repo/task-derby-reconciliation.xml
+++ b/testing/sanity/src/test/resources/repo/task-derby-reconciliation.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/sanity/src/test/resources/repo/task-opendj-reconciliation-legacy.xml
+++ b/testing/sanity/src/test/resources/repo/task-opendj-reconciliation-legacy.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/sanity/src/test/resources/repo/task-opendj-reconciliation.xml
+++ b/testing/sanity/src/test/resources/repo/task-opendj-reconciliation.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/sanity/src/test/resources/repo/task-opendj-sync-legacy.xml
+++ b/testing/sanity/src/test/resources/repo/task-opendj-sync-legacy.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/sanity/src/test/resources/repo/task-opendj-sync.xml
+++ b/testing/sanity/src/test/resources/repo/task-opendj-sync.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/sanity/src/test/resources/repo/task-user-recompute.xml
+++ b/testing/sanity/src/test/resources/repo/task-user-recompute.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/sanity/src/test/resources/repo/user-administrator.xml
+++ b/testing/sanity/src/test/resources/repo/user-administrator.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/sanity/src/test/resources/repo/user-e.xml
+++ b/testing/sanity/src/test/resources/repo/user-e.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/sanity/src/test/resources/repo/user-guybrush.xml
+++ b/testing/sanity/src/test/resources/repo/user-guybrush.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/sanity/src/test/resources/repo/user-jack.xml
+++ b/testing/sanity/src/test/resources/repo/user-jack.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/sanity/src/test/resources/repo/user-template.xml
+++ b/testing/sanity/src/test/resources/repo/user-template.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/sanity/src/test/resources/request/account-angelika-legacy.xml
+++ b/testing/sanity/src/test/resources/request/account-angelika-legacy.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/sanity/src/test/resources/request/account-angelika.xml
+++ b/testing/sanity/src/test/resources/request/account-angelika.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/sanity/src/test/resources/request/account-modify-attrs.xml
+++ b/testing/sanity/src/test/resources/request/account-modify-attrs.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/sanity/src/test/resources/request/account-modify-bad-path.xml
+++ b/testing/sanity/src/test/resources/request/account-modify-bad-path.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/sanity/src/test/resources/request/account-modify-roomnumber-explicit-type.xml
+++ b/testing/sanity/src/test/resources/request/account-modify-roomnumber-explicit-type.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/sanity/src/test/resources/request/account-modify-roomnumber.xml
+++ b/testing/sanity/src/test/resources/request/account-modify-roomnumber.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/sanity/src/test/resources/request/user-modify-activation-disable.xml
+++ b/testing/sanity/src/test/resources/request/user-modify-activation-disable.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/sanity/src/test/resources/request/user-modify-activation-enable.xml
+++ b/testing/sanity/src/test/resources/request/user-modify-activation-enable.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/sanity/src/test/resources/request/user-modify-add-account-derby.xml
+++ b/testing/sanity/src/test/resources/request/user-modify-add-account-derby.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/sanity/src/test/resources/request/user-modify-add-account-legacy.xml
+++ b/testing/sanity/src/test/resources/request/user-modify-add-account-legacy.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/sanity/src/test/resources/request/user-modify-add-account.xml
+++ b/testing/sanity/src/test/resources/request/user-modify-add-account.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/sanity/src/test/resources/request/user-modify-add-role-captain-1.xml
+++ b/testing/sanity/src/test/resources/request/user-modify-add-role-captain-1.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/sanity/src/test/resources/request/user-modify-add-role-captain-2.xml
+++ b/testing/sanity/src/test/resources/request/user-modify-add-role-captain-2.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/sanity/src/test/resources/request/user-modify-add-role-judge.xml
+++ b/testing/sanity/src/test/resources/request/user-modify-add-role-judge.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/sanity/src/test/resources/request/user-modify-add-role-pirate.xml
+++ b/testing/sanity/src/test/resources/request/user-modify-add-role-pirate.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/sanity/src/test/resources/request/user-modify-delete-role-captain-1.xml
+++ b/testing/sanity/src/test/resources/request/user-modify-delete-role-captain-1.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/sanity/src/test/resources/request/user-modify-delete-role-captain-2.xml
+++ b/testing/sanity/src/test/resources/request/user-modify-delete-role-captain-2.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/sanity/src/test/resources/request/user-modify-delete-role-pirate.xml
+++ b/testing/sanity/src/test/resources/request/user-modify-delete-role-pirate.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/sanity/src/test/resources/request/user-modify-fullname-locality.xml
+++ b/testing/sanity/src/test/resources/request/user-modify-fullname-locality.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/sanity/src/test/resources/request/user-modify-givenname.xml
+++ b/testing/sanity/src/test/resources/request/user-modify-givenname.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/sanity/src/test/resources/request/user-modify-name.xml
+++ b/testing/sanity/src/test/resources/request/user-modify-name.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/sanity/src/test/resources/request/user-modify-password.xml
+++ b/testing/sanity/src/test/resources/request/user-modify-password.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/selenidetest/basic-tests-suite.xml
+++ b/testing/selenidetest/basic-tests-suite.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/selenidetest/complex-test-suite.xml
+++ b/testing/selenidetest/complex-test-suite.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/selenidetest/src/test/resources/logback-test.xml
+++ b/testing/selenidetest/src/test/resources/logback-test.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/selenidetest/src/test/resources/mp-resources/localhost-csvfile-resource-advanced-sync.xml
+++ b/testing/selenidetest/src/test/resources/mp-resources/localhost-csvfile-resource-advanced-sync.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?><!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/selenidetest/testng-integration.xml
+++ b/testing/selenidetest/testng-integration.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/story/src/test/resources/common/role-superuser.xml
+++ b/testing/story/src/test/resources/common/role-superuser.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/story/src/test/resources/common/system-configuration.xml
+++ b/testing/story/src/test/resources/common/system-configuration.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/story/src/test/resources/common/task-trigger-scanner.xml
+++ b/testing/story/src/test/resources/common/task-trigger-scanner.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/story/src/test/resources/common/task-validity-scanner.xml
+++ b/testing/story/src/test/resources/common/task-validity-scanner.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/story/src/test/resources/common/user-administrator.xml
+++ b/testing/story/src/test/resources/common/user-administrator.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/story/src/test/resources/common/user-jack.xml
+++ b/testing/story/src/test/resources/common/user-jack.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/story/src/test/resources/common/user-mike.xml
+++ b/testing/story/src/test/resources/common/user-mike.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/story/src/test/resources/ctx-story-test-main.xml
+++ b/testing/story/src/test/resources/ctx-story-test-main.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/story/src/test/resources/ctx-story-test.xml
+++ b/testing/story/src/test/resources/ctx-story-test.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/story/src/test/resources/entertainment/resource-opendj.xml
+++ b/testing/story/src/test/resources/entertainment/resource-opendj.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/story/src/test/resources/entertainment/role-meta-org-groups.xml
+++ b/testing/story/src/test/resources/entertainment/role-meta-org-groups.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2014 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/story/src/test/resources/ldap-deeply-hierarchical/org-top.xml
+++ b/testing/story/src/test/resources/ldap-deeply-hierarchical/org-top.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/story/src/test/resources/ldap-deeply-hierarchical/resource-opendj.xml
+++ b/testing/story/src/test/resources/ldap-deeply-hierarchical/resource-opendj.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/story/src/test/resources/ldap-deeply-hierarchical/role-meta-org.xml
+++ b/testing/story/src/test/resources/ldap-deeply-hierarchical/role-meta-org.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 Evolveum
+  ~ Copyright (c) 2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/story/src/test/resources/ldap-dependency/org-top.xml
+++ b/testing/story/src/test/resources/ldap-dependency/org-top.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/story/src/test/resources/ldap-dependency/resource-opendj.xml
+++ b/testing/story/src/test/resources/ldap-dependency/resource-opendj.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/story/src/test/resources/ldap-dependency/role-meta-org-supervip.xml
+++ b/testing/story/src/test/resources/ldap-dependency/role-meta-org-supervip.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 Evolveum
+  ~ Copyright (c) 2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/story/src/test/resources/ldap-dependency/role-meta-org-vip.xml
+++ b/testing/story/src/test/resources/ldap-dependency/role-meta-org-vip.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 Evolveum
+  ~ Copyright (c) 2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/story/src/test/resources/ldap-dependency/role-meta-org.xml
+++ b/testing/story/src/test/resources/ldap-dependency/role-meta-org.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 Evolveum
+  ~ Copyright (c) 2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/story/src/test/resources/ldap-flat/org-top.xml
+++ b/testing/story/src/test/resources/ldap-flat/org-top.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/story/src/test/resources/ldap-flat/resource-opendj.xml
+++ b/testing/story/src/test/resources/ldap-flat/resource-opendj.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/story/src/test/resources/ldap-flat/role-meta-org.xml
+++ b/testing/story/src/test/resources/ldap-flat/role-meta-org.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 Evolveum
+  ~ Copyright (c) 2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/story/src/test/resources/ldap-hierarchical/org-top.xml
+++ b/testing/story/src/test/resources/ldap-hierarchical/org-top.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/story/src/test/resources/ldap-hierarchical/resource-opendj.xml
+++ b/testing/story/src/test/resources/ldap-hierarchical/resource-opendj.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/story/src/test/resources/ldap-hierarchical/role-meta-org.xml
+++ b/testing/story/src/test/resources/ldap-hierarchical/role-meta-org.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 Evolveum
+  ~ Copyright (c) 2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/story/src/test/resources/ldap-nested/org-top.xml
+++ b/testing/story/src/test/resources/ldap-nested/org-top.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/story/src/test/resources/ldap-nested/resource-opendj.xml
+++ b/testing/story/src/test/resources/ldap-nested/resource-opendj.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/story/src/test/resources/ldap-nested/role-meta-org.xml
+++ b/testing/story/src/test/resources/ldap-nested/role-meta-org.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 Evolveum
+  ~ Copyright (c) 2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/story/src/test/resources/logback-test.xml
+++ b/testing/story/src/test/resources/logback-test.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/story/src/test/resources/nullattribute/user-smack.xml
+++ b/testing/story/src/test/resources/nullattribute/user-smack.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum, mythoss
+  ~ Copyright (c) 2010-2017 Evolveum, mythoss
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/story/src/test/resources/orgsync/object-template-user.xml
+++ b/testing/story/src/test/resources/orgsync/object-template-user.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/story/src/test/resources/orgsync/resource-dummy-hr.xml
+++ b/testing/story/src/test/resources/orgsync/resource-dummy-hr.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2014 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/story/src/test/resources/orgsync/resource-opendj.xml
+++ b/testing/story/src/test/resources/orgsync/resource-opendj.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/story/src/test/resources/orgsync/role-basic.xml
+++ b/testing/story/src/test/resources/orgsync/role-basic.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2014 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/story/src/test/resources/orgsync/role-meta-replicated-org.xml
+++ b/testing/story/src/test/resources/orgsync/role-meta-replicated-org.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2014 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/story/src/test/resources/orgsync/role-meta-responsibility.xml
+++ b/testing/story/src/test/resources/orgsync/role-meta-responsibility.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2014 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/story/src/test/resources/retirement/org-retired.xml
+++ b/testing/story/src/test/resources/retirement/org-retired.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2016 Evolveum
+  ~ Copyright (c) 2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/story/src/test/resources/retirement/org-top.xml
+++ b/testing/story/src/test/resources/retirement/org-top.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/story/src/test/resources/retirement/resource-opendj.xml
+++ b/testing/story/src/test/resources/retirement/resource-opendj.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/story/src/test/resources/retirement/role-meta-org.xml
+++ b/testing/story/src/test/resources/retirement/role-meta-org.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 Evolveum
+  ~ Copyright (c) 2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/story/src/test/resources/science/resource-dummy-stats.xml
+++ b/testing/story/src/test/resources/science/resource-dummy-stats.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2014 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/story/src/test/resources/science/resource-dummy-unix.xml
+++ b/testing/story/src/test/resources/science/resource-dummy-unix.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2014 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/story/src/test/resources/science/resource-opendj-ad-simulation.xml
+++ b/testing/story/src/test/resources/science/resource-opendj-ad-simulation.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/story/src/test/resources/science/role-statistics.xml
+++ b/testing/story/src/test/resources/science/role-statistics.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2014 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/story/src/test/resources/strings/roles/metarole-approval-role-approvers-first.xml
+++ b/testing/story/src/test/resources/strings/roles/metarole-approval-role-approvers-first.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/story/src/test/resources/trafo/resource-dummy-ad.xml
+++ b/testing/story/src/test/resources/trafo/resource-dummy-ad.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2014 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/story/src/test/resources/trafo/resource-dummy-mail.xml
+++ b/testing/story/src/test/resources/trafo/resource-dummy-mail.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2014 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/story/src/test/resources/university/object-template-org.xml
+++ b/testing/story/src/test/resources/university/object-template-org.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/story/src/test/resources/university/org-top.xml
+++ b/testing/story/src/test/resources/university/org-top.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/story/src/test/resources/university/resource-dummy-hr.xml
+++ b/testing/story/src/test/resources/university/resource-dummy-hr.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/story/src/test/resources/university/resource-opendj.xml
+++ b/testing/story/src/test/resources/university/resource-opendj.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/story/src/test/resources/university/role-meta-org.xml
+++ b/testing/story/src/test/resources/university/role-meta-org.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/story/src/test/resources/university/task-dummy-hr-livesync.xml
+++ b/testing/story/src/test/resources/university/task-dummy-hr-livesync.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/story/src/test/resources/unix/resource-opendj.xml
+++ b/testing/story/src/test/resources/unix/resource-opendj.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/story/src/test/resources/uuid/resource-opendj.xml
+++ b/testing/story/src/test/resources/uuid/resource-opendj.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/story/src/test/resources/village/global-password-policy.xml
+++ b/testing/story/src/test/resources/village/global-password-policy.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/story/src/test/resources/village/object-template-user.xml
+++ b/testing/story/src/test/resources/village/object-template-user.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2014 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/story/src/test/resources/village/org-password-policy.xml
+++ b/testing/story/src/test/resources/village/org-password-policy.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/story/src/test/resources/village/resource-opendj.xml
+++ b/testing/story/src/test/resources/village/resource-opendj.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/story/src/test/resources/village/role-account-construction.xml
+++ b/testing/story/src/test/resources/village/role-account-construction.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/story/src/test/resources/village/role-basic.xml
+++ b/testing/story/src/test/resources/village/role-basic.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/story/src/test/resources/village/system-configuration.xml
+++ b/testing/story/src/test/resources/village/system-configuration.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <!--
-  ~ Copyright (c) 2010-2014 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/story/src/test/resources/village/user-murray.xml
+++ b/testing/story/src/test/resources/village/user-murray.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2014 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/wstest/src/test/resources/common/resource-opendj.xml
+++ b/testing/wstest/src/test/resources/common/resource-opendj.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/wstest/src/test/resources/common/role-adder.xml
+++ b/testing/wstest/src/test/resources/common/role-adder.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/wstest/src/test/resources/common/role-modifier.xml
+++ b/testing/wstest/src/test/resources/common/role-modifier.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/wstest/src/test/resources/common/role-reader.xml
+++ b/testing/wstest/src/test/resources/common/role-reader.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/wstest/src/test/resources/common/role-ws.xml
+++ b/testing/wstest/src/test/resources/common/role-ws.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/wstest/src/test/resources/common/user-jack.xml
+++ b/testing/wstest/src/test/resources/common/user-jack.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/wstest/src/test/resources/ctx-wstest-main.xml
+++ b/testing/wstest/src/test/resources/ctx-wstest-main.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/wstest/src/test/resources/logback-test.xml
+++ b/testing/wstest/src/test/resources/logback-test.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/testing/wstest/testng-integration.xml
+++ b/testing/wstest/testng-integration.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2015 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/tools/gui-i18n/pom.xml
+++ b/tools/gui-i18n/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/tools/gui-i18n/testng-unit.xml
+++ b/tools/gui-i18n/testng-unit.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/tools/pom.xml
+++ b/tools/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/tools/repo-ninja/pom.xml
+++ b/tools/repo-ninja/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/tools/repo-ninja/src/main/resources/ctx-ninja.xml
+++ b/tools/repo-ninja/src/main/resources/ctx-ninja.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/tools/repo-ninja/src/main/resources/logback.xml
+++ b/tools/repo-ninja/src/main/resources/logback.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/tools/repo-ninja/src/test/resources/midpoint-home/config.xml
+++ b/tools/repo-ninja/src/test/resources/midpoint-home/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/tools/repo-ninja/src/test/resources/objects.xml
+++ b/tools/repo-ninja/src/test/resources/objects.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/tools/repo-ninja/testng-unit.xml
+++ b/tools/repo-ninja/testng-unit.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/tools/test-ng/pom.xml
+++ b/tools/test-ng/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/tools/test-ng/testng-unit.xml
+++ b/tools/test-ng/testng-unit.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/tools/xjc-plugin/pom.xml
+++ b/tools/xjc-plugin/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-  ~ Copyright (c) 2010-2016 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/tools/xjc-plugin/src/main/java/com/evolveum/midpoint/schema/xjc/schema/SchemaProcessor.java
+++ b/tools/xjc-plugin/src/main/java/com/evolveum/midpoint/schema/xjc/schema/SchemaProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2016 Evolveum
+ * Copyright (c) 2010-2017 Evolveum
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tools/xjc-plugin/testng-unit.xml
+++ b/tools/xjc-plugin/testng-unit.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  ~ Copyright (c) 2010-2013 Evolveum
+  ~ Copyright (c) 2010-2017 Evolveum
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.


### PR DESCRIPTION
A rather large and yet mostly innocent change where copyright headers are updated to reflect the current year. It's possible that I have missed a few here and there, and I'll get to them on demand.

Happy new year :) 