### PR TITLE
Fix axiom parser grammar

### DIFF
--- a/infra/axiom/src/main/antlr4/com/evolveum/axiom/lang/antlr/Axiom.g4
+++ b/infra/axiom/src/main/antlr4/com/evolveum/axiom/lang/antlr/Axiom.g4
@@ -25,8 +25,9 @@ itemName: infraName | dataName;
 dataName: prefixedName;
 infraName: '@' prefixedName;
 
-item: SEP* itemName SEP* itemValue;
-itemValue: (argument)? SEP* (SEMICOLON | LEFT_BRACE SEP* (item)* SEP* RIGHT_BRACE SEP*) SEP*;
+file: SEP* item SEP* EOF;
+item: itemName itemValue;
+itemValue: (SEP+ argument)? SEP* (SEMICOLON | LEFT_BRACE SEP* (item SEP*)* RIGHT_BRACE);
 
 prefixedName : (prefix COLON)? localName;
 

--- a/infra/axiom/src/main/java/com/evolveum/axiom/lang/antlr/AxiomAntlrStatementSource.java
+++ b/infra/axiom/src/main/java/com/evolveum/axiom/lang/antlr/AxiomAntlrStatementSource.java
@@ -36,7 +36,7 @@ public class AxiomAntlrStatementSource {
         parser.removeErrorListeners();
         AxiomErrorListener errorListener = new AxiomErrorListener(sourceName);
         parser.addErrorListener(errorListener);
-        ItemContext statement = parser.item();
+        ItemContext statement = parser.file().item();
         errorListener.validate();
         return statement;
     }


### PR DESCRIPTION
Having SEP as a start of token leads to misleading item start pointer
when issuing diagnostic. Cleanup when separaterors are, and make sure
item starts with non-whitespace.

Signed-off-by: Robert Varga <robert.varga@pantheon.tech>