### PR TITLE
Resource administrative operational state (aka resource maintenance)

### DIFF
--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/api/GuiStyleConstants.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/api/GuiStyleConstants.java
@@ -79,6 +79,8 @@ public class GuiStyleConstants {
     public static final String CLASS_ICON_STYLE_END_USER = "icon-style-end-user";
     public static final String CLASS_ICON_STYLE_MANAGER = "icon-style-manager";
     public static final String CLASS_ICON_STYLE_WARNING = "icon-style-warning";
+
+    public static final String CLASS_ICON_STYLE_MAINTENANCE = "icon-style-maintenance";
     public static final String CLASS_ICON_STYLE_UP = "icon-style-up";
     public static final String CLASS_ICON_STYLE_DOWN = "icon-style-down";
     public static final String CLASS_ICON_STYLE_BROKEN = "icon-style-broken";
@@ -117,6 +119,7 @@ public class GuiStyleConstants {
     public static final String CLASS_ICON_ACTIVATION_INACTIVE = "fa fa-times";
     public static final String CLASS_ICON_RESOURCE_BROKEN = "fa fa-exclamation";
     public static final String CLASS_ICON_RESOURCE_UNKNOWN = "fa fa-question";
+    public static final String CLASS_ICON_RESOURCE_MAINTENANCE = "fa fa-snowflake-o";
     public static final String CLASS_ICON_ASSIGNMENTS = "fa fa-bank";
     public static final String CLASS_SHADOW_ICON_REQUEST = "fa fa-pencil-square-o";
     public static final String CLASS_ICON_TACHOMETER = "fa fa-tachometer";

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/api/util/WebComponentUtil.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/api/util/WebComponentUtil.java
@@ -2078,6 +2078,15 @@ public final class WebComponentUtil {
 
     public static String createResourceIcon(PrismObject<ResourceType> object) {
         OperationalStateType operationalState = object.asObjectable().getOperationalState();
+        AdministrativeOperationalStateType administrativeOperationalState = object.asObjectable().getAdministrativeOperationalState();
+
+        if (administrativeOperationalState != null) {
+            AdministrativeAvailabilityStatusType administrativeAvailabilityStatus = administrativeOperationalState.getAdministrativeAvailabilityStatus();
+            if (administrativeAvailabilityStatus == AdministrativeAvailabilityStatusType.MAINTENANCE) {
+                return GuiStyleConstants.CLASS_OBJECT_RESOURCE_ICON + " "
+                        + GuiStyleConstants.CLASS_ICON_STYLE_MAINTENANCE;
+            }
+        }
         if (operationalState != null) {
             AvailabilityStatusType lastAvailabilityStatus = operationalState.getLastAvailabilityStatus();
             if (lastAvailabilityStatus == AvailabilityStatusType.UP) {

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/resources/ResourceSummaryPanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/resources/ResourceSummaryPanel.java
@@ -9,6 +9,7 @@ package com.evolveum.midpoint.web.page.admin.resources;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.evolveum.midpoint.xml.ns._public.common.common_3.AdministrativeAvailabilityStatusType;
 import com.evolveum.midpoint.xml.ns._public.common.common_3.AvailabilityStatusType;
 import org.apache.wicket.model.IModel;
 
@@ -29,6 +30,7 @@ public class ResourceSummaryPanel extends ObjectSummaryPanel<ResourceType> {
     @Override
     protected List<SummaryTag<ResourceType>> getSummaryTagComponentList(){
         AvailabilityStatusType availability = ResourceTypeUtil.getLastAvailabilityStatus(getModelObject());
+        AdministrativeAvailabilityStatusType administrativeAvailability = ResourceTypeUtil.getAdministrativeAvailabilityStatus(getModelObject());
 
         List<SummaryTag<ResourceType>> summaryTagList = new ArrayList<>();
 
@@ -42,19 +44,24 @@ public class ResourceSummaryPanel extends ObjectSummaryPanel<ResourceType> {
                     setLabel(getString("ResourceSummaryPanel.UNKNOWN"));
                     return;
                 }
-                setLabel(ResourceSummaryPanel.this.getString(availability));
-                switch(availability) {
-                    case UP:
-                        setIconCssClass(GuiStyleConstants.CLASS_ICON_ACTIVATION_ACTIVE);
-                        break;
-                    case DOWN:
-                        setIconCssClass(GuiStyleConstants.CLASS_ICON_ACTIVATION_INACTIVE);
-                        break;
-                    case BROKEN:
-                        setIconCssClass(GuiStyleConstants.CLASS_ICON_RESOURCE_BROKEN);
-                        break;
 
+                if (AdministrativeAvailabilityStatusType.MAINTENANCE == administrativeAvailability) {
+                    setLabel(ResourceSummaryPanel.this.getString(administrativeAvailability));
+                    setIconCssClass(GuiStyleConstants.CLASS_ICON_RESOURCE_MAINTENANCE);
+                } else {
+                    setLabel(ResourceSummaryPanel.this.getString(availability));
+                    switch (availability) {
+                        case UP:
+                            setIconCssClass(GuiStyleConstants.CLASS_ICON_ACTIVATION_ACTIVE);
+                            break;
+                        case DOWN:
+                            setIconCssClass(GuiStyleConstants.CLASS_ICON_ACTIVATION_INACTIVE);
+                            break;
+                        case BROKEN:
+                            setIconCssClass(GuiStyleConstants.CLASS_ICON_RESOURCE_BROKEN);
+                            break;
 
+                    }
                 }
             }
         };

--- a/gui/admin-gui/src/main/resources/static/less/midpoint-theme.less
+++ b/gui/admin-gui/src/main/resources/static/less/midpoint-theme.less
@@ -222,6 +222,10 @@ body .treeview-menu > li > span:hover {
 	color: #f39c12;
 }
 
+.icon-style-maintenance {
+	color: #646665;
+}
+
 // Classes that can be added to color icons, info boxes and other widgets for particular object types
 
 .object-user-color {

--- a/infra/schema/src/main/java/com/evolveum/midpoint/schema/util/ResourceTypeUtil.java
+++ b/infra/schema/src/main/java/com/evolveum/midpoint/schema/util/ResourceTypeUtil.java
@@ -564,6 +564,21 @@ public class ResourceTypeUtil {
 
     }
 
+    public static AdministrativeAvailabilityStatusType getAdministrativeAvailabilityStatus(ResourceType resource) {
+        if (resource == null)
+            return null;
+
+        if (resource.getAdministrativeOperationalState() == null) {
+            return null;
+        }
+
+        if (resource.getAdministrativeOperationalState().getAdministrativeAvailabilityStatus() == null) {
+            return null;
+        }
+
+        return resource.getAdministrativeOperationalState().getAdministrativeAvailabilityStatus();
+    }
+
     public static boolean isAvoidDuplicateValues(ResourceType resource) {
         if (resource.getConsistency() == null) {
             return false;

--- a/infra/schema/src/main/resources/xml/ns/public/common/common-core-3.xsd
+++ b/infra/schema/src/main/resources/xml/ns/public/common/common-core-3.xsd
@@ -6393,6 +6393,7 @@
         <xsd:complexContent>
             <xsd:extension base="c:AssignmentHolderType">
                 <xsd:sequence>
+                    <xsd:element name="administrativeOperationalState" type="tns:AdministrativeOperationalStateType" minOccurs="0"/>
                     <xsd:element name="operationalState" type="tns:OperationalStateType" minOccurs="0"/>
                     <xsd:element name="operationalStateHistory" type="tns:OperationalStateType" minOccurs="0" maxOccurs="unbounded">
                         <xsd:annotation>
@@ -6505,6 +6506,28 @@
     </xsd:complexType>
     <xsd:element name="resource" type="tns:ResourceType" substitutionGroup="c:object"/>
 
+    <xsd:complexType name="AdministrativeOperationalStateType">
+        <xsd:annotation>
+            <xsd:documentation>
+                Structure containing metadata about administrative operational state of the resource.
+                Administrative operational state is set manually by midPoint users (e.g. administrator).
+                This is in contrast with OperationalStateType setting, which is set automatically by the midPoint.
+                It signalizes whether resource is up and OPERATIONAL to receive provisioning requests or is down in MAINTENANCE and midPoint should not contact it during the provisioning.
+                This setting is useful when resource is e.g. undergoing planned maintenance to save computing time and error messages.
+
+                EXPERIMENTAL FEATURE! Contributed by the community.
+            </xsd:documentation>
+            <xsd:appinfo>
+                <a:container/>
+                <a:since>4.2</a:since>
+            </xsd:appinfo>
+        </xsd:annotation>
+        <xsd:sequence>
+            <xsd:element name="administrativeAvailabilityStatus" type="tns:AdministrativeAvailabilityStatusType" minOccurs="0"/>
+        </xsd:sequence>
+        <xsd:attribute name="id" type="xsd:long"/>
+    </xsd:complexType>
+
     <xsd:complexType name="OperationalStateType">
         <xsd:annotation>
             <xsd:documentation>
@@ -6551,6 +6574,33 @@
         </xsd:sequence>
         <xsd:attribute name="id" type="xsd:long"/>
     </xsd:complexType>
+
+    <xsd:simpleType name="AdministrativeAvailabilityStatusType">
+        <xsd:annotation>
+            <xsd:documentation>
+                The enum describes the administrative availability of the resource, if it is operational or undergoing maintenance.
+            </xsd:documentation>
+            <xsd:appinfo>
+                <jaxb:typesafeEnumClass/>
+            </xsd:appinfo>
+        </xsd:annotation>
+        <xsd:restriction base="xsd:string">
+            <xsd:enumeration value="maintenance">
+                <xsd:annotation>
+                    <xsd:appinfo>
+                        <jaxb:typesafeEnumMember name="MAINTENANCE"/>
+                    </xsd:appinfo>
+                </xsd:annotation>
+            </xsd:enumeration>
+            <xsd:enumeration value="operational">
+                <xsd:annotation>
+                    <xsd:appinfo>
+                        <jaxb:typesafeEnumMember name="OPERATIONAL"/>
+                    </xsd:appinfo>
+                </xsd:annotation>
+            </xsd:enumeration>
+        </xsd:restriction>
+    </xsd:simpleType>
 
     <xsd:simpleType name="AvailabilityStatusType">
         <xsd:annotation>

--- a/infra/util/src/main/java/com/evolveum/midpoint/util/exception/MaintenanceException.java
+++ b/infra/util/src/main/java/com/evolveum/midpoint/util/exception/MaintenanceException.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2010-2020 Evolveum and contributors
+ *
+ * This work is dual-licensed under the Apache License 2.0
+ * and European Union Public License. See LICENSE file for details.
+ */
+package com.evolveum.midpoint.util.exception;
+
+import com.evolveum.midpoint.util.LocalizableMessage;
+
+/**
+ *
+ * May happen in case that resource is administratively set to maintenance mode.
+ *
+ *
+ * @author Martin Lizner
+ *
+ */
+public class MaintenanceException extends CommunicationException {
+    private static final long serialVersionUID = 1L;
+
+    public MaintenanceException() {
+    }
+
+    public MaintenanceException(String message) {
+        super(message);
+    }
+
+    public MaintenanceException(LocalizableMessage userFriendlyMessage) {
+        super(userFriendlyMessage);
+    }
+
+    public MaintenanceException(Throwable cause) {
+        super(cause);
+    }
+
+    public MaintenanceException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public MaintenanceException(LocalizableMessage userFriendlyMessage, Throwable cause) {
+        super(userFriendlyMessage, cause);
+    }
+
+    @Override
+    public String getErrorTypeMessage() {
+        return "Resource is in the maintenance";
+    }
+
+}

--- a/model/model-impl/src/main/java/com/evolveum/midpoint/model/impl/lens/LensProjectionContext.java
+++ b/model/model-impl/src/main/java/com/evolveum/midpoint/model/impl/lens/LensProjectionContext.java
@@ -1404,7 +1404,11 @@ public class LensProjectionContext extends LensElementContext<ShadowType> implem
             return;
         }
         OperationResultType fetchResult = shadowType.getFetchResult();
-        if (fetchResult != null
+        AdministrativeAvailabilityStatusType resourceAdministrativeAvailabilityStatus = ResourceTypeUtil.getAdministrativeAvailabilityStatus(resource);
+
+        if (AdministrativeAvailabilityStatusType.MAINTENANCE == resourceAdministrativeAvailabilityStatus) {
+            setFullShadow(false); // resource is in the maintenance, shadow is from repo, result is success
+        } else if (fetchResult != null
                 && (fetchResult.getStatus() == OperationResultStatusType.PARTIAL_ERROR
                     || fetchResult.getStatus() == OperationResultStatusType.FATAL_ERROR)) {  // todo what about other kinds of status? [e.g. in-progress]
                setFullShadow(false);

--- a/model/model-impl/src/main/java/com/evolveum/midpoint/model/impl/util/ModelImplUtils.java
+++ b/model/model-impl/src/main/java/com/evolveum/midpoint/model/impl/util/ModelImplUtils.java
@@ -61,6 +61,7 @@ import com.evolveum.midpoint.util.exception.PolicyViolationException;
 import com.evolveum.midpoint.util.exception.SchemaException;
 import com.evolveum.midpoint.util.exception.SecurityViolationException;
 import com.evolveum.midpoint.util.exception.SystemException;
+import com.evolveum.midpoint.util.exception.MaintenanceException;
 import com.evolveum.midpoint.util.logging.LoggingUtils;
 import com.evolveum.midpoint.util.logging.Trace;
 import com.evolveum.midpoint.util.logging.TraceManager;
@@ -786,7 +787,14 @@ public class ModelImplUtils {
             return CriticalityType.FATAL; // not reached
         } else {
             ErrorSelectorType errorSelector = ResourceTypeUtil.getConnectorErrorCriticality(resourceType);
-            if (e instanceof CommunicationException) {
+            if (e instanceof MaintenanceException) {
+                // The resource was put to maintenance mode administratively. Do not log the error.
+                if (result != null) {
+                    result.recordSuccess();
+                }
+                return CriticalityType.IGNORE;
+            }
+            else if (e instanceof CommunicationException) {
                 // Network problem. Just continue evaluation. The error is recorded in the result.
                 // The consistency mechanism has (most likely) already done the best.
                 // We cannot do any better.

--- a/provisioning/provisioning-impl/src/main/java/com/evolveum/midpoint/provisioning/impl/ProvisioningServiceImpl.java
+++ b/provisioning/provisioning-impl/src/main/java/com/evolveum/midpoint/provisioning/impl/ProvisioningServiceImpl.java
@@ -214,7 +214,13 @@ public class ProvisioningServiceImpl implements ProvisioningService, SystemConfi
                         }
                         exceptionRecorded = true;
                         throw e;
-                    } catch (CommunicationException | SchemaException | ConfigurationException | SecurityViolationException | RuntimeException | Error e) {
+                    } catch (MaintenanceException e) {
+                        LOGGER.trace(e.getMessage(), e);
+                        result.cleanupResult(e);
+                        exceptionRecorded = true;
+                        throw e;
+                    }
+                    catch (CommunicationException | SchemaException | ConfigurationException | SecurityViolationException | RuntimeException | Error e) {
                         ProvisioningUtil
                                 .recordFatalError(LOGGER, result, "Error getting object OID=" + oid + ": " + e.getMessage(), e);
                         exceptionRecorded = true;

--- a/provisioning/provisioning-impl/src/main/java/com/evolveum/midpoint/provisioning/impl/ShadowCache.java
+++ b/provisioning/provisioning-impl/src/main/java/com/evolveum/midpoint/provisioning/impl/ShadowCache.java
@@ -190,6 +190,17 @@ public class ShadowCache {
             throw e;
         }
 
+        if (ProvisioningUtil.resourceIsInMaintenance(resource)) {
+            try {
+                MaintenanceException ex = new MaintenanceException("Resource " + resource + " is in the maintenance");
+                PrismObject<ShadowType> handledShadow = handleGetError(ctx, repositoryShadow, rootOptions, ex, task, parentResult);
+                validateShadow(handledShadow, true);
+                return handledShadow;
+            } catch (GenericFrameworkException | ObjectAlreadyExistsException | PolicyViolationException e) {
+                throw new SystemException(e.getMessage(), e);
+            }
+        }
+
         if (shouldRefreshOnRead(resource, rootOptions)) {
             LOGGER.trace("Refreshing {} before reading", repositoryShadow);
             ProvisioningOperationOptions refreshOpts = toProvisioningOperationOptions(rootOptions);
@@ -548,6 +559,9 @@ public class ShadowCache {
             LOGGER.trace("ADD {}: resource operation, execution starting", shadowToAdd);
 
             try {
+                if (ProvisioningUtil.resourceIsInMaintenance(ctx.getResource())) {
+                    throw new MaintenanceException("Resource " + ctx.getResource() + " is in the maintenance"); // this tells mp to create pending delta
+                }
 
                 // RESOURCE OPERATION: add
                 AsynchronousOperationReturnValue<PrismObject<ShadowType>> asyncReturnValue =
@@ -606,6 +620,12 @@ public class ShadowCache {
                     finalOperationStatus = handleAddError(ctx, shadowToAdd, options, opState, e, failedOperationResult, task, parentResult);
                 }
 
+            } catch (MaintenanceException e) {
+                finalOperationStatus = handleAddError(ctx, shadowToAdd, options, opState, e, parentResult.getLastSubresult(), task, parentResult);
+                if (opState.getRepoShadow() != null) {
+                    setParentOperationStatus(parentResult, opState, finalOperationStatus);
+                    return opState.getRepoShadow().getOid();
+                }
             } catch (Exception e) {
                 finalOperationStatus = handleAddError(ctx, shadowToAdd, options, opState, e, parentResult.getLastSubresult(), task, parentResult);
             }
@@ -988,7 +1008,9 @@ public class ShadowCache {
                 ConnectorOperationOptions connOptions = createConnectorOperationOptions(ctx, options, parentResult);
 
                 try {
-
+                    if (ProvisioningUtil.resourceIsInMaintenance(ctx.getResource())) {
+                        throw new MaintenanceException("Resource " + ctx.getResource() + " is in the maintenance");
+                    }
 
                     if (!shouldExecuteModify(refreshShadowOperation)) {
                         ProvisioningUtil.postponeModify(ctx, repoShadow, modifications, opState, refreshShadowOperation.getRefreshResult(), parentResult);
@@ -1242,6 +1264,9 @@ public class ShadowCache {
                 LOGGER.trace("DELETE {}: resource deletion, execution starting", repoShadow);
 
                 try {
+                    if (ProvisioningUtil.resourceIsInMaintenance(ctx.getResource())) {
+                        throw new MaintenanceException("Resource " + ctx.getResource() + " is in the maintenance");
+                    }
 
                     AsynchronousOperationResult asyncReturnValue = resourceObjectConverter
                             .deleteResourceObject(ctx, repoShadow, scripts, connOptions, parentResult);

--- a/provisioning/provisioning-impl/src/main/java/com/evolveum/midpoint/provisioning/impl/errorhandling/ErrorHandlerLocator.java
+++ b/provisioning/provisioning-impl/src/main/java/com/evolveum/midpoint/provisioning/impl/errorhandling/ErrorHandlerLocator.java
@@ -19,6 +19,7 @@ import com.evolveum.midpoint.util.exception.PolicyViolationException;
 import com.evolveum.midpoint.util.exception.SchemaException;
 import com.evolveum.midpoint.util.exception.SecurityViolationException;
 import com.evolveum.midpoint.util.exception.SystemException;
+import com.evolveum.midpoint.util.exception.MaintenanceException;
 
 @Component
 public class ErrorHandlerLocator {
@@ -31,8 +32,12 @@ public class ErrorHandlerLocator {
     @Autowired ConfigurationExceptionHandler configurationExceptionHandler;
     @Autowired SecurityViolationHandler securityViolationHandler;
     @Autowired PolicyViolationHandler policyViolationHandler;
+    @Autowired MaintenanceExceptionHandler maintenanceExceptionHandler;
 
     public ErrorHandler locateErrorHandler(Throwable ex) {
+        if (ex instanceof MaintenanceException) {
+            return maintenanceExceptionHandler;
+        }
         if (ex instanceof CommunicationException){
             return communicationExceptionHandler;
         }

--- a/provisioning/provisioning-impl/src/main/java/com/evolveum/midpoint/provisioning/impl/errorhandling/MaintenanceExceptionHandler.java
+++ b/provisioning/provisioning-impl/src/main/java/com/evolveum/midpoint/provisioning/impl/errorhandling/MaintenanceExceptionHandler.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright (c) 2010-2020 Evolveum and contributors
+ *
+ * This work is dual-licensed under the Apache License 2.0
+ * and European Union Public License. See LICENSE file for details.
+ */
+
+/*
+ * @author Martin Lizner
+*/
+
+package com.evolveum.midpoint.provisioning.impl.errorhandling;
+
+import com.evolveum.midpoint.prism.PrismObject;
+import com.evolveum.midpoint.prism.PrismPropertyValue;
+import com.evolveum.midpoint.prism.delta.ItemDelta;
+import com.evolveum.midpoint.prism.delta.PropertyDelta;
+import com.evolveum.midpoint.prism.query.ObjectQuery;
+import com.evolveum.midpoint.provisioning.api.ProvisioningOperationOptions;
+import com.evolveum.midpoint.provisioning.impl.ProvisioningContext;
+import com.evolveum.midpoint.provisioning.impl.ProvisioningOperationState;
+import com.evolveum.midpoint.provisioning.util.ProvisioningUtil;
+import com.evolveum.midpoint.repo.api.RepositoryService;
+import com.evolveum.midpoint.schema.GetOperationOptions;
+import com.evolveum.midpoint.schema.SearchResultList;
+import com.evolveum.midpoint.schema.result.AsynchronousOperationResult;
+import com.evolveum.midpoint.schema.result.AsynchronousOperationReturnValue;
+import com.evolveum.midpoint.schema.result.OperationResult;
+import com.evolveum.midpoint.schema.result.OperationResultStatus;
+import com.evolveum.midpoint.task.api.Task;
+import com.evolveum.midpoint.util.exception.*;
+import com.evolveum.midpoint.xml.ns._public.common.common_3.ResourceType;
+import com.evolveum.midpoint.xml.ns._public.common.common_3.ShadowType;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Component;
+
+import java.util.Collection;
+
+@Component
+public class MaintenanceExceptionHandler extends ErrorHandler {
+
+    private static final String OPERATION_HANDLE_GET_ERROR = MaintenanceExceptionHandler.class.getName() + ".handleGetError";
+    private static final String OPERATION_HANDLE_ADD_ERROR = MaintenanceExceptionHandler.class.getName() + ".handleAddError";
+    private static final String OPERATION_HANDLE_MODIFY_ERROR = MaintenanceExceptionHandler.class.getName() + ".handleModifyError";
+    private static final String OPERATION_HANDLE_DELETE_ERROR = MaintenanceExceptionHandler.class.getName() + ".handleDeleteError";
+
+    @Autowired
+    @Qualifier("cacheRepositoryService")
+    private RepositoryService repositoryService;
+
+    @Override
+    public PrismObject<ShadowType> handleGetError(ProvisioningContext ctx,
+            PrismObject<ShadowType> repositoryShadow, GetOperationOptions rootOptions, Exception cause,
+            Task task, OperationResult parentResult) throws SchemaException, CommunicationException, ObjectNotFoundException,
+            ConfigurationException, ExpressionEvaluationException {
+
+        ResourceType resource = ctx.getResource();
+        if (!ProvisioningUtil.isDoDiscovery(resource, rootOptions)) {
+            throwException(cause, null, parentResult);
+        }
+
+        OperationResult result = parentResult.createSubresult(OPERATION_HANDLE_GET_ERROR);
+        result.addParam("exception", cause.getMessage());
+
+        for (OperationResult subRes : parentResult.getSubresults()) {
+            subRes.muteError();
+        }
+
+        result.recordSuccess();
+        repositoryShadow.asObjectable().setFetchResult(result.createOperationResultType());
+
+        return repositoryShadow;
+    }
+
+    @Override
+    public OperationResultStatus handleAddError(ProvisioningContext ctx,
+            PrismObject<ShadowType> shadowToAdd,
+            ProvisioningOperationOptions options,
+            ProvisioningOperationState<AsynchronousOperationReturnValue<PrismObject<ShadowType>>> opState,
+            Exception cause,
+            OperationResult failedOperationResult,
+            Task task,
+            OperationResult parentResult) throws ObjectNotFoundException, SchemaException, CommunicationException, ConfigurationException, ExpressionEvaluationException {
+
+        OperationResult result = parentResult.createSubresult(OPERATION_HANDLE_ADD_ERROR);
+        result.addParam("exception", cause.getMessage());
+
+        if (ProvisioningUtil.isDoDiscovery(ctx.getResource(), options)) {
+            ObjectQuery query = ObjectAlreadyExistHandler.createQueryBySecondaryIdentifier
+                    (shadowToAdd.asObjectable(), prismContext);
+            SearchResultList<PrismObject<ShadowType>> conflictingShadows =
+                    repositoryService.searchObjects(ShadowType.class, query, null, parentResult);
+
+            if (!conflictingShadows.isEmpty()) {
+                opState.setRepoShadow(conflictingShadows.get(0)); // there is already repo shadow in mp
+                failedOperationResult.setStatus(OperationResultStatus.SUCCESS);
+                result.recordSuccess();
+                return OperationResultStatus.SUCCESS;
+            }
+        }
+
+        failedOperationResult.setStatus(OperationResultStatus.IN_PROGRESS); // this influences how pending operation resultStatus is saved
+        return postponeAdd(ctx, shadowToAdd, opState, failedOperationResult, result);
+    }
+
+    @Override
+    public OperationResultStatus handleModifyError(ProvisioningContext ctx, PrismObject<ShadowType> repoShadow,
+            Collection<? extends ItemDelta> modifications, ProvisioningOperationOptions options,
+            ProvisioningOperationState<AsynchronousOperationReturnValue<Collection<PropertyDelta<PrismPropertyValue>>>> opState,
+            Exception cause, OperationResult failedOperationResult, Task task, OperationResult parentResult) {
+
+        OperationResult result = parentResult.createSubresult(OPERATION_HANDLE_MODIFY_ERROR);
+        result.addParam("exception", cause.getMessage());
+
+        failedOperationResult.setStatus(OperationResultStatus.IN_PROGRESS);
+        return postponeModify(ctx, repoShadow, modifications, opState, failedOperationResult, result);
+    }
+
+    @Override
+    public OperationResultStatus handleDeleteError(ProvisioningContext ctx, PrismObject<ShadowType> repoShadow,
+            ProvisioningOperationOptions options,
+            ProvisioningOperationState<AsynchronousOperationResult> opState, Exception cause,
+            OperationResult failedOperationResult, Task task, OperationResult parentResult) {
+        OperationResult result = parentResult.createSubresult(OPERATION_HANDLE_DELETE_ERROR);
+        result.addParam("exception", cause.getMessage());
+
+        failedOperationResult.setStatus(OperationResultStatus.IN_PROGRESS);
+        return postponeDelete(ctx, repoShadow, opState, failedOperationResult, result);
+    }
+
+    @Override
+    protected void throwException(Exception cause, ProvisioningOperationState<? extends AsynchronousOperationResult> opState, OperationResult result) throws MaintenanceException {
+        recordCompletionError(cause, opState, result);
+        if (cause instanceof MaintenanceException) {
+            throw (MaintenanceException)cause;
+        } else {
+            throw new MaintenanceException(cause.getMessage(), cause);
+        }
+    }
+}

--- a/provisioning/provisioning-impl/src/main/java/com/evolveum/midpoint/provisioning/impl/errorhandling/ObjectAlreadyExistHandler.java
+++ b/provisioning/provisioning-impl/src/main/java/com/evolveum/midpoint/provisioning/impl/errorhandling/ObjectAlreadyExistHandler.java
@@ -10,6 +10,7 @@ package com.evolveum.midpoint.provisioning.impl.errorhandling;
 import java.util.Collection;
 import java.util.List;
 
+import com.evolveum.midpoint.prism.PrismContext;
 import com.evolveum.midpoint.prism.delta.ObjectDeltaUtil;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -120,7 +121,7 @@ public class ObjectAlreadyExistHandler extends HardErrorHandler {
         OperationResult result = parentResult.createSubresult(OP_DISCOVERY);
         try {
 
-            ObjectQuery query = createQueryBySecondaryIdentifier(newShadow.asObjectable());
+            ObjectQuery query = createQueryBySecondaryIdentifier(newShadow.asObjectable(), prismContext);
 
             final List<PrismObject<ShadowType>> conflictingRepoShadows = findConflictingShadowsInRepo(query, task, result);
             PrismObject<ShadowType> oldShadow = shadowManager.eliminateDeadShadows(conflictingRepoShadows, result);
@@ -176,7 +177,7 @@ public class ObjectAlreadyExistHandler extends HardErrorHandler {
     }
 
 
-    private ObjectQuery createQueryBySecondaryIdentifier(ShadowType shadow) {
+    protected static ObjectQuery createQueryBySecondaryIdentifier(ShadowType shadow, PrismContext prismContext) {
         // TODO ensure that the identifiers are normalized here
         // Note that if the query is to be used against the repository, we should not provide matching rules here. See MID-5547.
         Collection<ResourceAttribute<?>> secondaryIdentifiers = ShadowUtil.getSecondaryIdentifiers(shadow);

--- a/provisioning/provisioning-impl/src/main/java/com/evolveum/midpoint/provisioning/util/ProvisioningUtil.java
+++ b/provisioning/provisioning-impl/src/main/java/com/evolveum/midpoint/provisioning/util/ProvisioningUtil.java
@@ -586,6 +586,24 @@ public class ProvisioningUtil {
         return Boolean.TRUE.equals(readCapabilityType.isCachingOnly());
     }
 
+    public static boolean resourceIsInMaintenance(ResourceType resource) {
+        if (resource == null)
+            return false;
+
+        AdministrativeOperationalStateType administrativeOperationalState = resource.getAdministrativeOperationalState();
+        if (administrativeOperationalState == null)
+            return false;
+
+        AdministrativeAvailabilityStatusType administrativeAvailabilityStatus = administrativeOperationalState.getAdministrativeAvailabilityStatus();
+        if (administrativeAvailabilityStatus == null)
+            return false;
+
+        if (AdministrativeAvailabilityStatusType.MAINTENANCE == administrativeAvailabilityStatus)
+            return true;
+
+        return false;
+    }
+
     public static Duration getGracePeriod(ProvisioningContext ctx) throws ObjectNotFoundException, SchemaException, CommunicationException, ConfigurationException, ExpressionEvaluationException {
         Duration gracePeriod = null;
         ResourceConsistencyType consistency = ctx.getResource().getConsistency();

--- a/testing/story/src/test/java/com/evolveum/midpoint/testing/story/TestResourceInMaintenance.java
+++ b/testing/story/src/test/java/com/evolveum/midpoint/testing/story/TestResourceInMaintenance.java
@@ -1,0 +1,327 @@
+/*
+ * Copyright (c) 2010-2020 Evolveum and contributors
+ *
+ * This work is dual-licensed under the Apache License 2.0
+ * and European Union Public License. See LICENSE file for details.
+ */
+
+/*
+ * @author Martin Lizner
+ */
+
+package com.evolveum.midpoint.testing.story;
+
+import static org.testng.AssertJUnit.*;
+
+import java.io.File;
+import java.io.FileInputStream;
+import javax.xml.namespace.QName;
+
+import com.evolveum.midpoint.schema.constants.MidPointConstants;
+import com.evolveum.midpoint.test.asserter.ShadowAsserter;
+
+import com.evolveum.midpoint.util.exception.*;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.annotation.DirtiesContext.ClassMode;
+import org.springframework.test.context.ContextConfiguration;
+import org.testng.annotations.Test;
+
+import com.evolveum.midpoint.common.configuration.api.MidpointConfiguration;
+import com.evolveum.midpoint.prism.PrismObject;
+import com.evolveum.midpoint.prism.delta.ObjectDelta;
+import com.evolveum.midpoint.prism.path.ItemPath;
+import com.evolveum.midpoint.schema.constants.SchemaConstants;
+import com.evolveum.midpoint.schema.result.OperationResult;
+import com.evolveum.midpoint.task.api.Task;
+import com.evolveum.midpoint.test.util.MidPointTestConstants;
+import com.evolveum.midpoint.test.util.TestUtil;
+import com.evolveum.midpoint.util.ClassPathUtil;
+import com.evolveum.midpoint.xml.ns._public.common.common_3.*;
+
+@ContextConfiguration(locations = { "classpath:ctx-story-test-main.xml" })
+@DirtiesContext(classMode = ClassMode.AFTER_CLASS)
+public class TestResourceInMaintenance extends AbstractStoryTest {
+
+    public static final File TEST_DIR = new File(MidPointTestConstants.TEST_RESOURCES_DIR, "resource-in-maintenance");
+
+    private static final File RESOURCE_CSV_FILE = new File(TEST_DIR, "csv-resource1.xml");
+    private static final File RESOURCE_CSV_CONTENT_FILE = new File(TEST_DIR, "data-resource1.csv");
+    private static String sourceFilePath;
+
+    private static final File SHADOW_FILE = new File(TEST_DIR, "shadow-user1.xml");
+    private static final File USER1_FILE = new File(TEST_DIR, "user1.xml");
+    private static final File USER2_FILE = new File(TEST_DIR, "user2.xml");
+
+    private static final String RESOURCE_OID = "25dd0010-5115-4ac0-960f-4889d1b960ff";
+    private static final String SHADOW_OID = "c4071f2e-3f8d-4301-9027-c57033c702ff";
+    private static final String USER1_OID = "cdc33185-c817-4be7-8158-8f338824cdff";
+    private static final String USER2_OID = "cdc33185-c817-4be7-8158-8f3388241234";
+
+    private static final QName CSV_ATTRIBUTE_DESC = new QName(MidPointConstants.NS_RI, "description");
+    private static final QName CSV_ATTRIBUTE_FULLNAME = new QName(MidPointConstants.NS_RI, "fullname");
+
+    private static final String NS_RESOURCE_CSV = "http://midpoint.evolveum.com/xml/ns/public/connector/icf-1/bundle/com.evolveum.polygon.connector-csv/com.evolveum.polygon.connector.csv.CsvConnector";
+
+    @Autowired
+    private MidpointConfiguration midPointConfig;
+
+    @Override
+    protected File getSystemConfigurationFile() {
+        return super.getSystemConfigurationFile();
+    }
+
+    @Override
+    public void initSystem(Task initTask, OperationResult initResult) throws Exception {
+        String home = midPointConfig.getMidpointHome();
+        File resourceDir = new File(home, "resource-in-maintenance");
+        resourceDir.mkdir();
+
+        File desticationFile = new File(resourceDir, "data-resource1.csv");
+        ClassPathUtil.copyFile(new FileInputStream(RESOURCE_CSV_CONTENT_FILE), "data-resource1.csv", desticationFile);
+
+        if (!desticationFile.exists()) {
+            throw new SystemException("Source file for CSV resource was not created");
+        }
+
+        sourceFilePath = desticationFile.getAbsolutePath();
+
+        super.initSystem(initTask, initResult);
+
+        importObjectFromFile(RESOURCE_CSV_FILE);
+    }
+
+    @Test
+    public void test000Sanity() throws Exception {
+        Task task = getTestTask();
+        OperationResult result = task.getResult();
+        Object[] newRealValue = { sourceFilePath };
+
+        ObjectDelta<ResourceType> objectDelta = prismContext.deltaFactory().object()
+                .createModificationReplaceProperty(ResourceType.class, RESOURCE_OID, ItemPath.create(ResourceType.F_CONNECTOR_CONFIGURATION,
+                        SchemaConstants.ICF_CONFIGURATION_PROPERTIES, new QName(NS_RESOURCE_CSV, "filePath")),
+                        newRealValue);
+        provisioningService.applyDefinition(objectDelta, task, result);
+        provisioningService.modifyObject(ResourceType.class, objectDelta.getOid(), objectDelta.getModifications(), null, null, task, result);
+
+        OperationResult csvTestResult = modelService.testResource(RESOURCE_OID, task);
+        TestUtil.assertSuccess("CSV resource test result", csvTestResult);
+
+        SystemConfigurationType systemConfiguration = getSystemConfiguration();
+        assertNotNull("No system configuration", systemConfiguration);
+        display("System config", systemConfiguration);
+
+        importObjectFromFile(SHADOW_FILE);
+        importObjectFromFile(USER1_FILE);
+        importObjectFromFile(USER2_FILE);
+    }
+
+    @Test
+    public void test010RecomputeUserWithoutChange() throws Exception {
+        Task task = getTestTask();
+        OperationResult result = task.getResult();
+
+        modelService.recompute(UserType.class, USER1_OID, executeOptions().reconcile(), task, result);
+        result.computeStatus();
+        display(result);
+
+        //TestUtil.assertPartialError(result);
+        //assertEquals("Expected handled error but got: " + result.getStatus(), OperationResultStatus.HANDLED_ERROR, result.getStatus());
+        //TestUtil.assertMessageContains(result.getMessage(), "maintenance");
+        TestUtil.assertSuccess(result);
+
+        PrismObject<ShadowType> shadow = getShadowRepo(SHADOW_OID);
+        assertNoPendingOperation(shadow); // no change was requested = no pending operation is saved
+    }
+
+    @Test
+    public void test020ModifyAccount() throws Exception {
+        Task task = getTestTask();
+        OperationResult result = task.getResult();
+
+        modifyUserReplace(USER1_OID, UserType.F_DESCRIPTION, task, result, "jedi");
+
+        result.computeStatus();
+        display(result);
+
+        TestUtil.assertInProgress("resource in the maintenance pending delta", result);
+
+        PrismObject<ShadowType> shadow = getShadowRepo(SHADOW_OID);
+        assertSinglePendingOperation(shadow, PendingOperationExecutionStatusType.EXECUTING, OperationResultStatusType.IN_PROGRESS);
+    }
+
+    @Test
+    public void test030ApplyPendingModify() throws Exception {
+        Task task = getTestTask();
+        OperationResult result = task.getResult();
+
+        // Cancel maintenance mode:
+        switchResourceMaintenance(AdministrativeAvailabilityStatusType.OPERATIONAL, task, result);
+
+        // Check description value hasnt changed yet:
+        PrismObject<ShadowType> shadowBefore = getShadowModel(SHADOW_OID);
+        ShadowAsserter.forShadow(shadowBefore)
+                .assertKind(ShadowKindType.ACCOUNT)
+                .assertIntent("default")
+                .attributes()
+                .assertHasPrimaryIdentifier()
+                .assertValue(CSV_ATTRIBUTE_DESC, "sith")
+                .end()
+                .assertResource(RESOURCE_OID);
+
+        // Apply pending delta:
+        modelService.recompute(UserType.class, USER1_OID, executeOptions().reconcile(), task, result);
+        result.computeStatus();
+
+        TestUtil.assertSuccess(result);
+
+        // Now check description value in CSV file has changed according to pending operation:
+        PrismObject<ShadowType> shadowAfter = getShadowModel(SHADOW_OID);
+        ShadowAsserter.forShadow(shadowAfter)
+                .assertKind(ShadowKindType.ACCOUNT)
+                .assertIntent("default")
+                .attributes()
+                .assertHasPrimaryIdentifier()
+                .assertValue(CSV_ATTRIBUTE_DESC, "jedi")
+                .end()
+                .assertResource(RESOURCE_OID);
+
+        assertSinglePendingOperation(shadowAfter, PendingOperationExecutionStatusType.COMPLETED, OperationResultStatusType.SUCCESS);
+    }
+
+    @Test
+    public void test040CreateNewAccount() throws Exception {
+        Task task = getTestTask();
+        OperationResult result = task.getResult();
+
+        // Turn maintenance mode ON:
+        switchResourceMaintenance(AdministrativeAvailabilityStatusType.MAINTENANCE, task, result);
+
+        assignAccountToUser(USER2_OID, RESOURCE_OID, "default", task, result);
+
+        result.computeStatus();
+        display(result);
+
+        TestUtil.assertInProgress("resource in the maintenance pending delta", result);
+
+        String newShadowOid = getLinkRefOid(USER2_OID, RESOURCE_OID);
+        assertNotNull(newShadowOid);
+        PrismObject<ShadowType> shadow = getShadowRepo(newShadowOid);
+        assertSinglePendingOperation(shadow, PendingOperationExecutionStatusType.EXECUTING, OperationResultStatusType.IN_PROGRESS);
+
+        // lets try recompute just for fun, mp should do nothing and report success:
+        OperationResult result2 = createOperationResult();
+        modelService.recompute(UserType.class, USER2_OID, executeOptions().reconcile(), task, result2);
+        result2.computeStatus();
+
+        TestUtil.assertSuccess(result2);
+        //TestUtil.assertInProgress("resource in the maintenance pending delta", result);
+        assertSinglePendingOperation(shadow, PendingOperationExecutionStatusType.EXECUTING, OperationResultStatusType.IN_PROGRESS);
+    }
+
+    @Test
+    public void test050ApplyPendingCreate() throws Exception {
+        Task task = getTestTask();
+        OperationResult result = task.getResult();
+
+        // Cancel maintenance mode:
+        switchResourceMaintenance(AdministrativeAvailabilityStatusType.OPERATIONAL, task, result);
+
+        // Check shadow does not exist yet:
+        String newShadowOid = getLinkRefOid(USER2_OID, RESOURCE_OID);
+        PrismObject<ShadowType> shadowBefore = getShadowModel(newShadowOid);
+        ShadowAsserter.forShadow(shadowBefore)
+                .assertIsNotExists()
+                .end();
+
+        // Apply pending delta:
+        modelService.recompute(UserType.class, USER2_OID, executeOptions().reconcile(), task, result);
+        result.computeStatus();
+
+        TestUtil.assertSuccess(result);
+
+        // Now check shadow exists in CSV file
+        PrismObject<ShadowType> shadowCreated = getShadowModel(newShadowOid);
+        ShadowAsserter.forShadow(shadowCreated)
+                .assertKind(ShadowKindType.ACCOUNT)
+                .assertIntent("default")
+                .attributes()
+                .assertHasPrimaryIdentifier()
+                .assertValue(CSV_ATTRIBUTE_FULLNAME, "R2-D2")
+                .end()
+                .assertResource(RESOURCE_OID);
+
+        assertSinglePendingOperation(shadowCreated, PendingOperationExecutionStatusType.COMPLETED, OperationResultStatusType.SUCCESS);
+    }
+
+    @Test
+    public void test060DeleteAccount() throws Exception {
+        Task task = getTestTask();
+        OperationResult result = task.getResult();
+
+        // Turn maintenance mode ON:
+        switchResourceMaintenance(AdministrativeAvailabilityStatusType.MAINTENANCE, task, result);
+
+        String shadowOid = getLinkRefOid(USER2_OID, RESOURCE_OID);
+        assertNotNull(shadowOid);
+        unassignAccountFromUser(USER2_OID, RESOURCE_OID, "default", task, result);
+
+        result.computeStatus();
+        display(result);
+
+        TestUtil.assertInProgress("resource in the maintenance pending delta", result);
+
+        PrismObject<ShadowType> shadow = getShadowRepo(shadowOid);
+        PendingOperationType deleteOp = findPendingOperation(shadow, PendingOperationExecutionStatusType.EXECUTING);
+        assertNotNull(deleteOp);
+
+        // lets try recompute just for fun, mp should do nothing and report success:
+        OperationResult result2 = createOperationResult();
+        modelService.recompute(UserType.class, USER2_OID, executeOptions().reconcile(), task, result2);
+        result2.computeStatus();
+
+        TestUtil.assertSuccess(result2);
+    }
+
+    @Test
+    public void test070ApplyPendingDelete() throws Exception {
+        Task task = getTestTask();
+        OperationResult result = task.getResult();
+
+        // Cancel maintenance mode:
+        switchResourceMaintenance(AdministrativeAvailabilityStatusType.OPERATIONAL, task, result);
+
+        // Check shadow still exists:
+        String shadowOid = getLinkRefOid(USER2_OID, RESOURCE_OID);
+        PrismObject<ShadowType> shadow = getShadowModel(shadowOid);
+        ShadowAsserter.forShadow(shadow)
+                .assertIsExists()
+                .end();
+
+        // Apply pending delete delta:
+        modelService.recompute(UserType.class, USER2_OID, executeOptions().reconcile(), task, result);
+        result.computeStatus();
+
+        TestUtil.assertSuccess(result);
+
+        // Now check shadow does not exist in CSV file
+        PrismObject<ShadowType> shadowDeleted = getShadowModel(shadowOid);
+        ShadowAsserter.forShadow(shadowDeleted)
+                .assertIsNotExists()
+                .assertDead()
+                .end();
+
+        PendingOperationType deleteOp = findPendingOperation(shadow, PendingOperationExecutionStatusType.COMPLETED);
+        assertNotNull(deleteOp);
+    }
+
+    private void switchResourceMaintenance (AdministrativeAvailabilityStatusType mode, Task task, OperationResult result) throws Exception {
+        ObjectDelta<ResourceType> objectDelta = prismContext.deltaFactory().object()
+                .createModificationReplaceProperty(ResourceType.class, RESOURCE_OID, ItemPath.create(ResourceType.F_ADMINISTRATIVE_OPERATIONAL_STATE,
+                        new QName("administrativeAvailabilityStatus")), mode);
+
+        provisioningService.applyDefinition(objectDelta, task, result);
+        provisioningService.modifyObject(ResourceType.class, objectDelta.getOid(), objectDelta.getModifications(), null, null, task, result);
+    }
+}

--- a/testing/story/src/test/resources/resource-in-maintenance/csv-resource1.xml
+++ b/testing/story/src/test/resources/resource-in-maintenance/csv-resource1.xml
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resource xmlns="http://midpoint.evolveum.com/xml/ns/public/common/common-3" xmlns:c="http://midpoint.evolveum.com/xml/ns/public/common/common-3" xmlns:icfs="http://midpoint.evolveum.com/xml/ns/public/connector/icf-1/resource-schema-3" xmlns:org="http://midpoint.evolveum.com/xml/ns/public/common/org-3" xmlns:q="http://prism.evolveum.com/xml/ns/public/query-3" xmlns:ri="http://midpoint.evolveum.com/xml/ns/public/resource/instance-3" xmlns:t="http://prism.evolveum.com/xml/ns/public/types-3" oid="25dd0010-5115-4ac0-960f-4889d1b960ff">
+    <name>CSV1</name>
+
+    <administrativeOperationalState>
+        <administrativeAvailabilityStatus>maintenance</administrativeAvailabilityStatus>
+    </administrativeOperationalState>
+
+    <connectorRef type="ConnectorType">
+        <filter>
+            <q:equal>
+                <q:path>c:connectorType</q:path>
+                <q:value>com.evolveum.polygon.connector.csv.CsvConnector</q:value>
+            </q:equal>
+        </filter>
+    </connectorRef>
+    
+    <connectorConfiguration xmlns:icfc="http://midpoint.evolveum.com/xml/ns/public/connector/icf-1/connector-schema-3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="c:ConnectorConfigurationType">
+        <icfc:configurationProperties xmlns:icfccsvfile="http://midpoint.evolveum.com/xml/ns/public/connector/icf-1/bundle/com.evolveum.polygon.connector-csv/com.evolveum.polygon.connector.csv.CsvConnector" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="icfc:ConfigurationPropertiesType">
+            <icfccsvfile:filePath>shold-be-replaced-by-test-code</icfccsvfile:filePath>            
+            <icfccsvfile:uniqueAttribute>username</icfccsvfile:uniqueAttribute>
+        </icfc:configurationProperties>
+    </connectorConfiguration>
+
+    <schemaHandling>
+        <objectType>
+            <kind>account</kind>
+            <default>true</default>
+            <objectClass>ri:AccountObjectClass</objectClass>
+            <attribute>
+                <c:ref xmlns:ri="http://midpoint.evolveum.com/xml/ns/public/resource/instance-3">ri:username</c:ref>
+                <outbound>
+                    <strength>strong</strength>
+                    <source>
+                        <c:path>$focus/name</c:path>
+                    </source>
+                </outbound>
+            </attribute>
+            <attribute>
+                <c:ref xmlns:ri="http://midpoint.evolveum.com/xml/ns/public/resource/instance-3">ri:fullname</c:ref>
+                <outbound>
+                    <strength>strong</strength>
+                    <source>
+                        <c:path>$focus/fullName</c:path>
+                    </source>
+                </outbound>
+            </attribute>
+            <attribute>
+                <c:ref xmlns:ri="http://midpoint.evolveum.com/xml/ns/public/resource/instance-3">ri:description</c:ref>
+                <outbound>
+                    <strength>normal</strength>
+                    <source>
+                        <c:path>$focus/description</c:path>
+                    </source>
+                </outbound>
+            </attribute>
+        </objectType>
+    </schemaHandling>
+    
+    <synchronization>
+        <objectSynchronization>
+            <kind>account</kind>
+            <intent>default</intent>
+            <focusType>c:UserType</focusType>            
+            <enabled>true</enabled>
+            <correlation>
+                <q:equal>
+                    <q:path>c:name</q:path>
+                    <expression>
+                        <path>$account/attributes/ri:username</path>
+                    </expression>
+                </q:equal>
+            </correlation>
+            <reaction>
+                <situation>linked</situation>
+                <synchronize>true</synchronize>
+            </reaction>
+            <reaction>
+                <situation>deleted</situation>
+                <synchronize>true</synchronize>
+                <action>
+                    <handlerUri>http://midpoint.evolveum.com/xml/ns/public/model/action-3#unlink</handlerUri>
+                </action>
+            </reaction>
+            <reaction>
+                <situation>unlinked</situation>
+                <synchronize>true</synchronize>
+                <action>
+                    <handlerUri>http://midpoint.evolveum.com/xml/ns/public/model/action-3#link</handlerUri>
+                </action>
+            </reaction>
+        </objectSynchronization>
+    </synchronization>
+</resource>

--- a/testing/story/src/test/resources/resource-in-maintenance/data-resource1.csv
+++ b/testing/story/src/test/resources/resource-in-maintenance/data-resource1.csv
@@ -1,0 +1,2 @@
+username;fullname;description
+user1;Darth Vader;sith

--- a/testing/story/src/test/resources/resource-in-maintenance/shadow-user1.xml
+++ b/testing/story/src/test/resources/resource-in-maintenance/shadow-user1.xml
@@ -1,0 +1,15 @@
+<shadow xmlns="http://midpoint.evolveum.com/xml/ns/public/common/common-3" xmlns:c="http://midpoint.evolveum.com/xml/ns/public/common/common-3" xmlns:icfs="http://midpoint.evolveum.com/xml/ns/public/connector/icf-1/resource-schema-3" xmlns:org="http://midpoint.evolveum.com/xml/ns/public/common/org-3" xmlns:q="http://prism.evolveum.com/xml/ns/public/query-3" xmlns:ri="http://midpoint.evolveum.com/xml/ns/public/resource/instance-3" xmlns:t="http://prism.evolveum.com/xml/ns/public/types-3" oid="c4071f2e-3f8d-4301-9027-c57033c702ff">
+    <name>user1</name>
+    <resourceRef oid="25dd0010-5115-4ac0-960f-4889d1b960ff" relation="org:default" type="c:ResourceType"/>
+    <synchronizationSituation>linked</synchronizationSituation>
+    <objectClass>ri:AccountObjectClass</objectClass>
+    <primaryIdentifierValue>user1</primaryIdentifierValue>
+    <kind>account</kind>
+    <intent>default</intent>
+    <exists>true</exists>
+    <iteration>0</iteration>
+    <iterationToken/>
+    <attributes>
+        <ri:username>user1</ri:username>
+    </attributes>
+</shadow>

--- a/testing/story/src/test/resources/resource-in-maintenance/user1.xml
+++ b/testing/story/src/test/resources/resource-in-maintenance/user1.xml
@@ -1,0 +1,9 @@
+<user xmlns="http://midpoint.evolveum.com/xml/ns/public/common/common-3" xmlns:c="http://midpoint.evolveum.com/xml/ns/public/common/common-3" xmlns:icfs="http://midpoint.evolveum.com/xml/ns/public/connector/icf-1/resource-schema-3" xmlns:org="http://midpoint.evolveum.com/xml/ns/public/common/org-3" xmlns:q="http://prism.evolveum.com/xml/ns/public/query-3" xmlns:ri="http://midpoint.evolveum.com/xml/ns/public/resource/instance-3" xmlns:t="http://prism.evolveum.com/xml/ns/public/types-3" oid="cdc33185-c817-4be7-8158-8f338824cdff">
+    <name>user1</name>
+    <fullName>Darth Vader</fullName>
+    <description>sith</description>
+    <linkRef oid="c4071f2e-3f8d-4301-9027-c57033c702ff" relation="org:default" type="c:ShadowType"/>    
+    <activation>
+        <effectiveStatus>enabled</effectiveStatus>       
+    </activation>
+</user>

--- a/testing/story/src/test/resources/resource-in-maintenance/user2.xml
+++ b/testing/story/src/test/resources/resource-in-maintenance/user2.xml
@@ -1,0 +1,8 @@
+<user xmlns="http://midpoint.evolveum.com/xml/ns/public/common/common-3" xmlns:c="http://midpoint.evolveum.com/xml/ns/public/common/common-3" xmlns:icfs="http://midpoint.evolveum.com/xml/ns/public/connector/icf-1/resource-schema-3" xmlns:org="http://midpoint.evolveum.com/xml/ns/public/common/org-3" xmlns:q="http://prism.evolveum.com/xml/ns/public/query-3" xmlns:ri="http://midpoint.evolveum.com/xml/ns/public/resource/instance-3" xmlns:t="http://prism.evolveum.com/xml/ns/public/types-3" oid="cdc33185-c817-4be7-8158-8f3388241234">
+    <name>user2</name>
+    <fullName>R2-D2</fullName>
+    <description>robot</description> 
+    <activation>
+        <effectiveStatus>enabled</effectiveStatus>       
+    </activation>
+</user>

--- a/testing/story/testng-integration.xml
+++ b/testing/story/testng-integration.xml
@@ -65,6 +65,7 @@
             <class name="com.evolveum.midpoint.testing.story.TestPhotoAssignment"/>
             <class name="com.evolveum.midpoint.testing.story.grouper.TestGrouperAsyncUpdate"/>
             <class name="com.evolveum.midpoint.testing.story.TestWriter"/>
+            <class name="com.evolveum.midpoint.testing.story.TestResourceInMaintenance"/>
         </classes>
     </test>
 </suite>


### PR DESCRIPTION
Administrative operational state is set manually by midPoint users (e.g. administrator).
It signalizes whether resource is up and OPERATIONAL to receive provisioning requests or is down in MAINTENANCE and midPoint should not contact it during the provisioning.
This setting is useful when resource is e.g. undergoing planned maintenance to save computing time and error messages.
When under maintenance, operations are cached to the repository shadow and processed later when resource is back in OPERATIONAL mode.

EXPERIMENTAL FEATURE!