### PR TITLE
Make SelectorOptions modify list of fetched attrs

### DIFF
--- a/provisioning/provisioning-impl/src/main/java/com/evolveum/midpoint/provisioning/util/ProvisioningUtil.java
+++ b/provisioning/provisioning-impl/src/main/java/com/evolveum/midpoint/provisioning/util/ProvisioningUtil.java
@@ -188,7 +188,7 @@ public class ProvisioningUtil {
 			AttributeFetchStrategyType fetchStrategy = attributeDefinition.getFetchStrategy();
 			if (fetchStrategy != null && fetchStrategy == AttributeFetchStrategyType.EXPLICIT) {
 				explicit.add(attributeDefinition);
-			} else if (hasMinimal && fetchStrategy != AttributeFetchStrategyType.MINIMAL) {
+			} else if (hasMinimal && (fetchStrategy != AttributeFetchStrategyType.MINIMAL || SelectorOptions.hasToLoadPath(attributeDefinition.getName(), ctx.getGetOperationOptions()))) {
 				explicit.add(attributeDefinition);
 			}
 		}


### PR DESCRIPTION
SelectorOptions retrieval settings currently influences only several hardcoded attributes (see blocks of code labeled by comments Password, Activation etc.). With this change attributes with minimal fetch strategy will not be in the list given to the connector by default, but can be turned on by setting their selector option retrieval to INCLUDE.