### PR TITLE
Apply subtype using page parameter when accessing new object page

### DIFF
--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/PageAdminObjectDetails.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/PageAdminObjectDetails.java
@@ -303,6 +303,11 @@ public abstract class PageAdminObjectDetails<O extends ObjectType> extends PageA
 				if (objectToEdit == null) {
 					LOGGER.trace("Loading object: New object (creating)");
 					O focusType = createNewObject();
+
+					// Apply subtype using page parameters
+					List<StringValue> subtypes = getPageParameters().getValues(ObjectType.F_SUBTYPE.getLocalPart());
+					subtypes.stream().filter(p -> !p.isEmpty()).forEach(c -> focusType.subtype(c.toString()));
+
 					getMidpointApplication().getPrismContext().adopt(focusType);
 					object = (PrismObject<O>) focusType.asPrismObject();
 				} else {


### PR DESCRIPTION
This is very small PR, but it helps creating subtype-specific new object form. 

For example, when we define custom form using object templates for two subtype of UserType like `permanent` and `temporary`, we can open the new page using below links. Also we can define these links as additionalMenuLink or additionalMenuLink in adminGuiConfiguration. It's very useful. 

* /admin/user?subtype=permanent
* /admin/user?subtype=temporary


