### PR TITLE
MID-9062 Optimized to compile GuiProfile

### DIFF
--- a/model/authentication-api/src/main/java/com/evolveum/midpoint/authentication/api/AuthenticationChannel.java
+++ b/model/authentication-api/src/main/java/com/evolveum/midpoint/authentication/api/AuthenticationChannel.java
@@ -43,6 +43,8 @@ public interface AuthenticationChannel {
 
     boolean isSupportActivationByChannel();
 
+    boolean isSupportGuiConfigByChannel();
+
     String getUrlSuffix();
 
     boolean isPostAuthenticationEnabled();

--- a/model/authentication-api/src/main/java/com/evolveum/midpoint/authentication/api/evaluator/context/AbstractAuthenticationContext.java
+++ b/model/authentication-api/src/main/java/com/evolveum/midpoint/authentication/api/evaluator/context/AbstractAuthenticationContext.java
@@ -30,6 +30,8 @@ public abstract class AbstractAuthenticationContext {
 
     private final boolean supportActivationByChannel;
 
+    private final boolean supportGuiConfigByChannel;
+
     public AbstractAuthenticationContext(
             String username,
             Class<? extends FocusType> principalType,
@@ -39,6 +41,7 @@ public abstract class AbstractAuthenticationContext {
         this.requireAssignments = requireAssignment;
         this.principalType = principalType;
         this.supportActivationByChannel = channel == null || channel.isSupportActivationByChannel();
+        this.supportGuiConfigByChannel = channel == null || channel.isSupportGuiConfigByChannel();
     }
 
     public String getUsername() {
@@ -51,6 +54,10 @@ public abstract class AbstractAuthenticationContext {
 
     public boolean isSupportActivationByChannel() {
         return supportActivationByChannel;
+    }
+
+    public boolean isSupportGuiConfigByChannel() {
+        return supportGuiConfigByChannel;
     }
 
     public List<ObjectReferenceType> getRequireAssignments() {

--- a/model/authentication-impl/src/main/java/com/evolveum/midpoint/authentication/impl/FocusAuthenticationResultRecorder.java
+++ b/model/authentication-impl/src/main/java/com/evolveum/midpoint/authentication/impl/FocusAuthenticationResultRecorder.java
@@ -179,7 +179,8 @@ public class FocusAuthenticationResultRecorder {
         FocusType focusType = null;
         if (principal == null && StringUtils.isNotEmpty(username)) {
             try {
-                principal = focusProfileService.getPrincipal(username, FocusType.class);
+                // For recording audit log, we don't need to support GUI config
+                principal = focusProfileService.getPrincipal(username, FocusType.class, false);
             } catch (CommonException e) {
                 //ignore error
             }

--- a/model/authentication-impl/src/main/java/com/evolveum/midpoint/authentication/impl/authorization/evaluator/MidpointHttpAuthorizationEvaluator.java
+++ b/model/authentication-impl/src/main/java/com/evolveum/midpoint/authentication/impl/authorization/evaluator/MidpointHttpAuthorizationEvaluator.java
@@ -88,6 +88,7 @@ public class MidpointHttpAuthorizationEvaluator extends MidPointGuiAuthorization
                                 // TODO get operation result from the caller
                                 securityContextManager.getUserProfileService().getPrincipal(
                                         authorizedUser,
+                                        false, // For REST API, we don't need to support GUI config
                                         new OperationResult(MidPointPrincipalManager.OPERATION_GET_PRINCIPAL));
                         ((MidpointAuthentication) authentication).setPrincipal(principal);
                         ((MidpointAuthentication) authentication).setAuthorities(principal.getAuthorities());

--- a/model/authentication-impl/src/main/java/com/evolveum/midpoint/authentication/impl/channel/AuthenticationChannelImpl.java
+++ b/model/authentication-impl/src/main/java/com/evolveum/midpoint/authentication/impl/channel/AuthenticationChannelImpl.java
@@ -139,6 +139,11 @@ public class AuthenticationChannelImpl implements AuthenticationChannel {
     }
 
     @Override
+    public boolean isSupportGuiConfigByChannel() {
+        return true;
+    }
+
+    @Override
     public String getUrlSuffix() {
         return this.channel.getUrlSuffix();
     }

--- a/model/authentication-impl/src/main/java/com/evolveum/midpoint/authentication/impl/channel/RestAuthenticationChannel.java
+++ b/model/authentication-impl/src/main/java/com/evolveum/midpoint/authentication/impl/channel/RestAuthenticationChannel.java
@@ -25,4 +25,9 @@ public class RestAuthenticationChannel extends AuthenticationChannelImpl {
     public String getPathAfterSuccessfulAuthentication() {
         return "/ws/rest/self";
     }
+
+    @Override
+    public boolean isSupportGuiConfigByChannel() {
+        return false;
+    }
 }

--- a/model/authentication-impl/src/main/java/com/evolveum/midpoint/authentication/impl/evaluator/AuthenticationEvaluatorImpl.java
+++ b/model/authentication-impl/src/main/java/com/evolveum/midpoint/authentication/impl/evaluator/AuthenticationEvaluatorImpl.java
@@ -59,7 +59,7 @@ public abstract class AuthenticationEvaluatorImpl<T extends AbstractAuthenticati
         Class<? extends FocusType> clazz = authCtx.getPrincipalType();
         MidPointPrincipal principal;
         try {
-            principal = focusProfileService.getPrincipal(query, clazz);
+            principal = focusProfileService.getPrincipal(query, clazz, authCtx.isSupportGuiConfigByChannel());
         } catch (ObjectNotFoundException e) {
             recordModuleAuthenticationFailure(username, null, connEnv, null, "no focus");
             throw new UsernameNotFoundException(AuthUtil.generateBadCredentialsMessageKey(SecurityContextHolder.getContext().getAuthentication()));

--- a/model/authentication-impl/src/main/java/com/evolveum/midpoint/authentication/impl/provider/CorrelationProvider.java
+++ b/model/authentication-impl/src/main/java/com/evolveum/midpoint/authentication/impl/provider/CorrelationProvider.java
@@ -129,17 +129,6 @@ public class CorrelationProvider extends MidpointAbstractAuthenticationProvider 
         }
     }
 
-    private Authentication createAuthenticationToken(ObjectType owner, Class<? extends FocusType> focusType) {
-        try {
-            MidPointPrincipal principal = focusProfileService.getPrincipalByOid(owner.getOid(), focusType);
-            return new UsernamePasswordAuthenticationToken(principal, null);
-        } catch (ObjectNotFoundException | SchemaException | CommunicationException | ConfigurationException |
-                SecurityViolationException | ExpressionEvaluationException e) {
-            throw new RuntimeException(e);
-            //TODO
-        }
-    }
-
     private CompleteCorrelationResult correlate(
             CorrelationVerificationToken correlationToken,
             String archetypeOid,

--- a/model/authentication-impl/src/main/java/com/evolveum/midpoint/authentication/impl/provider/MidPointLdapAuthenticationProvider.java
+++ b/model/authentication-impl/src/main/java/com/evolveum/midpoint/authentication/impl/provider/MidPointLdapAuthenticationProvider.java
@@ -258,7 +258,8 @@ public class MidPointLdapAuthenticationProvider extends MidpointAbstractAuthenti
         String channel = getChannel();
         MidPointPrincipal principal = null;
         try {
-            principal = focusProfileService.getPrincipal(name, getFocusType());
+            // For recording audit log, we don't need to support GUI config
+            principal = focusProfileService.getPrincipal(name, getFocusType(), false);
             focus = principal.getFocus();
         } catch (Exception e) {
             //ignore if non-exist

--- a/model/authentication-impl/src/test/java/com/evolveum/midpoint/authentication/evaluator/TestAbstractAuthenticationEvaluator.java
+++ b/model/authentication-impl/src/test/java/com/evolveum/midpoint/authentication/evaluator/TestAbstractAuthenticationEvaluator.java
@@ -186,37 +186,37 @@ public abstract class TestAbstractAuthenticationEvaluator<V, AC extends Abstract
             }
 
             @Override
-            public GuiProfiledPrincipal getPrincipal(PrismObject<? extends FocusType> user, OperationResult result)
+            public GuiProfiledPrincipal getPrincipal(PrismObject<? extends FocusType> user, boolean supportGuiConfig, OperationResult result)
                     throws SchemaException, CommunicationException, ConfigurationException, SecurityViolationException, ExpressionEvaluationException {
-                return getPrincipal(user, null, result);
+                return getPrincipal(user, null, supportGuiConfig, result);
             }
 
             @Override
             public GuiProfiledPrincipal getPrincipal(PrismObject<? extends FocusType> user,
-                    AuthorizationTransformer authorizationLimiter, OperationResult result)
+                    AuthorizationTransformer authorizationLimiter, boolean supportGuiConfig, OperationResult result)
                     throws SchemaException, CommunicationException, ConfigurationException, SecurityViolationException, ExpressionEvaluationException {
-                GuiProfiledPrincipal principal = focusProfileService.getPrincipal(user, result);
+                GuiProfiledPrincipal principal = focusProfileService.getPrincipal(user, supportGuiConfig, result);
                 addFakeAuthorization(principal);
                 return principal;
             }
 
             @Override
-            public GuiProfiledPrincipal getPrincipal(String username, Class<? extends FocusType> clazz) throws ObjectNotFoundException, SchemaException, CommunicationException, ConfigurationException, SecurityViolationException, ExpressionEvaluationException {
-                GuiProfiledPrincipal principal = focusProfileService.getPrincipal(username, clazz);
+            public GuiProfiledPrincipal getPrincipal(String username, Class<? extends FocusType> clazz, boolean supportGuiConfig) throws ObjectNotFoundException, SchemaException, CommunicationException, ConfigurationException, SecurityViolationException, ExpressionEvaluationException {
+                GuiProfiledPrincipal principal = focusProfileService.getPrincipal(username, clazz, supportGuiConfig);
                 addFakeAuthorization(principal);
                 return principal;
             }
 
             @Override
-            public GuiProfiledPrincipal getPrincipal(ObjectQuery query, Class<? extends FocusType> clazz) throws ObjectNotFoundException, SchemaException, CommunicationException, ConfigurationException, SecurityViolationException, ExpressionEvaluationException {
-                GuiProfiledPrincipal principal = focusProfileService.getPrincipal(query, clazz);
+            public GuiProfiledPrincipal getPrincipal(ObjectQuery query, Class<? extends FocusType> clazz, boolean supportGuiConfig) throws ObjectNotFoundException, SchemaException, CommunicationException, ConfigurationException, SecurityViolationException, ExpressionEvaluationException {
+                GuiProfiledPrincipal principal = focusProfileService.getPrincipal(query, clazz, supportGuiConfig);
                 addFakeAuthorization(principal);
                 return principal;
             }
 
             @Override
-            public GuiProfiledPrincipal getPrincipalByOid(String oid, Class<? extends FocusType> clazz) throws ObjectNotFoundException, SchemaException, CommunicationException, ConfigurationException, SecurityViolationException, ExpressionEvaluationException {
-                GuiProfiledPrincipal principal = focusProfileService.getPrincipalByOid(oid, clazz);
+            public GuiProfiledPrincipal getPrincipalByOid(String oid, Class<? extends FocusType> clazz, boolean supportGuiConfig) throws ObjectNotFoundException, SchemaException, CommunicationException, ConfigurationException, SecurityViolationException, ExpressionEvaluationException {
+                GuiProfiledPrincipal principal = focusProfileService.getPrincipalByOid(oid, clazz, supportGuiConfig);
                 addFakeAuthorization(principal);
                 return principal;
             }

--- a/model/model-api/src/main/java/com/evolveum/midpoint/model/api/authentication/GuiProfiledPrincipalManager.java
+++ b/model/model-api/src/main/java/com/evolveum/midpoint/model/api/authentication/GuiProfiledPrincipalManager.java
@@ -34,21 +34,21 @@ import org.jetbrains.annotations.NotNull;
 public interface GuiProfiledPrincipalManager extends MidPointPrincipalManager {
 
     @Override
-    GuiProfiledPrincipal getPrincipal(String username, Class<? extends FocusType> clazz) throws ObjectNotFoundException, SchemaException, CommunicationException, ConfigurationException, SecurityViolationException, ExpressionEvaluationException;
+    GuiProfiledPrincipal getPrincipal(String username, Class<? extends FocusType> clazz, boolean supportGuiConfig) throws ObjectNotFoundException, SchemaException, CommunicationException, ConfigurationException, SecurityViolationException, ExpressionEvaluationException;
 
-    GuiProfiledPrincipal getPrincipal(ObjectQuery query, Class<? extends FocusType> clazz) throws ObjectNotFoundException, SchemaException, CommunicationException, ConfigurationException, SecurityViolationException, ExpressionEvaluationException;
-
-    @Override
-    GuiProfiledPrincipal getPrincipalByOid(String oid, Class<? extends FocusType> clazz) throws ObjectNotFoundException, SchemaException, CommunicationException, ConfigurationException, SecurityViolationException, ExpressionEvaluationException;
+    GuiProfiledPrincipal getPrincipal(ObjectQuery query, Class<? extends FocusType> clazz, boolean supportGuiConfig) throws ObjectNotFoundException, SchemaException, CommunicationException, ConfigurationException, SecurityViolationException, ExpressionEvaluationException;
 
     @Override
-    GuiProfiledPrincipal getPrincipal(PrismObject<? extends FocusType> focus, OperationResult result)
+    GuiProfiledPrincipal getPrincipalByOid(String oid, Class<? extends FocusType> clazz, boolean supportGuiConfig) throws ObjectNotFoundException, SchemaException, CommunicationException, ConfigurationException, SecurityViolationException, ExpressionEvaluationException;
+
+    @Override
+    GuiProfiledPrincipal getPrincipal(PrismObject<? extends FocusType> focus, boolean supportGuiConfig, OperationResult result)
             throws SchemaException, CommunicationException, ConfigurationException, SecurityViolationException,
             ExpressionEvaluationException;
 
     @Override
     GuiProfiledPrincipal getPrincipal(
-            PrismObject<? extends FocusType> focus, AuthorizationTransformer authorizationTransformer, OperationResult result)
+            PrismObject<? extends FocusType> focus, AuthorizationTransformer authorizationTransformer, boolean supportGuiConfig, OperationResult result)
             throws SchemaException, CommunicationException, ConfigurationException, SecurityViolationException,
             ExpressionEvaluationException;
 

--- a/model/model-impl/src/main/java/com/evolveum/midpoint/model/impl/controller/AuthorizationDiagEvaluation.java
+++ b/model/model-impl/src/main/java/com/evolveum/midpoint/model/impl/controller/AuthorizationDiagEvaluation.java
@@ -111,8 +111,9 @@ abstract class AuthorizationDiagEvaluation<REQ extends AuthorizationEvaluationRe
         } else {
             FocusType subject = b.modelObjectResolver.resolve(
                     subjectRef, FocusType.class, null, "subject", task, result);
+            // For Authorization Playground page, we don't need to support GUI config
             return b.securityContextManager.getUserProfileService().getPrincipal(
-                    subject.asPrismObject(), null, result);
+                    subject.asPrismObject(), null, false, result);
         }
     }
 

--- a/model/model-impl/src/main/java/com/evolveum/midpoint/model/impl/controller/ModelInteractionServiceImpl.java
+++ b/model/model-impl/src/main/java/com/evolveum/midpoint/model/impl/controller/ModelInteractionServiceImpl.java
@@ -1851,7 +1851,8 @@ public class ModelInteractionServiceImpl implements ModelInteractionService {
     @Override
     public void refreshPrincipal(String oid, Class<? extends FocusType> clazz) throws ObjectNotFoundException, SchemaException, CommunicationException, ConfigurationException, SecurityViolationException, ExpressionEvaluationException {
         try {
-            MidPointPrincipal principal = guiProfiledPrincipalManager.getPrincipalByOid(oid, clazz);
+            // For refreshing current logged-in principal, we need to support GUI config
+            MidPointPrincipal principal = guiProfiledPrincipalManager.getPrincipalByOid(oid, clazz, true);
             Authentication authentication = securityContextManager.getAuthentication();
             if (authentication instanceof MidpointAuthentication) {
                 ((MidpointAuthentication) authentication).setPrincipal(principal);

--- a/model/model-intest/src/test/java/com/evolveum/midpoint/model/intest/security/TestSecurityPrincipal.java
+++ b/model/model-intest/src/test/java/com/evolveum/midpoint/model/intest/security/TestSecurityPrincipal.java
@@ -222,6 +222,37 @@ public class TestSecurityPrincipal extends AbstractInitializedSecurityTest {
     }
 
     @Test
+    public void test100JackRolePirateWithNoSupportGuiConfig() throws Exception {
+        // GIVEN
+        login(USER_ADMINISTRATOR_USERNAME);
+        Task task = getTestTask();
+        OperationResult result = task.getResult();
+        assignRole(USER_JACK_OID, ROLE_PIRATE_OID, task, result);
+
+        resetAuthentication();
+
+        // WHEN
+        MidPointPrincipal principal = focusProfileService.getPrincipal(USER_JACK_USERNAME, UserType.class, false);
+
+        // THEN
+        assertJack(principal);
+
+        assertEquals("Wrong number of authorizations", 1, principal.getAuthorities().size());
+        assertHasAuthorizationAllow(principal.getAuthorities().iterator().next(), AUTZ_LOOT_URL);
+
+        assertAuthorized(principal, AUTZ_LOOT_URL, AuthorizationPhaseType.EXECUTION);
+        assertNotAuthorized(principal, AUTZ_LOOT_URL, AuthorizationPhaseType.REQUEST);
+        assertNotAuthorized(principal, AUTZ_LOOT_URL, null);
+        assertNotAuthorized(principal, AUTZ_COMMAND_URL);
+
+        assertCompiledGuiProfile(principal)
+                .assertAdditionalMenuLinks(0)
+                .assertUserDashboardLinks(0)
+                .assertObjectCollectionViews(0)
+                .assertUserDashboardWidgets(0);
+    }
+
+    @Test
     public void test109JackUnassignRolePirate() throws Exception {
         // GIVEN
         login(USER_ADMINISTRATOR_USERNAME);

--- a/model/model-test/src/main/java/com/evolveum/midpoint/model/test/AbstractModelIntegrationTest.java
+++ b/model/model-test/src/main/java/com/evolveum/midpoint/model/test/AbstractModelIntegrationTest.java
@@ -4627,7 +4627,7 @@ public abstract class AbstractModelIntegrationTest extends AbstractIntegrationTe
             throws SchemaException, CommunicationException, ConfigurationException, SecurityViolationException,
             ExpressionEvaluationException {
         // If we are brave enough, we can use getTestOperationResult here -- later.
-        return focusProfileService.getPrincipal(user, new OperationResult(OPERATION_GET_PRINCIPAL));
+        return focusProfileService.getPrincipal(user, true, new OperationResult(OPERATION_GET_PRINCIPAL));
     }
 
     protected void login(MidPointPrincipal principal) {

--- a/repo/security-api/src/main/java/com/evolveum/midpoint/security/api/MidPointPrincipalManager.java
+++ b/repo/security-api/src/main/java/com/evolveum/midpoint/security/api/MidPointPrincipalManager.java
@@ -33,22 +33,30 @@ public interface MidPointPrincipalManager extends OwnerResolver {
     String OPERATION_GET_PRINCIPAL = DOT_CLASS + "getPrincipal";
     String OPERATION_UPDATE_USER = DOT_CLASS + "updateUser";
 
+    // This method is used from many test cases, and some of them require GUI Config.
+    // Therefore, supportGuiConfig must be set to true.
+    default MidPointPrincipal getPrincipal(String username, Class<? extends FocusType> clazz)
+            throws ObjectNotFoundException, SchemaException, CommunicationException, ConfigurationException,
+            SecurityViolationException, ExpressionEvaluationException {
+        return getPrincipal(username, clazz, true);
+    }
+
     // TODO add OperationResult here
-    MidPointPrincipal getPrincipal(String username, Class<? extends FocusType> clazz)
+    MidPointPrincipal getPrincipal(String username, Class<? extends FocusType> clazz, boolean supportGuiConfig)
             throws ObjectNotFoundException, SchemaException, CommunicationException, ConfigurationException,
             SecurityViolationException, ExpressionEvaluationException;
 
     // TODO add OperationResult here
-    MidPointPrincipal getPrincipalByOid(String oid, Class<? extends FocusType> clazz)
+    MidPointPrincipal getPrincipalByOid(String oid, Class<? extends FocusType> clazz, boolean supportGuiConfig)
             throws ObjectNotFoundException, SchemaException, CommunicationException, ConfigurationException,
             SecurityViolationException, ExpressionEvaluationException;
 
-    MidPointPrincipal getPrincipal(PrismObject<? extends FocusType> focus, OperationResult result)
+    MidPointPrincipal getPrincipal(PrismObject<? extends FocusType> focus, boolean supportGuiConfig, OperationResult result)
             throws SchemaException, CommunicationException, ConfigurationException, SecurityViolationException,
             ExpressionEvaluationException;
 
     MidPointPrincipal getPrincipal(
-            PrismObject<? extends FocusType> focus, AuthorizationTransformer authorizationTransformer, OperationResult result)
+            PrismObject<? extends FocusType> focus, AuthorizationTransformer authorizationTransformer, boolean supportGuiConfig, OperationResult result)
             throws SchemaException, CommunicationException, ConfigurationException, SecurityViolationException,
             ExpressionEvaluationException;
 

--- a/repo/security-enforcer-impl/src/main/java/com/evolveum/midpoint/security/enforcer/impl/SecurityEnforcerImpl.java
+++ b/repo/security-enforcer-impl/src/main/java/com/evolveum/midpoint/security/enforcer/impl/SecurityEnforcerImpl.java
@@ -320,8 +320,9 @@ public class SecurityEnforcerImpl implements SecurityEnforcer {
             failAuthorization(attorneyAuthorizationAction, null, autzParams, result);
         }
 
+        // For running operations by Power Of Attorney, we don't need to support GUI config
         MidPointPrincipal donorPrincipal =
-                securityContextManager.getUserProfileService().getPrincipal(donor, limitationsCollector, result);
+                securityContextManager.getUserProfileService().getPrincipal(donor, limitationsCollector, false, result);
         donorPrincipal.setAttorney(attorneyPrincipal.getFocus());
 
         // chain principals so we can easily drop the power of attorney and return back to original identity

--- a/repo/security-impl/src/main/java/com/evolveum/midpoint/security/impl/SecurityContextManagerImpl.java
+++ b/repo/security-impl/src/main/java/com/evolveum/midpoint/security/impl/SecurityContextManagerImpl.java
@@ -106,7 +106,8 @@ public class SecurityContextManagerImpl implements SecurityContextManager {
                     + "This is OK in low-level tests but it is a serious problem in running system");
             principal = MidPointPrincipal.create(focus.asObjectable());
         } else {
-            principal = userProfileService.getPrincipal(focus, result);
+            // For expression using runAsRef, task execution, etc., we don't need to support GUI config
+            principal = userProfileService.getPrincipal(focus, false, result);
         }
         setupPreAuthenticatedSecurityContext(principal);
     }

--- a/repo/security-impl/src/test/java/com/evolveum/midpoint/security/impl/MidPointPrincipalManagerMock.java
+++ b/repo/security-impl/src/test/java/com/evolveum/midpoint/security/impl/MidPointPrincipalManagerMock.java
@@ -56,7 +56,7 @@ public class MidPointPrincipalManagerMock implements MidPointPrincipalManager, U
     private PrismContext prismContext;
 
     @Override
-    public MidPointPrincipal getPrincipal(String username, Class<? extends FocusType> clazz) throws ObjectNotFoundException, SchemaException {
+    public MidPointPrincipal getPrincipal(String username, Class<? extends FocusType> clazz, boolean supportGuiConfig) throws ObjectNotFoundException, SchemaException {
         OperationResult result = new OperationResult(OPERATION_GET_PRINCIPAL);
         PrismObject<? extends FocusType> focus;
         try {
@@ -71,24 +71,25 @@ public class MidPointPrincipalManagerMock implements MidPointPrincipalManager, U
             throw new SystemException(ex.getMessage(), ex);
         }
 
-        return getPrincipal(focus, null, result);
+        return getPrincipal(focus, null, supportGuiConfig, result);
     }
 
     @Override
-    public MidPointPrincipal getPrincipalByOid(String oid, Class<? extends FocusType> clazz) throws ObjectNotFoundException, SchemaException {
+    public MidPointPrincipal getPrincipalByOid(String oid, Class<? extends FocusType> clazz, boolean supportGuiConfig) throws ObjectNotFoundException, SchemaException {
         OperationResult result = new OperationResult(OPERATION_GET_PRINCIPAL);
         FocusType focus = getUserByOid(oid, clazz, result);
-        return getPrincipal(focus.asPrismObject(), result);
+        return getPrincipal(focus.asPrismObject(), supportGuiConfig, result);
     }
 
     @Override
-    public MidPointPrincipal getPrincipal(PrismObject<? extends FocusType> focus, OperationResult result) throws SchemaException {
-        return getPrincipal(focus, null, result);
+    public MidPointPrincipal getPrincipal(PrismObject<? extends FocusType> focus, boolean supportGuiConfig, OperationResult result)
+            throws SchemaException {
+        return getPrincipal(focus, null, supportGuiConfig, result);
     }
 
     @Override
     public MidPointPrincipal getPrincipal(PrismObject<? extends FocusType> focus,
-            AuthorizationTransformer authorizationLimiter, OperationResult result) {
+            AuthorizationTransformer authorizationLimiter, boolean supportGuiConfig, OperationResult result) {
         if (focus == null) {
             return null;
         }
@@ -210,7 +211,7 @@ public class MidPointPrincipalManagerMock implements MidPointPrincipalManager, U
     public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
 //         TODO Auto-generated method stub
         try {
-            return getPrincipal(username, FocusType.class);
+            return getPrincipal(username, FocusType.class, true);
         } catch (ObjectNotFoundException e) {
             throw new UsernameNotFoundException(e.getMessage(), e);
         } catch (SchemaException e) {


### PR DESCRIPTION
https://jira.evolveum.com/browse/MID-9062

Until now, GuiProfile compilation process has included not only Authorization resolution, but also GUI Config resolution. However, for operations that do not require GUI display, GUI Config resolution consume a lot of CPU in unnecessary processing (e.g., REST API authentication, script execution by runAsRef, etc.). Now, we have optimized the GUI Config resolution to be performed only when compiling GuiProfile that requires GUI display.