### PR TITLE
MID-8469 Fixed display format of case/work item pages

### DIFF
--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/api/util/WebComponentUtil.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/api/util/WebComponentUtil.java
@@ -2074,6 +2074,17 @@ public final class WebComponentUtil {
                 pageBase.createStringResource(relation.getLocalPart()).getString();
     }
 
+    public static String getRelationLabelValue(PrismReferenceValue referenceValue, PageBase pageBase) {
+        if (referenceValue == null) {
+            return "";
+        }
+        QName relation = referenceValue.getRelation();
+        String relationDisplayName = getRelationHeaderLabelKeyIfKnown(relation);
+        return StringUtils.isNotEmpty(relationDisplayName) ?
+                pageBase.createStringResource(relationDisplayName).getString() :
+                pageBase.createStringResource(relation.getLocalPart()).getString();
+    }
+
     private static QName getRelation(PrismContainerValueWrapper<AssignmentType> assignmentWrapper) throws SchemaException {
         if (assignmentWrapper == null) {
             return null;

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/data/column/ColumnUtils.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/data/column/ColumnUtils.java
@@ -606,14 +606,7 @@ public class ColumnUtils {
             protected IModel<String> createLinkModel(IModel<PrismContainerValueWrapper<CaseWorkItemType>> rowModel) {
                 CaseWorkItemType caseWorkItemType = unwrapRowModel(rowModel);
                 CaseType caseType = CaseTypeUtil.getCase(caseWorkItemType);
-                String name;
-                AssignmentHolderType object = WebComponentUtil.getObjectFromAddDeltaForCase(caseType);
-                if (object == null) {
-                    name = WebModelServiceUtils.resolveReferenceName(caseType.getObjectRef(), pageBase, true);
-                } else {
-                    name = WebComponentUtil.getEffectiveName(object, AbstractRoleType.F_DISPLAY_NAME, true);
-                }
-                return Model.of(name);
+                return Model.of(WebComponentUtil.getReferencedObjectDisplayNameAndName(caseType.getObjectRef(), true, pageBase));
             }
 
             @Override
@@ -662,7 +655,7 @@ public class ColumnUtils {
             protected IModel<String> createLinkModel(IModel<PrismContainerValueWrapper<CaseWorkItemType>> rowModel) {
                 CaseWorkItemType caseWorkItemType = unwrapRowModel(rowModel);
                 CaseType caseType = CaseTypeUtil.getCase(caseWorkItemType);
-                return Model.of(WebModelServiceUtils.resolveReferenceName(caseType.getTargetRef(), pageBase, true));
+                return Model.of(WebComponentUtil.getReferencedObjectDisplayNameAndName(caseType.getTargetRef(), true, pageBase));
             }
 
             @Override
@@ -799,41 +792,37 @@ public class ColumnUtils {
         IColumn column = new PropertyColumn(createStringResource("pageCases.table.description"), "value.description");
         columns.add(column);
 
-        column = new AbstractExportableColumn<SelectableBean<CaseType>, String>(createStringResource("pageCases.table.objectRef")) {
+        columns.add(new AjaxLinkColumn<>(createStringResource("pageCases.table.objectRef")) {
+            private static final long serialVersionUID = 1L;
+
             @Override
-            public IModel<?> getDataModel(IModel<SelectableBean<CaseType>> iModel) {
-                return (IModel<String>) () -> {
-                    CaseType caseModelObject = iModel.getObject().getValue();
-                    if (caseModelObject == null) {
-                        return "";
-                    }
-                    AssignmentHolderType objectRef = WebComponentUtil.getObjectFromAddDeltaForCase(caseModelObject);
-                    if (objectRef != null) {
-                        return WebComponentUtil.getEffectiveName(objectRef, AbstractRoleType.F_DISPLAY_NAME);
-                    } else if (caseModelObject.getObjectRef() != null
-                            && StringUtils.isNotEmpty(caseModelObject.getObjectRef().getOid())) {
-                        if (caseModelObject.getObjectRef().getObject() != null) {
-                            return WebComponentUtil.getEffectiveName(caseModelObject.getObjectRef().getObject(),
-                                    AbstractRoleType.F_DISPLAY_NAME);
-                        } else {
-                            try {
-                                return WebComponentUtil.getEffectiveName(caseModelObject.getObjectRef(), AbstractRoleType.F_DISPLAY_NAME, pageBase,
-                                        pageBase.getClass().getSimpleName() + "." + "loadCaseObjectRefName");
-                            } catch (Exception ex) {
-                                LOGGER.error("Unable find the object for reference: {}", caseModelObject.getObjectRef());
-                            }
-                        }
-                    }
-                    return "";
-                };
+            public IModel<String> getDataModel(IModel<SelectableBean<CaseType>> rowModel) {
+                CaseType caseModelObject = rowModel.getObject().getValue();
+                return Model.of(WebComponentUtil.getReferencedObjectDisplayNameAndName(caseModelObject.getObjectRef(), true, pageBase));
             }
 
             @Override
-            public void populateItem(Item<ICellPopulator<SelectableBean<CaseType>>> item, String componentId, IModel<SelectableBean<CaseType>> rowModel) {
-                item.add(new Label(componentId, getDataModel(rowModel)));
+            protected IModel<String> createLinkModel(IModel<SelectableBean<CaseType>> rowModel) {
+                CaseType caseType = rowModel.getObject().getValue();
+                return Model.of(WebComponentUtil.getReferencedObjectDisplayNameAndName(caseType.getObjectRef(), true, pageBase));
             }
-        };
-        columns.add(column);
+
+            @Override
+            public void onClick(AjaxRequestTarget target, IModel<SelectableBean<CaseType>> rowModel) {
+                CaseType caseType = rowModel.getObject().getValue();
+
+                dispatchToObjectDetailsPage(caseType.getObjectRef(), pageBase, false);
+            }
+
+            @Override
+            public boolean isEnabled(IModel<SelectableBean<CaseType>> rowModel) {
+                CaseType caseType = rowModel.getObject().getValue();
+                PrismObject object = caseType.getObjectRef().getObject();
+                // Do not generate link if the object has not been created yet.
+                // Check the version to see if it has not been created.
+                return object != null && object.getVersion() != null;
+            }
+        });
 
         if (!isDashboard) {
             columns.add(createCaseActorsColumn(pageBase));
@@ -1053,7 +1042,7 @@ public class ColumnUtils {
         if (referencesList != null) {
             referencesList.forEach(reference -> {
                 AjaxLinkPanel referenceAjaxLinkPanel = new AjaxLinkPanel(multilineLinkPanel.newChildId(),
-                        Model.of(WebModelServiceUtils.resolveReferenceName(reference.clone(), pageBase, true))) {
+                        Model.of(WebComponentUtil.getReferencedObjectDisplayNameAndName(reference, true, pageBase))) {
                     private static final long serialVersionUID = 1L;
 
                     @Override

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/prism/show/VisualizationItemValuePanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/prism/show/VisualizationItemValuePanel.java
@@ -97,7 +97,7 @@ public class VisualizationItemValuePanel extends BasePanel<VisualizationItemValu
         link.add(visibleIfReference);
         add(link);
 
-        final Label additionalText = new Label(ID_ADDITIONAL_TEXT, () -> getModelObject() != null ? WebComponentUtil.translateMessage(getModelObject().getAdditionalText()) : null);
+        final Label additionalText = new Label(ID_ADDITIONAL_TEXT, new AdditionalLabelModel());
         add(additionalText);
     }
 
@@ -157,6 +157,20 @@ public class VisualizationItemValuePanel extends BasePanel<VisualizationItemValu
             }
 
             return value;
+        }
+    }
+
+    private class AdditionalLabelModel implements IModel<String> {
+        @Override
+        public String getObject() {
+            VisualizationItemValue val = getModelObject();
+            if (val == null) {
+                return null;
+            }
+            if (val.getSourceValue() != null && val.getSourceValue() instanceof PrismReferenceValue) {
+                return "[" + WebComponentUtil.getRelationLabelValue((PrismReferenceValue) val.getSourceValue(), getPageBase()) + "]";
+            }
+            return WebComponentUtil.translateMessage(getModelObject().getAdditionalText());
         }
     }
 }

--- a/model/model-impl/src/main/java/com/evolveum/midpoint/model/impl/visualizer/Visualizer.java
+++ b/model/model-impl/src/main/java/com/evolveum/midpoint/model/impl/visualizer/Visualizer.java
@@ -16,6 +16,7 @@ import static com.evolveum.midpoint.schema.SelectorOptions.createCollection;
 import java.util.*;
 
 import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;

--- a/model/workflow-impl/src/main/java/com/evolveum/midpoint/wf/impl/processors/primary/policy/AssignmentPolicyAspectPart.java
+++ b/model/workflow-impl/src/main/java/com/evolveum/midpoint/wf/impl/processors/primary/policy/AssignmentPolicyAspectPart.java
@@ -52,6 +52,7 @@ import org.jetbrains.annotations.NotNull;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
+import javax.xml.namespace.QName;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
@@ -337,11 +338,26 @@ public class AssignmentPolicyAspectPart {
                 assignment.isBeingDeleted() ? "Deleted" :
                         "Modified";
 
-        return new LocalizableMessageBuilder()
-                .key(SchemaConstants.DEFAULT_POLICY_CONSTRAINT_SHORT_MESSAGE_KEY_PREFIX + "assignmentModification.toBe" + operationKey)
-                .arg(ObjectTypeUtil.createDisplayInformation(target, false))
-                .arg(ObjectTypeUtil.createDisplayInformation(asPrismObject(focus), false))
-                .build();
+        QName relation = assignment.getNormalizedRelation();
+
+        if (relation == null) {
+            return new LocalizableMessageBuilder()
+                    .key(SchemaConstants.DEFAULT_POLICY_CONSTRAINT_SHORT_MESSAGE_KEY_PREFIX + "assignmentModification.toBe" + operationKey)
+                    .arg(ObjectTypeUtil.createDisplayInformation(target, false))
+                    .arg(ObjectTypeUtil.createDisplayInformation(asPrismObject(focus), false))
+                    .build();
+        } else {
+            LocalizableMessage relationMessage = new LocalizableMessageBuilder()
+                    .key("relation." + relation.getLocalPart())
+                    .build();
+
+            return new LocalizableMessageBuilder()
+                    .key(SchemaConstants.DEFAULT_POLICY_CONSTRAINT_SHORT_REL_MESSAGE_KEY_PREFIX + "assignmentModification.toBe" + operationKey)
+                    .arg(ObjectTypeUtil.createDisplayInformation(target, false))
+                    .arg(ObjectTypeUtil.createDisplayInformation(asPrismObject(focus), false))
+                    .arg(relationMessage)
+                    .build();
+        }
     }
 
     // creates an ObjectDelta that will be executed after successful approval of the given assignment


### PR DESCRIPTION
https://jira.evolveum.com/browse/MID-8469

Fixed the following display format of the case/work item pages:

* The object, target and actor(s) are formatted with `displayName (name)` or `fullname (name)`. They are also clickable if exists.
* In the "View case work item" page, now the relation is translated (e.g. `[default]` => `[Member]` in english).
* The name of CaseType when assigning includes the relation. (Note: I didn't fix the target name in the text as `displayName (name)` because It is necessary to change `ObjectTypeUtil.createDisplayInformation` and it is used in many places and has some impact to fix)


### All work items page
![fixed-all-work-items](https://user-images.githubusercontent.com/28739/216609479-9e387c98-e9b8-42c8-8a83-3f45bd4a7267.png)


### All cases page

![fixed-all-cases](https://user-images.githubusercontent.com/28739/216609498-c622e9c5-c626-462c-a329-06a62aba0b6c.png)


### View case work item page
![fixed-view-case-work-item](https://user-images.githubusercontent.com/28739/216609526-bee5e098-087a-457e-9c4c-f1f2e5ebb04a.png)


### View approval case page

![fixed-view-approval-case1](https://user-images.githubusercontent.com/28739/216609563-34b3eda8-75ef-41cb-ae69-54bd20029c81.png)

![fixed-view-approval-case2](https://user-images.githubusercontent.com/28739/216609580-a3b14e90-8482-4ebd-bc5f-584bb56a029a.png)
