### PR TITLE
backport fix for MID-6765 - compare binary data

### DIFF
--- a/infra/prism/src/main/java/com/evolveum/midpoint/prism/match/DefaultMatchingRule.java
+++ b/infra/prism/src/main/java/com/evolveum/midpoint/prism/match/DefaultMatchingRule.java
@@ -15,6 +15,7 @@
  */
 package com.evolveum.midpoint.prism.match;
 
+import java.util.Arrays;
 import java.util.regex.Pattern;
 
 import javax.xml.namespace.QName;
@@ -62,6 +63,9 @@ public class DefaultMatchingRule<T> implements MatchingRule<T> {
 		}
 		if (a instanceof Matchable && b instanceof Matchable) {
 			return ((Matchable)a).match((Matchable)b);
+		}
+		if (a instanceof byte[] && b instanceof byte[]) {
+			return Arrays.equals((byte[]) a, (byte[]) b);
 		}
 		// Just use plain java equals() method
 		return a.equals(b);


### PR DESCRIPTION
Backport from 4.0 without testing routine.