### PR TITLE
new config.xml option keystore/fixedSalt

### DIFF
--- a/repo/system-init/src/main/java/com/evolveum/midpoint/init/ConfigurableProtectorFactory.java
+++ b/repo/system-init/src/main/java/com/evolveum/midpoint/init/ConfigurableProtectorFactory.java
@@ -89,6 +89,7 @@ public class ConfigurableProtectorFactory {
         protector.setKeyStorePassword(protectorConfig.getKeyStorePassword());
         protector.setKeyStorePath(protectorConfig.getKeyStorePath());
         protector.setEncryptionAlgorithm(protectorConfig.getXmlCipher());
+        protector.setFixedSalt(protectorConfig.getFixedSalt());
         protector.init();
         return protector;
     }

--- a/repo/system-init/src/main/java/com/evolveum/midpoint/init/ProtectorConfiguration.java
+++ b/repo/system-init/src/main/java/com/evolveum/midpoint/init/ProtectorConfiguration.java
@@ -18,12 +18,14 @@ public class ProtectorConfiguration {
     private String keyStorePassword;
     private String encryptionKeyAlias;
     private String xmlCipher;
+    private String fixedSalt;
 
     public ProtectorConfiguration(Configuration configuration) {
         this.setKeyStorePath(configuration.getString("keyStorePath"));
         this.setKeyStorePassword(configuration.getString("keyStorePassword"));
         this.setEncryptionKeyAlias(configuration.getString("encryptionKeyAlias"));
         this.setXmlCipher(configuration.getString("xmlCipher"));
+        this.setFixedSalt(configuration.getString("fixedSalt"));
     }
 
     public String getEncryptionKeyAlias() {
@@ -56,5 +58,13 @@ public class ProtectorConfiguration {
 
     public void setXmlCipher(String xmlCipher) {
         this.xmlCipher = xmlCipher;
+    }
+
+    public String getFixedSalt() {
+        return fixedSalt;
+    }
+
+    public void setFixedSalt(String fixedSalt) {
+        this.fixedSalt = fixedSalt;
     }
 }


### PR DESCRIPTION
This new option sacrifices little security to allow new scenarios when using hashed password storage. E.g. with fixed salt passive-cached credentials in ShadowTypes can be compared to password history in UserType as hashes for same password values are equivalent. New config.xml option keystore/fixedSalt need to be set to any arbitrary value and is used globally as single fixed salt for all hashed values in midPoint.

Dependency here: https://github.com/Evolveum/prism/pull/1