### PR TITLE
make the start method wait until the debry server is accesible

### DIFF
--- a/infra/test-util/src/main/java/com/evolveum/midpoint/test/util/DerbyController.java
+++ b/infra/test-util/src/main/java/com/evolveum/midpoint/test/util/DerbyController.java
@@ -110,6 +110,16 @@ public class DerbyController {
         server = new NetworkServerControl(listenAddress, listenPort);
         System.setProperty("derby.stream.error.file", "target/derby.log");
         server.start(null);
+        boolean dbServerOk = false;
+        do {
+            try {
+                Thread.sleep(100);
+                server.ping();
+                dbServerOk = true;
+            } catch (Exception e) {
+                LOGGER.debug("Derby embedded network server not ready yet...");
+            }
+        } while (!dbServerOk);
     }
 
     public void stop() throws Exception {


### PR DESCRIPTION
When running the tests I encountered a timing issue where the derby server was not ready and a connection was being established resulting in a connection failure. This fix waits until the server pings back before continuing the test.