### PR TITLE
Fixed Couldn't record operation execution

### DIFF
--- a/model/model-impl/src/main/java/com/evolveum/midpoint/model/impl/lens/Clockwork.java
+++ b/model/model-impl/src/main/java/com/evolveum/midpoint/model/impl/lens/Clockwork.java
@@ -875,7 +875,7 @@ public class Clockwork {
 			}
 		}
 		// delete all surplus executions
-		if (recordsToKeep != null && object.asObjectable().getOperationExecution().size() > recordsToKeep - 1) {
+		if (recordsToKeep != null && executions.size() > recordsToKeep - 1) {
 			if (keepNoExecutions) {
 				executionsToDelete.addAll(executions);
 			} else {


### PR DESCRIPTION
I found tons of log messages
(com.evolveum.midpoint.model.impl.lens.Clockwork): Couldn't record operation execution. Model context:
...
caused by
java.lang.IllegalArgumentException: fromIndex(0) > toIndex(-1)
        at java.util.ArrayList.subListRangeCheck(ArrayList.java:1006)
        at java.util.ArrayList.subList(ArrayList.java:996)
        at com.evolveum.midpoint.model.impl.lens.Clockwork.storeOperationExecution(Clockwork.java:883)

The array in the condition was no longer the same as the array in subList call, there may be items deleted just two lines above.