### PR TITLE
Fix to override the config properties from JVM arguments

### DIFF
--- a/dist/src/main/bin/midpoint.bat
+++ b/dist/src/main/bin/midpoint.bat
@@ -70,8 +70,8 @@ echo Using parameters:      "%*"
 echo.
 echo Starting midPoint.
 start /b "midPoint" "%RUN_JAVA%"^
- %JAVA_OPTS% -Dmidpoint.home="%MIDPOINT_HOME%"^
- -jar "%LIB_DIR%\midpoint.war" %2 %3 %4 %5 %6 %7 %8 %9 > "%BOOT_OUT%" 2>&1
+ %JAVA_OPTS% -Dmidpoint.home="%MIDPOINT_HOME%" %2 %3 %4 %5 %6 %7 %8 %9^
+ -jar "%LIB_DIR%\midpoint.war" > "%BOOT_OUT%" 2>&1
 goto end
 
 :doStop


### PR DESCRIPTION
This is related to the ticket https://jira.evolveum.com/browse/MID-7764.

If trying to override the config properties from JVM arguments like the following,
```
>bin\start.bat "-Dserver.port=8081" "-Dserver.servlet.context-path=/mypoint"
Using MIDPOINT_HOME:   "c:\Users\xxx\media\midPoint\midpoint-4.4\bin\..\var"
Using BOOT_OUT:        "c:\Users\xxx\media\midPoint\midpoint-4.4\bin\..\var\log\midpoint.out"
Using RUN_JAVA:        "C:\Program Files\Java\jdk11\bin\javaw"
Using JAVA_OPTS:       "-Xms2048M -Xmx4096M -Dpython.cachedir="c:\Users\xxx\media\midPoint\midpoint-4.4\bin\..\var\tmp" -Djavax.net.ssl.trustStore="c:\Users\xxx\media\midPoint\midpoint-4.4\bin\..\var\keystore.jceks" -Djavax.net.ssl.trustStoreType=jceks "
Using parameters:      "start "-Dserver.port=8081" "-Dserver.servlet.context-path=/mypoint""


Starting midPoint.
```

The config properties are not overridden.
```
2022-03-29 16:11:35,211 [] [main] INFO (org.apache.coyote.http11.Http11NioProtocol): Starting ProtocolHandler ["http-nio-8080"]
2022-03-29 16:11:35,320 [] [main] INFO (org.springframework.boot.web.embedded.tomcat.TomcatWebServer): Tomcat started on port(s): 8080 (http) with context path '/midpoint'
2022-03-29 16:11:35,370 [] [main] INFO (com.evolveum.midpoint.web.boot.MidPointSpringApplication): Started MidPointSpringApplication in 96.551 seconds (JVM running for 99.642)
```

The arguments are passed successfully.
```
>WMIC PROCESS where caption="javaw.exe" GET Caption,Name,ProcessId,CommandLine /FORMAT:LIST

Caption=javaw.exe
CommandLine="C:\Program Files\Java\jdk11\bin\javaw"  -Xms2048M -Xmx4096M -Dpython.cachedir="c:\Users\xxx\media\midPoint\midpoint-4.4\bin\..\var\tmp" -Djavax.net.ssl.trustStore="c:\Users\xxx\media\midPoint\midpoint-4.4\bin\..\var\keystore.jceks" -Djavax.net.ssl.trustStoreType=jceks  -Dmidpoint.home="c:\Users\xxx\media\midPoint\midpoint-4.4\bin\..\var" -jar "c:\Users\xxx\media\midPoint\midpoint-4.4\bin\..\lib\midpoint.war" "-Dserver.port=8081" "-Dserver.servlet.context-path=/mypoint"
Name=javaw.exe
ProcessId=3884
```

This is because the arguments are passed after the jar file.
If modifying like this PR, the overriding is successful.
```
>bin\start.bat "-Dserver.port=8081" "-Dserver.servlet.context-path=/mypoint"
Using MIDPOINT_HOME:   "c:\Users\xxx\media\midPoint\midpoint-4.4\bin\..\var"
Using BOOT_OUT:        "c:\Users\xxx\media\midPoint\midpoint-4.4\bin\..\var\log\midpoint.out"
Using RUN_JAVA:        "C:\Program Files\Java\jdk11\bin\javaw"
Using JAVA_OPTS:       "-Xms2048M -Xmx4096M -Dpython.cachedir="c:\Users\xxx\media\midPoint\midpoint-4.4\bin\..\var\tmp" -Djavax.net.ssl.trustStore="c:\Users\xxx\media\midPoint\midpoint-4.4\bin\..\var\keystore.jceks" -Djavax.net.ssl.trustStoreType=jceks "
Using parameters:      "start "-Dserver.port=8081" "-Dserver.servlet.context-path=/mypoint""

Starting midPoint.
```

```
2022-03-29 16:15:17,525 [] [main] INFO (org.apache.coyote.http11.Http11NioProtocol): Starting ProtocolHandler ["http-nio-8081"]
2022-03-29 16:15:17,658 [] [main] INFO (org.springframework.boot.web.embedded.tomcat.TomcatWebServer): Tomcat started on port(s): 8081 (http) with context path '/mypoint'
2022-03-29 16:15:17,700 [] [main] INFO (com.evolveum.midpoint.web.boot.MidPointSpringApplication): Started MidPointSpringApplication in 94.588 seconds (JVM running for 97.48)
```

```
>WMIC PROCESS where caption="javaw.exe" GET Caption,Name,ProcessId,CommandLine /FORMAT:LIST

Caption=javaw.exe
CommandLine="C:\Program Files\Java\jdk11\bin\javaw"  -Xms2048M -Xmx4096M -Dpython.cachedir="c:\Users\xxx\media\midPoint\midpoint-4.4\bin\..\var\tmp" -Djavax.net.ssl.trustStore="c:\Users\xxx\media\midPoint\midpoint-4.4\bin\..\var\keystore.jceks" -Djavax.net.ssl.trustStoreType=jceks  -Dmidpoint.home="c:\Users\xxx\media\midPoint\midpoint-4.4\bin\..\var" "-Dserver.port=8081" "-Dserver.servlet.context-path=/mypoint"       -jar "c:\Users\xxx\media\midPoint\midpoint-4.4\bin\..\lib\midpoint.war"
Name=javaw.exe
ProcessId=11292
```


My Windows version is Windows 10 Pro 19043.1586.