### PR TITLE
Prevents gui color conflict between headerColor and skin colors

### DIFF
--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/api/page/PageBase.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/api/page/PageBase.java
@@ -684,9 +684,10 @@ public abstract class PageBase extends WebPage implements ModelServiceLocator {
         body.add(new AttributeAppender("class", "hold-transition ", " "));
         body.add(new AttributeAppender("class", "custom-hold-transition ", " "));
 
-        if (deploymentInfoModel != null && deploymentInfoModel.getObject() != null &&
-                StringUtils.isNotEmpty(deploymentInfoModel.getObject().getSkin())) {
+        Boolean usingSkin = deploymentInfoModel != null && deploymentInfoModel.getObject() != null &&
+                StringUtils.isNotEmpty(deploymentInfoModel.getObject().getSkin());
 
+        if (usingSkin) {
             body.add(new AttributeAppender("class", deploymentInfoModel.getObject().getSkin(), " "));
         } else {
             body.add(new AttributeAppender("class", CLASS_DEFAULT_SKIN, " "));
@@ -771,8 +772,11 @@ public abstract class PageBase extends WebPage implements ModelServiceLocator {
                     "background-color: " + deploymentInfoModel.getObject().getHeaderColor() + "; !important;"));
             mainHeader.add(new AttributeAppender("style",
                     "background-color: " + deploymentInfoModel.getObject().getHeaderColor() + "; !important;"));
-            navigation.add(new AttributeAppender("style",
-                    "background-color: " + deploymentInfoModel.getObject().getHeaderColor() + "; !important;"));
+            //using a skin overrides the navigation color
+            if (!usingSkin) {
+                navigation.add(new AttributeAppender("style",
+                        "background-color: " + deploymentInfoModel.getObject().getHeaderColor() + "; !important;"));
+            }
         }
         initDebugBarLayout();
 


### PR DESCRIPTION
After this change you can now use `<headerColor/>`  in tandem with `<skin/>`. If skin is populated, the skins header color will apply to the main header bar, but if headerColor is also populated, it will apply to the left side around the image. This is useful for example, if you also need to use a logo with a solid white background, but want to also use an alternate skin. The example below shows a more extreme contrast for illustration purposes. 

```
<deploymentInformation>
  <name>TEST</name>
  <headerColor>red</headerColor>
  <skin>skin-green-light</skin>
</deploymentInformation>
```

![image](https://user-images.githubusercontent.com/1008728/30225493-ac356bb2-94a0-11e7-9fe4-067b9f172068.png)
