### PR TITLE
.editorconfig charset latin1/ISO-8859-1 on prop files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1146,6 +1146,7 @@ ij_prototext_spaces_within_braces = true
 ij_prototext_spaces_within_brackets = false
 
 [{*.properties,spring.handlers,spring.schemas}]
+charset = latin1
 ij_visual_guides = none
 ij_properties_align_group_field_declarations = false
 ij_properties_keep_blank_lines = false


### PR DESCRIPTION
IDEA already force ISO-8859-1 by default for these files and even ignore whatever is set in .editorconfig for the files *.properties, spring.handlers and spring.schemas to ensure the correct charset.

But since this is not a behavior shared by all editors, I would like to set it it here for people that might user other editors.
