### PR TITLE
Fix MID-4867 5 for all browsers

### DIFF
--- a/gui/admin-gui/src/main/resources/static/less/midpoint-theme.less
+++ b/gui/admin-gui/src/main/resources/static/less/midpoint-theme.less
@@ -1460,10 +1460,8 @@ th.countLabel{
 	table-layout: fixed; // fix for text in cells
 }
 
-@-moz-document url-prefix() {
-.shopping-cart-icon > .badge { //fix for bug in firefox
+.shopping-cart-icon > .badge {
     margin-left: -10px !important;
-}
 }
 
 @media (max-width: 767px) {


### PR DESCRIPTION
I noticed [MID-4867](https://jira.evolveum.com/browse/MID-4867) 5 (Number icon in new shopping cart position is misplaced in Firefox) is also occurring in other browsers (Chrome, IE11 with IE9 mode).
I think the css style should be applied to all browsers.

#### Chrome
![image](https://user-images.githubusercontent.com/28739/64409483-ee7ed380-d0c3-11e9-94c7-a374e773534a.png)

#### IE11 with IE9 mode
![image](https://user-images.githubusercontent.com/28739/64409550-179f6400-d0c4-11e9-86c6-c9cdbaabd1e4.png)

