### PR TITLE
Optimize map iterations using entrySet()

### DIFF
--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/DropDownMultiChoice.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/DropDownMultiChoice.java
@@ -71,11 +71,11 @@ public class DropDownMultiChoice<T> extends ListMultipleChoice<T> {
         }
 
         sb.append('{');
-        Iterator<String> keys = map.keySet().iterator();
+       Iterator<Map.Entry<String, String>> keys = map.entrySet().iterator();
         while (keys.hasNext()) {
-            String key = keys.next();
-            sb.append(key).append(":");
-            sb.append('\'').append(map.get(key)).append('\'');
+            final Map.Entry<String, String> key = keys.next();
+            sb.append(key.getKey()).append(":");
+            sb.append('\'').append(key.getValue()).append('\'');
             if (keys.hasNext()) {
                 sb.append(",\n");
             }

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/security/MidPointApplication.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/security/MidPointApplication.java
@@ -357,18 +357,18 @@ public class MidPointApplication extends AuthenticatedWebApplication {
                 map.put(key, properties.getProperty(key));
             }
 
-            for (String key : localeMap.keySet()) {
-                Map<String, String> localeDefinition = localeMap.get(key);
-                if (!localeDefinition.containsKey(key + PROP_NAME)
-                        || !localeDefinition.containsKey(key + PROP_FLAG)) {
+            for (Map.Entry<String, Map<String, String>> entry : localeMap.entrySet()) {
+                Map<String, String> localeDefinition = entry.getValue();
+                if (!localeDefinition.containsKey(entry + PROP_NAME)
+                        || !localeDefinition.containsKey(entry + PROP_FLAG)) {
                     continue;
                 }
 
                 LocaleDescriptor descriptor = new LocaleDescriptor(
-                        localeDefinition.get(key + PROP_NAME),
-                        localeDefinition.get(key + PROP_FLAG),
-                        localeDefinition.get(key + PROP_DEFAULT),
-                        WebComponentUtil.getLocaleFromString(key)
+                        localeDefinition.get(entry + PROP_NAME),
+                        localeDefinition.get(entry + PROP_FLAG),
+                        localeDefinition.get(entry + PROP_DEFAULT),
+                        WebComponentUtil.getLocaleFromString(entry.getKey())
                 );
                 locales.add(descriptor);
             }

--- a/infra/prism/src/main/java/com/evolveum/midpoint/prism/marshaller/ItemPathHolder.java
+++ b/infra/prism/src/main/java/com/evolveum/midpoint/prism/marshaller/ItemPathHolder.java
@@ -543,17 +543,18 @@ public class ItemPathHolder {
 
 	private void addExplicitNsDeclarations(StringBuilder sb) {
 		if (explicitNamespaceDeclarations != null) {
-			for (String prefix : explicitNamespaceDeclarations.keySet()) {
+			for (Map.Entry<String, String> prefix : explicitNamespaceDeclarations.entrySet()) {
 				sb.append("declare ");
+				final String declaration = explicitNamespaceDeclarations.get(prefix);
 				if (prefix.equals("")) {
 					sb.append("default namespace '");
-					sb.append(explicitNamespaceDeclarations.get(prefix));
+					sb.append(declaration);
 					sb.append("'; ");
 				} else {
 					sb.append("namespace ");
 					sb.append(prefix);
 					sb.append("='");
-					sb.append(explicitNamespaceDeclarations.get(prefix));
+					sb.append(declaration);
 					sb.append("'; ");
 				}
 			}

--- a/infra/prism/src/main/java/com/evolveum/midpoint/prism/xml/XsdTypeMapper.java
+++ b/infra/prism/src/main/java/com/evolveum/midpoint/prism/xml/XsdTypeMapper.java
@@ -152,13 +152,13 @@ public class XsdTypeMapper {
     public static <T> Class<T> getXsdToJavaMapping(QName xsdType) {
     	Class clazz = xsdToJavaTypeMap.get(xsdType);
     	if (clazz == null){
-    		Set<QName> keys = xsdToJavaTypeMap.keySet();
-    		for (Iterator<QName> iterator = keys.iterator(); iterator.hasNext();){
-    			QName key = iterator.next();
-    			if (QNameUtil.match(key, xsdType)){
-    				return xsdToJavaTypeMap.get(key);
-    			}
-    		}
+    		Set<Map.Entry<QName, Class>> entries = xsdToJavaTypeMap.entrySet();
+    		for (Map.Entry<QName, Class> entry : entries) {
+                QName key = entry.getKey();
+                if (QNameUtil.match(key, xsdType)){
+                    return entry.getValue();
+                }
+            }
     	}
     	return xsdToJavaTypeMap.get(xsdType);
     }

--- a/infra/util/src/main/java/com/evolveum/midpoint/util/aspect/ProfilingDataManager.java
+++ b/infra/util/src/main/java/com/evolveum/midpoint/util/aspect/ProfilingDataManager.java
@@ -268,10 +268,10 @@ public class ProfilingDataManager {
     }
 
     private static void printMap(Map<String, MethodUsageStatistics> logMap, Subsystem subsystem, boolean afterTest){
-
-        for(String key: logMap.keySet()){
-            if(logMap.get(key) != null && subsystem.equals(logMap.get(key).getSubsystem())){
-                logMap.get(key).appendToLogger(afterTest);
+        for (Map.Entry<String, MethodUsageStatistics> usage : logMap.entrySet()){
+            final MethodUsageStatistics value = usage.getValue();
+            if(subsystem.equals(value.getSubsystem())){
+                value.appendToLogger(afterTest);
             }
         }
     }

--- a/model/model-common/src/main/java/com/evolveum/midpoint/model/common/stringpolicy/ValuePolicyProcessor.java
+++ b/model/model-common/src/main/java/com/evolveum/midpoint/model/common/stringpolicy/ValuePolicyProcessor.java
@@ -554,9 +554,10 @@ public class ValuePolicyProcessor {
 		 * first in password
 		 */
 		Map<StringLimitType, List<String>> mustBeFirst = new HashMap<>();
-		for (StringLimitType l : lims.keySet()) {
-			if (l.isMustBeFirst() != null && l.isMustBeFirst()) {
-				mustBeFirst.put(l, lims.get(l));
+		for (Map.Entry<StringLimitType, List<String>> entry : lims.entrySet()) {
+			final StringLimitType key = entry.getKey();
+			if (key.isMustBeFirst() != null && key.isMustBeFirst()) {
+				mustBeFirst.put(key, entry.getValue());
 			}
 		}
 
@@ -771,26 +772,28 @@ public class ValuePolicyProcessor {
 			List<String> password, Boolean skipMatchedLims, boolean uniquenessReached, OperationResult op) {
 		HashMap<String, Integer> counter = new HashMap<>();
 
-		for (StringLimitType l : lims.keySet()) {
+		Map<StringLimitType, List<String>> mustBeFirst = new HashMap<>();
+		for (Map.Entry<StringLimitType, List<String>> entry : lims.entrySet()) {
+			final StringLimitType key = entry.getKey();
 			int counterKey = 1;
-			List<String> chars = lims.get(l);
+			List<String> chars = entry.getValue();
 			int i = 0;
 			if (null != password) {
-				i = charIntersectionCounter(lims.get(l), password);
+				i = charIntersectionCounter(entry.getValue(), password);
 			}
 			// If max is exceed then error unable to continue
-			if (l.getMaxOccurs() != null && i > l.getMaxOccurs()) {
-				OperationResult o = new OperationResult("Limitation check :" + l.getDescription());
+			if (key.getMaxOccurs() != null && i > key.getMaxOccurs()) {
+				OperationResult o = new OperationResult("Limitation check :" + key.getDescription());
 				o.recordFatalError(
-						"Exceeded maximal value for this limitation. " + i + ">" + l.getMaxOccurs());
+					"Exceeded maximal value for this limitation. " + i + ">" + key.getMaxOccurs());
 				op.addSubresult(o);
 				return null;
 				// if max is all ready reached or skip enabled for minimal skip
 				// counting
-			} else if (l.getMaxOccurs() != null && i == l.getMaxOccurs()) {
+			} else if (key.getMaxOccurs() != null && i == key.getMaxOccurs()) {
 				continue;
 				// other cases minimum is not reached
-			} else if ((l.getMinOccurs() == null || i >= l.getMinOccurs()) && !skipMatchedLims) {
+			} else if ((key.getMinOccurs() == null || i >= key.getMinOccurs()) && !skipMatchedLims) {
 				continue;
 			}
 			for (String s : chars) {
@@ -803,8 +806,8 @@ public class ValuePolicyProcessor {
 				}
 			}
 			counterKey++;
-
 		}
+
 
 		// If need to remove disabled chars (already reached limitations)
 		if (null != password) {

--- a/model/notifications-impl/src/main/java/com/evolveum/midpoint/notifications/impl/api/transports/MailTransport.java
+++ b/model/notifications-impl/src/main/java/com/evolveum/midpoint/notifications/impl/api/transports/MailTransport.java
@@ -177,7 +177,7 @@ public class MailTransport implements Transport {
                 LOGGER.debug("Using mail properties: ");
                 for (Object key : properties.keySet()) {
                     if (key instanceof String && ((String) key).startsWith("mail.")) {
-                        LOGGER.debug(" - " + key + " = " + properties.get(key));
+                        LOGGER.debug(" - {} = {}", key, properties.get(key));
                     }
                 }
             }

--- a/tools/xjc-plugin/src/main/java/com/evolveum/midpoint/schema/xjc/schema/SchemaProcessor.java
+++ b/tools/xjc-plugin/src/main/java/com/evolveum/midpoint/schema/xjc/schema/SchemaProcessor.java
@@ -1117,9 +1117,9 @@ public class SchemaProcessor implements Processor {
 
 			print("Updating fields and get/set methods: " + classOutline.implClass.fullName());
 
-			for (String field : fields.keySet()) {
-                JFieldVar fieldVar = fields.get(field);
-				// marks a:rawType fields with @Raw - this has to be executed for any bean, not only for prism containers
+            for (Map.Entry<String, JFieldVar> field : fields.entrySet()) {
+                JFieldVar fieldVar = field.getValue();
+                // marks a:rawType fields with @Raw - this has to be executed for any bean, not only for prism containers
                 if (hasAnnotation(classOutline, fieldVar, A_RAW_TYPE) != null) {
                     annotateFieldAsRaw(fieldVar);
                 }
@@ -1134,7 +1134,7 @@ public class SchemaProcessor implements Processor {
         }
 
         allFieldsToBeRemoved.forEach((jDefinedClass, jFieldVars) -> {
-        	jFieldVars.forEach(field -> jDefinedClass.removeField(field));
+        	jFieldVars.forEach(jDefinedClass::removeField);
 		});
     }
 
@@ -1148,8 +1148,8 @@ public class SchemaProcessor implements Processor {
 		boolean isObject = hasAnnotation(classOutline, A_PRISM_OBJECT);
 
 		List<JFieldVar> fieldsToBeRemoved = new ArrayList<>();
-		for (String field : fields.keySet()) {
-			JFieldVar fieldVar = fields.get(field);
+        for (Map.Entry<String, JFieldVar> field : fields.entrySet()) {
+			JFieldVar fieldVar = field.getValue();
 			if (isAuxiliaryField(fieldVar)) {
 				continue;
 			}
@@ -1183,8 +1183,8 @@ public class SchemaProcessor implements Processor {
 
 	private void createFluentFieldMethods(ClassOutline targetClass, ClassOutline sourceClass) {
 		Map<String, JFieldVar> fields = sourceClass.implClass.fields();
-		for (String field : fields.keySet()) {
-			JFieldVar fieldVar = fields.get(field);
+        for (Map.Entry<String, JFieldVar> field : fields.entrySet()) {
+            JFieldVar fieldVar = field.getValue();
 			if (!isAuxiliaryField(fieldVar) && !hasAnnotationClass(fieldVar, XmlAnyElement.class)) {
 				createFluentFieldMethods(fieldVar, targetClass, sourceClass);
 			}


### PR DESCRIPTION
A number of map iterations access values using a key fetched from keySet. Using entrySet is more efficient, in order to avoid get(key) lookups later.