### PR TITLE
Add generated prism schema source to ide source path

### DIFF
--- a/infra/schema/pom.xml
+++ b/infra/schema/pom.xml
@@ -289,6 +289,24 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>add-sources</id>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>add-source</goal>
+                        </goals>
+                        <configuration>
+                            <sources>
+                                <source>target/generated-sources/prism</source>
+                            </sources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
         <resources>
             <resource>


### PR DESCRIPTION
This can avoid manual steps required when setting up in IDE such as vscode.