### PR TITLE
Added support to insert a reference to an organization or a role into operatorRef.

### DIFF
--- a/infra/schema/src/main/resources/xml/ns/public/common/common-core-3.xsd
+++ b/infra/schema/src/main/resources/xml/ns/public/common/common-core-3.xsd
@@ -8061,7 +8061,7 @@
                 <xsd:annotation>
                     <xsd:documentation>
                         Reference to users that should execute operations on manual resources.
-                        It may point to user or organization. (Currently only users are supported.)
+                        It may point to user, role (only role members) or organization (only direct org. members).
                         If more than one operator is specified they are considered equivalent.
                     </xsd:documentation>
                     <xsd:appinfo>


### PR DESCRIPTION
Members of the organizations (direct only) or roles can be used as operators of manual applications - only org:default relation.
- It enables more robust and automated management of operators of individual manual resources.