### PR TITLE
introduce MIDPOINT_PORT environment variable

### DIFF
--- a/dist/src/main/bin/midpoint.bat
+++ b/dist/src/main/bin/midpoint.bat
@@ -44,6 +44,10 @@ call "%MIDPOINT_HOME%\setenv.bat"
 
 :noSetEnvMpHome
 
+if "%MIDPOINT_PORT%" == "" (
+    set MIDPOINT_PORT=8080
+)
+
 echo Using MIDPOINT_HOME:   "%MIDPOINT_HOME%"
 
 if not exist "%LIB_DIR%\midpoint.war" (
@@ -70,13 +74,15 @@ echo Using parameters:      "%*"
 echo.
 echo Starting midPoint.
 start /b "midPoint" "%RUN_JAVA%"^
- %JAVA_OPTS% -Dmidpoint.home="%MIDPOINT_HOME%"^
+ %JAVA_OPTS% -Dmidpoint.home="%MIDPOINT_HOME%" -Dmidpoint.port="%MIDPOINT_PORT%"^
  -jar "%LIB_DIR%\midpoint.war" %2 %3 %4 %5 %6 %7 %8 %9 > "%BOOT_OUT%" 2>&1
 goto end
 
 :doStop
 
-set MIDPOINT_PORT=8080
+if "%MIDPOINT_PORT%" == "" (
+    set MIDPOINT_PORT=8080
+)
 
 echo Trying to find and stop a process listening on port %MIDPOINT_PORT%...
 set MIDPOINT_FOUND=

--- a/dist/src/main/bin/midpoint.sh
+++ b/dist/src/main/bin/midpoint.sh
@@ -366,6 +366,9 @@ if [[ -r "${MIDPOINT_HOME}/setenv.sh" ]]; then
   . "${MIDPOINT_HOME}/setenv.sh"
 fi
 
+: "${MIDPOINT_PORT:=8080}"
+if $(echo "${JAVA_OPTS:-}" | grep -v -q "\-Dmidpoint.port=") ; then JAVA_OPTS="${JAVA_OPTS:-} -Dmidpoint.port=\"${MIDPOINT_PORT}\"" ; fi
+
 : "${BOOT_OUT:="${MIDPOINT_HOME}/log/midpoint.out"}"
 : "${PID_FILE:="${MIDPOINT_HOME}/log/midpoint.pid"}"
 

--- a/gui/admin-gui/src/main/resources/application.yml
+++ b/gui/admin-gui/src/main/resources/application.yml
@@ -13,6 +13,7 @@ spring:
     cache: false
 
 server:
+  port: ${midpoint.port}
   tomcat:
     basedir: ${midpoint.home}
     max-http-form-post-size: 100MB


### PR DESCRIPTION
Closes https://jira.evolveum.com/browse/MID-7764.
Port 8080 is used by various services unexpectedly, so it is a little inconvenient if we can not change the port when we try to newly introduce midPoint to the existing server.