### PR TITLE
Fix error in test.log "ObjectNotFoundException:Object of type 'System…

### DIFF
--- a/model/model-test/src/main/java/com/evolveum/midpoint/model/test/AbstractModelIntegrationTest.java
+++ b/model/model-test/src/main/java/com/evolveum/midpoint/model/test/AbstractModelIntegrationTest.java
@@ -240,6 +240,7 @@ public abstract class AbstractModelIntegrationTest extends AbstractIntegrationTe
     protected DummyResourceCollection dummyResourceCollection;
 
     protected DummyAuditService dummyAuditService;
+    private SystemConfigurationType systemConfiguration;
     private boolean accessesMetadataEnabled;
 
     public AbstractModelIntegrationTest() {
@@ -270,8 +271,6 @@ public abstract class AbstractModelIntegrationTest extends AbstractIntegrationTe
         // We generally do not import all the archetypes for all kinds of tasks (at least not now).
         activityBasedTaskHandler.setAvoidAutoAssigningArchetypes(true);
 
-        accessesMetadataEnabled = SystemConfigurationTypeUtil.isAccessesMetadataEnabled(
-                systemObjectCache.getSystemConfigurationBean(initResult));
     }
 
     @Override
@@ -279,6 +278,9 @@ public abstract class AbstractModelIntegrationTest extends AbstractIntegrationTe
         if (dummyResourceCollection != null) {
             dummyResourceCollection.resetResources();
         }
+        systemConfiguration = systemObjectCache.getSystemConfigurationBean(initResult);
+        assertNotNull("No systemConfiguration found after initSystem", systemConfiguration);
+        accessesMetadataEnabled = SystemConfigurationTypeUtil.isAccessesMetadataEnabled(systemConfiguration);
     }
 
     protected boolean isAvoidLoggingChange() {


### PR DESCRIPTION
…ConfigurationType' with OID '00000000-0000-0000-0000-000000000001' was not found"

In method AbstractModelIntegrationTest.initSystemm, systemConfiguration object may be not initialized, it is up to subclass. If subclass invokes super.initSystem method before adding systemConfiguration object, there is no systemConfiguration object available over the span of initSystem method.

Otherwise, we can suppose that systemConfiguration object must be available in method postInitSystem, so we can move codes required access systemConfiguration object to postInitSystem from initSystem.