### PR TITLE
Improve Travis CI build Performance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,4 +34,4 @@ matrix:
     - name: JDK11 - Run all excluding model-intest
       script: mvn install -T 1C -q -DskipTests; mvn verify -DskipModelIntTest=true -DskipModelUnitTest=true -DtestsRetryCount=2
     - name: JDK11 - Run only model-intest
-      script: mvn install -T 1C -q -DskipTests; travis_wait 120 mvn verify -pl :model-intest -DtestsRetryCount=2
+      script: mvn install -T 1C -q -DskipTests; mvn verify -pl :model-intest -DtestsRetryCount=2


### PR DESCRIPTION

According to [Build times out because no output was received](https://docs.travis-ci.com/user/common-build-problems/#build-times-out-because-no-output-was-received), we should carefully use travis_wait, as it may make the build unstable and extend the build time.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
