### PR TITLE
Fixed hashCode in LayeredRefinedAttributeDefinitionImpl

### DIFF
--- a/infra/common/src/main/java/com/evolveum/midpoint/common/refinery/LayerRefinedAttributeDefinitionImpl.java
+++ b/infra/common/src/main/java/com/evolveum/midpoint/common/refinery/LayerRefinedAttributeDefinitionImpl.java
@@ -161,7 +161,7 @@ public class LayerRefinedAttributeDefinitionImpl<T> implements LayerRefinedAttri
 	@Override
 	public int hashCode() {
 		final int prime = 31;
-		int result = super.hashCode();
+		int result = 17;
 		result = prime * result + ((layer == null) ? 0 : layer.hashCode());
 		result = prime * result + ((refinedAttributeDefinition == null) ? 0 : refinedAttributeDefinition.hashCode());
 		return result;


### PR DESCRIPTION
The hashCode breaks equals contract by calling super.hashCode() which is java.lang.Object.hashCode().

This was breaking ExpressionFactory.cache key hashCode causing the cache to grow indefinitely.