### PR TITLE
fix Conflicting modification in delta exceptions

### DIFF
--- a/infra/prism/src/main/java/com/evolveum/midpoint/prism/delta/ContainerDelta.java
+++ b/infra/prism/src/main/java/com/evolveum/midpoint/prism/delta/ContainerDelta.java
@@ -169,16 +169,18 @@ public class ContainerDelta<V extends Containerable> extends ItemDelta<PrismCont
 		if (cvalues == null) {
 			return null;
 		}
+		boolean foundValuesOnPath = false;
 		Collection<PrismValue> subValues = new ArrayList<PrismValue>();
 		for (PrismContainerValue<V> cvalue: cvalues) {
 			if (id == null || id == cvalue.getId()) {
 				Item<?,?> item = cvalue.findItem(path);
 				if (item != null) {
 					subValues.addAll(PrismValue.cloneCollection(item.getValues()));
+					foundValuesOnPath = true;
 				}
 			}
 		}
-		return subValues;
+		return foundValuesOnPath ? subValues : null;
 	}
 
 	/**


### PR DESCRIPTION
This fixes the "Conflicting modification in delta" exceptions  when delta has no modifications in conflict. If this change makes sense, please port to 3.8 and master as well.

TLDR Preparing mapping source values with paths into containers that are created or modified in the current object delta by multiple non-conflicting modifications could lead to 'Conflicting modification in delta'. I belive the problem is ContainerDelta.findItemValues treats empty collection ItemDelta as empty while ItemDelta.isEmpty thinks otherwise.

To save you an ugly debugging session and justify my change, here is the long story:

Test case is changing users password for the first time - midpoint creates one modification for credentials/password/value and another for credentials/password/metadata in the object delta. When resolving object template mapping source path 'credentials/password/metadata/modifyTimestamp' in wave 1, debugging shows that 

1. ObjectDeltaObject.findIdi checks all delta modifications for potential conflicts
2. the first modification to 'credentials/password/value' triggers the SUBPATH branch
3. ContainerDelta.getSubDelta calls ContainerDelta.findItemValues for valuesToReplace
4. findItemValues returns an empty collection (no 'metadata' in password/value modification)
5. getSubDelta interpretes the resulting ItemDelta with null add and delete but with empty replace collection as NOT EMPTY
6. back in findIdi itemDelta is set with this 'not empty but empty' delta. if i understand the situation, this represents a fake modification to 'credentials/password/metadata/modifyTimestamp'
7. findIdi checks the second modification to 'credentials/password/metadata', subpath is triggered again and fake 'Conflicting modification' is thrown

The fix seemed to me as the smallest change fixing this situation. I assume findItemValues is not supposed to find 'values' (as interpreted by ItemDelta.isEmpty) of 'password/metadata/modifyTimestamp' in a credentials container with 'password/value'.