### PR TITLE
Let there be more space for My Work Items!

### DIFF
--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/self/PageSelfDashboard.html
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/self/PageSelfDashboard.html
@@ -23,7 +23,7 @@
             <div class="quicksearch-panel" wicket:id="searchPanel"/>
             <div wicket:id="linksPanel"/>
         </div>
-        <div class="col-md-6">
+        <div class="col-md-12">
             <div wicket:id="workItemsPanel"/>
         </div>
     </div>


### PR DESCRIPTION
I believe there is no need for My Work Items to cover only half of screen. They deserve as much space as My Requests.
So I changed col-md-6 to col-md-12