### PR TITLE
Refactor StringChoiceRenderer

### DIFF
--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/input/StringChoiceRenderer.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/input/StringChoiceRenderer.java
@@ -1,50 +1,86 @@
 package com.evolveum.midpoint.web.component.input;
 
-import java.util.List;
+import static java.util.Objects.requireNonNull;
 
+import java.util.List;
+import java.util.regex.Pattern;
 import org.apache.commons.lang.StringUtils;
 import org.apache.wicket.Application;
 import org.apache.wicket.markup.html.form.IChoiceRenderer;
 import org.apache.wicket.model.IModel;
 
-public class StringChoiceRenderer implements IChoiceRenderer<String> {
+public abstract class StringChoiceRenderer implements IChoiceRenderer<String> {
+	private static final class Simple extends StringChoiceRenderer {
+		private static final long serialVersionUID = 1L;
 
-	private static final long serialVersionUID = 1L;
-
-	private String keyPrefix;
-	private String splitPattern;
-
-	public StringChoiceRenderer(String keyPrefix) {
-		this.keyPrefix = StringUtils.isNotBlank(keyPrefix) ? keyPrefix : "";
-	}
-
-	public StringChoiceRenderer(String keyPrefix, String splitPattern) {
-		this.keyPrefix = StringUtils.isNotBlank(keyPrefix) ? keyPrefix : "";
-		this.splitPattern = splitPattern;
-	}
-
-	@Override
-	public String getObject(String id, IModel<? extends List<? extends String>> choices) {
-		return StringUtils.isNotBlank(id) ? choices.getObject().get(Integer.parseInt(id)) : null;
-	}
-
-	@Override
-	public String getDisplayValue(String object) {
-		if (StringUtils.isNotBlank(splitPattern)){
-			String[] fields = object.split(splitPattern);
-			object = fields[1];
+		@Override
+		public String getDisplayValue(final String object) {
+			return object;
 		}
 
-		if (StringUtils.isNotBlank(keyPrefix)){
+		Object readResolve() {
+			return SIMPLE;
+		}
+	}
+
+	public static class Prefixed extends StringChoiceRenderer {
+		private static final long serialVersionUID = 1L;
+
+		private final String keyPrefix;
+
+		public Prefixed(final String keyPrefix) {
+			this.keyPrefix = requireNonNull(keyPrefix);
+		}
+
+		@Override
+		public String getDisplayValue(final String object) {
 			return Application.get().getResourceSettings().getLocalizer().getString(keyPrefix + object, null);
 		}
+	}
 
-		return object;
+	private static final class PrefixedSplit extends Prefixed {
+		private static final long serialVersionUID = 1L;
+
+		private final Pattern splitPattern;
+
+		PrefixedSplit(final String keyPrefix, final Pattern splitPattern) {
+			super(keyPrefix);
+			this.splitPattern = requireNonNull(splitPattern);
+		}
+
+		@Override
+		public String getDisplayValue(final String object) {
+			return super.getDisplayValue(splitPattern.split(object)[1]);
+		}
+	}
+
+	private static final StringChoiceRenderer SIMPLE = new Simple();
+
+	private static final long serialVersionUID = 2L;
+
+	public static StringChoiceRenderer simple() {
+		return SIMPLE;
+	}
+
+	public static StringChoiceRenderer prefixed(final String keyPrefix) {
+		return StringUtils.isBlank(keyPrefix) ? SIMPLE : new Prefixed(keyPrefix);
+	}
+
+	public static StringChoiceRenderer prefixedSplit(final String keyPrefix, final String splitPattern) {
+		if (StringUtils.isBlank(splitPattern)) {
+			return prefixed(keyPrefix);
+		}
+
+		return new PrefixedSplit(StringUtils.isBlank(keyPrefix) ? "" : keyPrefix, Pattern.compile(splitPattern));
 	}
 
 	@Override
-	public String getIdValue(String object, int index) {
-		return Integer.toString(index);
+	public String getObject(final String id, final IModel<? extends List<? extends String>> choices) {
+		return StringUtils.isBlank(id) ? null : choices.getObject().get(Integer.parseInt(id));
 	}
 
+	@Override
+	public String getIdValue(final String object, final int index) {
+		return Integer.toString(index);
+	}
 }

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/wizard/resource/component/schemahandling/modal/MappingEditorDialog.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/wizard/resource/component/schemahandling/modal/MappingEditorDialog.java
@@ -110,6 +110,8 @@ public class MappingEditorDialog extends ModalWindow {
 
 	private static final int CODE_ROW_COUNT = 5;
 
+	private static final StringChoiceRenderer CHANNEL_RENDERER = StringChoiceRenderer.prefixedSplit("Channel.", "#");
+
 	private boolean initialized;
 	private IModel<MappingTypeDto> model;
 	private Map<String, String> policyMap = new HashMap<>();
@@ -255,7 +257,7 @@ public class MappingEditorDialog extends ModalWindow {
 
 			@Override
 			protected IChoiceRenderer<String> createRenderer() {
-				return new StringChoiceRenderer("Channel.", "#");
+				return CHANNEL_RENDERER;
 
 			}
 		};
@@ -282,7 +284,7 @@ public class MappingEditorDialog extends ModalWindow {
 
 			@Override
 			protected IChoiceRenderer<String> createRenderer() {
-					return new StringChoiceRenderer("Channel.", "#");
+					return CHANNEL_RENDERER;
 			}
 		};
 		form.add(exceptChannel);

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/wizard/resource/component/synchronization/SynchronizationReactionEditor.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/wizard/resource/component/synchronization/SynchronizationReactionEditor.java
@@ -78,6 +78,8 @@ public class SynchronizationReactionEditor extends BasePanel<SynchronizationReac
     private static final String ID_T_OBJ_TEMPLATE = "objectTemplateRefTooltip";
     private static final String ID_T_ACTION = "actionTooltip";
 
+    private static final StringChoiceRenderer CHANNEL_RENDERER = StringChoiceRenderer.prefixedSplit("Channel.", "#");
+
     private Map<String, String> objectTemplateMap = new HashMap<>();
 
 	@NotNull private final SynchronizationStep parentStep;
@@ -138,8 +140,7 @@ public class SynchronizationReactionEditor extends BasePanel<SynchronizationReac
 
             @Override
             protected IChoiceRenderer<String> createRenderer() {
-            	return new StringChoiceRenderer("Channel.", "#");
-
+                return CHANNEL_RENDERER;
             }
         };
         add(channel);

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/configuration/PageAccounts.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/configuration/PageAccounts.java
@@ -360,7 +360,7 @@ public class PageAccounts extends PageAdminConfiguration {
 
         DropDownChoice intent = new DropDownChoice<>(ID_SEARCH_INTENT,
                 new PropertyModel<String>(searchModel, AccountDetailsSearchDto.F_INTENT),
-                createIntentChoices(), new StringChoiceRenderer(null));
+                createIntentChoices(), StringChoiceRenderer.simple());
         intent.setNullValid(true);
         intent.add(new OnChangeAjaxBehavior() {
 

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/configuration/component/LoggingConfigPanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/configuration/component/LoggingConfigPanel.java
@@ -361,7 +361,7 @@ public class LoggingConfigPanel extends SimplePanel<LoggingDto> {
                 options.setObject(optionsMap);
                 ListMultipleChoicePanel panel = new ListMultipleChoicePanel<>(componentId,
                         new PropertyModel<List<String>>(model, getPropertyExpression()),
-                        createNewLoggerAppendersListModel(), new StringChoiceRenderer(null), options);
+                        createNewLoggerAppendersListModel(), StringChoiceRenderer.simple(), options);
 
                 FormComponent<AppenderConfigurationType> input = panel.getBaseFormComponent();
                 input.add(new EmptyOnChangeAjaxFormUpdatingBehavior());

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/reports/PageCreatedReports.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/reports/PageCreatedReports.java
@@ -172,7 +172,7 @@ public class PageCreatedReports extends PageAdminReports {
         DropDownChoicePanel<String> reportTypeSelect = new DropDownChoicePanel(ID_REPORT_TYPE_SELECT,
               Model.of(reportTypeMal.get(getReportType())),
               Model.of(reportTypeMal.values()),
-              new StringChoiceRenderer(null), true);
+              StringChoiceRenderer.simple(), true);
 
       reportTypeSelect.getBaseFormComponent().add(new OnChangeAjaxBehavior() {
 

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/server/PageTaskAdd.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/server/PageTaskAdd.java
@@ -150,6 +150,9 @@ public class PageTaskAdd extends PageAdminTasks {
     private static final String OPERATION_LOAD_RESOURCES = DOT_CLASS + "createResourceList";
     private static final String OPERATION_LOAD_RESOURCE = DOT_CLASS + "loadResource";
     private static final String OPERATION_SAVE_TASK = DOT_CLASS + "saveTask";
+
+    private static final StringChoiceRenderer CATEGORY_RENDERER = StringChoiceRenderer.prefixed("pageTask.category.");
+
     private IModel<TaskAddDto> model;
 
     public PageTaskAdd() {
@@ -341,7 +344,7 @@ public class PageTaskAdd extends PageAdminTasks {
                     public List<String> getObject() {
                         return WebComponentUtil.createTaskCategoryList();
                     }
-                }, new StringChoiceRenderer("pageTask.category."));
+                }, CATEGORY_RENDERER);
         type.add(new AjaxFormComponentUpdatingBehavior("change") {
 
             @Override

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/server/PageTasks.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/server/PageTasks.java
@@ -1587,9 +1587,9 @@ public class PageTasks extends PageAdminTasks implements Refreshable {
                             return createCategoryList();
                         }
                     },
-                    new StringChoiceRenderer("pageTasks.category.") {
+                    new StringChoiceRenderer.Prefixed("pageTasks.category.") {
 
-                    	 @Override
+                        @Override
                         public String getDisplayValue(String object) {
                             if (ALL_CATEGORIES.equals(object)) {
                                 object = "AllCategories";


### PR DESCRIPTION
This class is used in three distinct cases:
- no prefix at all
- with a prefix
- with a prefix and a split pattern

Refactor each case into a separate subclass and expose them
via static factory methods. This allows for smaller footprint
and more direct execution paths, as well as sharing a single object
for the non-prefixed case.

Users are updated to account for the split and to reuse instances
where possible.

Signed-off-by: Robert Varga <nite@hq.sk>