### PR TITLE
MID-7135 Add no-serialization option for Wicket

### DIFF
--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/security/MidPointApplication.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/security/MidPointApplication.java
@@ -188,6 +188,7 @@ public class MidPointApplication extends AuthenticatedWebApplication implements 
     @Autowired private SystemConfigurationChangeDispatcher systemConfigurationChangeDispatcher;
     @Autowired private Clock clock;
     @Autowired private AccessCertificationService certificationService;
+    @Autowired(required = false) private List<WicketConfigurator> wicketConfigurators = new ArrayList<>();
     @Autowired @Qualifier("descriptorLoader") private DescriptorLoader descriptorLoader;
     @Value("${midpoint.additionalPackagesToScan:}") private String additionalPackagesToScan;
 
@@ -323,6 +324,8 @@ public class MidPointApplication extends AuthenticatedWebApplication implements 
             taskManager.setWebContextPath(servletContext.getContextPath());
         }
 
+        // Additional wicket configuration
+        wicketConfigurators.forEach(c -> c.configure(this));
     }
 
     public DeploymentInformationType getDeploymentInfo() {

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/security/WicketConfigurator.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/security/WicketConfigurator.java
@@ -1,0 +1,13 @@
+/*
+ * Copyright (C) 2010-2022 Evolveum and contributors
+ *
+ * This work is dual-licensed under the Apache License 2.0
+ * and European Union Public License. See LICENSE file for details.
+ */
+package com.evolveum.midpoint.web.security;
+
+import org.apache.wicket.Application;
+
+public interface WicketConfigurator {
+    void configure(Application application);
+}

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/security/WicketNoSerializationConfigurator.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/security/WicketNoSerializationConfigurator.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2010-2022 Evolveum and contributors
+ *
+ * This work is dual-licensed under the Apache License 2.0
+ * and European Union Public License. See LICENSE file for details.
+ */
+package com.evolveum.midpoint.web.security;
+
+import org.apache.wicket.Application;
+import org.apache.wicket.DefaultPageManagerProvider;
+import org.apache.wicket.page.IPageManager;
+import org.apache.wicket.page.PageManager;
+import org.apache.wicket.pageStore.IPageStore;
+import org.apache.wicket.pageStore.InMemoryPageStore;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+
+@Component
+@ConditionalOnProperty(name = "wicket.no-serialization.enabled", havingValue = "true")
+public class WicketNoSerializationConfigurator implements WicketConfigurator {
+
+    @Value("${wicket.no-serialization.max-pages:1}")
+    private int maxPages;
+
+    @Override
+    public void configure(Application application) {
+        application.setPageManagerProvider(new NoSerializationPageManagerProvider(application));
+    }
+
+    private class NoSerializationPageManagerProvider extends DefaultPageManagerProvider {
+
+        public NoSerializationPageManagerProvider(Application application) {
+            super(application);
+        }
+
+        @Override
+        public IPageManager get() {
+            IPageStore store = newPersistentStore();
+            store = newCachingStore(store);
+            store = newRequestStore(store);
+            return new PageManager(store);
+        }
+
+        protected IPageStore newPersistentStore() {
+            return new InMemoryPageStore(application.getName(), maxPages);
+        }
+    }
+}


### PR DESCRIPTION
In MID-7135, serialization costs have been greatly reduced, but I have added an option to accept Wicket's feature limitation and choose the no-serialization mode for performance reason.

To use it, set the following in `$MP_HOME/application.properties`.

```
wicket.no-serialization.enabled=true
```

Enabling this mode will prevent the creation of serialized pages files under `$MP_HOME/Tomcat/localhost/midpoint/wicketFilestore/...`.

The maximum number of pages per session to be kept on-memory is also configurable (default is 1) with `wicket.no-serialization.max-pages`.
