### PR TITLE
Fix IllegalArgumentException when opening task panel without permission

### DIFF
--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/server/PageTasks.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/server/PageTasks.java
@@ -1005,7 +1005,8 @@ public class PageTasks extends PageAdminTasks implements Refreshable {
 			@Override
 			protected IModel createLinkModel(IModel<TaskDto> rowModel) {
 				PageBase page = (PageBase) component.getPage();
-				IModel<String> taskNameModel = page.createStringResource(rowModel.getObject().getName());
+				String name = rowModel.getObject().getName();
+				IModel<String> taskNameModel = StringUtils.isNotEmpty(name) ? page.createStringResource(name) : null;
 				String taskName = taskNameModel != null && StringUtils.isNotEmpty(taskNameModel.getObject()) ?
 						taskNameModel.getObject() : "";
 


### PR DESCRIPTION
When the user who doesn't have proper permission opens task panel, the following IllegalArgumentException is thrown. I added checking code before calling `PageBase#createStringResource`.

```
Caused by: java.lang.IllegalArgumentException: Argument 'resource key' may not be null.
        at org.apache.wicket.util.lang.Args.notNull(Args.java:41)
        at org.apache.wicket.model.StringResourceModel.<init>(StringResourceModel.java:305)
        at org.apache.wicket.model.StringResourceModel.<init>(StringResourceModel.java:327)
        at com.evolveum.midpoint.gui.api.page.PageBase.createStringResource(PageBase.java:1231)
        at com.evolveum.midpoint.web.page.admin.server.PageTasks$26.createLinkModel(PageTasks.java:1008)
        at com.evolveum.midpoint.web.component.data.column.LinkColumn.populateItem(LinkColumn.java:59)
        at org.apache.wicket.extensions.markup.html.repeater.data.grid.AbstractDataGridView.populateItem(AbstractDataGridView.java:156)
        at org.apache.wicket.markup.repeater.RefreshingView$1.newItem(RefreshingView.java:114)
        at org.apache.wicket.markup.repeater.DefaultItemReuseStrategy$1.next(DefaultItemReuseStrategy.java:75)
        at org.apache.wicket.markup.repeater.DefaultItemReuseStrategy$1.next(DefaultItemReuseStrategy.java:56)
        at org.apache.wicket.markup.repeater.RefreshingView.addItems(RefreshingView.java:189)
        at org.apache.wicket.markup.repeater.RefreshingView.onPopulate(RefreshingView.java:97)
        at org.apache.wicket.markup.repeater.AbstractRepeater.onBeforeRender(AbstractRepeater.java:124)
        at org.apache.wicket.markup.repeater.AbstractPageableView.onBeforeRender(AbstractPageableView.java:115)
        at org.apache.wicket.Component.internalBeforeRender(Component.java:950)
        at org.apache.wicket.Component.beforeRender(Component.java:1018)
        at org.apache.wicket.MarkupContainer.onBeforeRenderChildren(MarkupContainer.java:1825)
        ... 113 common frames omitted
```