### PR TITLE
Fix handling negative assignmentPathIndex

### DIFF
--- a/model/model-impl/src/main/java/com/evolveum/midpoint/model/impl/lens/AssignmentPathImpl.java
+++ b/model/model-impl/src/main/java/com/evolveum/midpoint/model/impl/lens/AssignmentPathImpl.java
@@ -59,7 +59,7 @@ public class AssignmentPathImpl implements AssignmentPath {
 		if (index >= 0) {
 			return segments.get(index);
 		} else {
-			return segments.get(segments.size() - index);
+			return segments.get(segments.size() + index);
 		}
 	}
 


### PR DESCRIPTION
When using negative assignmentPathIndex, it always causes `IndexOutOfBoundsException`.