### PR TITLE
Support 4.2 resolves MID-6475

### DIFF
--- a/dist/src/main/bin/service.bat
+++ b/dist/src/main/bin/service.bat
@@ -83,7 +83,7 @@ set PR_LOGPREFIX=%SERVICE_NAME%
 set PR_LOGPATH=%MIDPOINT_HOME%\log
 set PR_STDOUTPUT=auto
 set PR_STDERROR=auto
-set PR_LOGLEVEL=Debug
+set PR_LOGLEVEL=Error
 
 REM Path to java installation
 REM Try to use the server jvm

--- a/dist/src/main/bin/service.bat
+++ b/dist/src/main/bin/service.bat
@@ -73,14 +73,17 @@ REM ----- Execute The Requested Command ---------------------------------------
 
 set EXECUTABLE=%BIN_DIR%\midpoint.exe
 set PR_INSTALL=%EXECUTABLE%
-set MIDPOINT_START_CLASS=com.evolveum.midpoint.tools.layout.MidPointWarLauncher
+
+REM use spring-boot through the PropertiesLauncher to start and the legacy WarLauncer to stop the application
+set MIDPOINT_START_CLASS=org.springframework.boot.loader.PropertiesLauncher
+set MIDPOINT_STOP_CLASS=com.evolveum.midpoint.tools.layout.MidPointWarLauncher
 
 REM Service log configuration
 set PR_LOGPREFIX=%SERVICE_NAME%
 set PR_LOGPATH=%MIDPOINT_HOME%\log
 set PR_STDOUTPUT=auto
 set PR_STDERROR=auto
-set PR_LOGLEVEL=Error
+set PR_LOGLEVEL=Debug
 
 REM Path to java installation
 REM Try to use the server jvm
@@ -104,9 +107,9 @@ set PR_STARTCLASS=%MIDPOINT_START_CLASS%
 
 REM Shutdown configuration
 set PR_STOPMODE=jvm
-set PR_STOPMETHOD=%PR_STARTMETHOD%
+set PR_STOPMETHOD=main
 set PR_STOPPARAMS=stop
-set PR_STOPCLASS=%MIDPOINT_START_CLASS%
+set PR_STOPCLASS=%MIDPOINT_STOP_CLASS%
 
 REM JVM configuration
 set PR_JVMMS=1024
@@ -132,6 +135,7 @@ echo Using JRE_HOME:         "%JRE_HOME%"
 
 REM Install service
 "%PR_INSTALL%" //IS//%SERVICE_NAME% ^
+--Description="Identity Governance and Administration Application" ^
 --StartMode="%PR_STARTMODE%" ^
 --StartClass="%PR_STARTCLASS%" ^
 --StartMethod="%PR_STARTMETHOD%" ^
@@ -149,7 +153,7 @@ REM Install service
 --LogLevel="%PR_LOGLEVEL%" ^
 --StdOutput="%PR_STDOUTPUT%" ^
 --StdError="%PR_STDERROR%" ^
---JvmOptions -Dmidpoint.home="%MIDPOINT_HOME%";-Dpython.cachedir="%MIDPOINT_HOME%\tmp";-Djavax.net.ssl.trustStore="%MIDPOINT_HOME%\keystore.jceks";-Djavax.net.ssl.trustStoreType=jceks ^
+--JvmOptions -Dmidpoint.home="%MIDPOINT_HOME%";-Dpython.cachedir="%MIDPOINT_HOME%\tmp";-Djavax.net.ssl.trustStore="%MIDPOINT_HOME%\keystore.jceks";-Djavax.net.ssl.trustStoreType=jceks;-Dloader.path=WEB-INF/classes,WEB-INF/lib,WEB-INF/lib-provided,"%MIDPOINT_HOME%\lib" ^
 --Classpath="%PR_CLASSPATH%"
 
 if not errorlevel 1 goto installed

--- a/tools/midpoint-war-layout/src/main/java/com/evolveum/midpoint/tools/layout/MidPointWarLauncher.java
+++ b/tools/midpoint-war-layout/src/main/java/com/evolveum/midpoint/tools/layout/MidPointWarLauncher.java
@@ -63,16 +63,7 @@ public class MidPointWarLauncher extends WarLauncher {
     }
 
     public static synchronized void stop(String[] args) throws Exception {
-        try {
-            if (warLauncher != null) {
-                warLauncher.launch(args, warLauncher.getMainClass(), classLoader, true);
-                warLauncher = null;
-                classLoader = null;
-            }
-        } catch (Exception ex) {
-            throw new Exception(
-                    "Could not stop MidPoint application" + ";" + ex.getLocalizedMessage(), ex);
-        }
+        System.exit(0);
     }
 
     @SuppressWarnings("SameParameterValue")


### PR DESCRIPTION
This PR fixes https://jira.evolveum.com/browse/MID-6475 windows service script by utilizing the spring boot PropertiesLoader class   to start the application which redirects to the main class specified in META-INF. Additionally, the service.bat script uses the existing, but modified MidPointWarLauncher application to safely stop the application. 

It does not appear that the modified method is uses by any other method of stopping the application and it is believed that this change is safe.