### PR TITLE
FIX : personalNumber doesn't match employeeNumber as deprecated repla…

### DIFF
--- a/config/initial-objects/role/041-role-approver.xml
+++ b/config/initial-objects/role/041-role-approver.xml
@@ -84,6 +84,7 @@
         <item>fullName</item>
         <item>employeeType</item>
         <item>employeeNumber</item>
+        <item>personalNumber</item>
     </authorization>
     <authorization id="6">
         <name>roles-read</name>

--- a/config/initial-objects/role/042-role-reviewer.xml
+++ b/config/initial-objects/role/042-role-reviewer.xml
@@ -46,6 +46,7 @@
         <item>fullName</item>
         <item>employeeType</item>
         <item>employeeNumber</item>
+        <item>personalNumber</item>
     </authorization>
     <authorization id="5">
         <name>roles-read</name>

--- a/config/sql/native/postgres-upgrade.sql
+++ b/config/sql/native/postgres-upgrade.sql
@@ -461,6 +461,10 @@ BEGIN
 END;
 $$;
 $aa$);
+
+call apply_change(26, $aa$
+CREATE INDEX m_user_personalNumber_idx ON m_user (personalNumber);
+$aa$);
 ---
 -- WRITE CHANGES ABOVE ^^
 -- IMPORTANT: update apply_change number at the end of postgres-new.sql

--- a/config/sql/native/postgres.sql
+++ b/config/sql/native/postgres.sql
@@ -653,6 +653,7 @@ CREATE INDEX m_user_fullNameOrig_idx ON m_user (fullNameOrig);
 CREATE INDEX m_user_familyNameOrig_idx ON m_user (familyNameOrig);
 CREATE INDEX m_user_givenNameOrig_idx ON m_user (givenNameOrig);
 CREATE INDEX m_user_employeeNumber_idx ON m_user (employeeNumber);
+CREATE INDEX m_user_personalNumber_idx ON m_user (personalNumber);
 CREATE INDEX m_user_subtypes_idx ON m_user USING gin(subtypes);
 CREATE INDEX m_user_organizations_idx ON m_user USING gin(organizations);
 CREATE INDEX m_user_organizationUnits_idx ON m_user USING gin(organizationUnits);
@@ -2218,4 +2219,4 @@ END $$;
 -- This is important to avoid applying any change more than once.
 -- Also update SqaleUtils.CURRENT_SCHEMA_CHANGE_NUMBER
 -- repo/repo-sqale/src/main/java/com/evolveum/midpoint/repo/sqale/SqaleUtils.java
-call apply_change(25, $$ SELECT 1 $$, true);
+call apply_change(26, $$ SELECT 1 $$, true);

--- a/repo/repo-sqale/src/main/java/com/evolveum/midpoint/repo/sqale/SqaleUtils.java
+++ b/repo/repo-sqale/src/main/java/com/evolveum/midpoint/repo/sqale/SqaleUtils.java
@@ -38,7 +38,7 @@ public class SqaleUtils {
      */
     public static final String SCHEMA_AUDIT_CHANGE_NUMBER = "schemaAuditChangeNumber";
 
-    public static final int CURRENT_SCHEMA_CHANGE_NUMBER = 25;
+    public static final int CURRENT_SCHEMA_CHANGE_NUMBER = 26;
 
     public static final int CURRENT_SCHEMA_AUDIT_CHANGE_NUMBER = 8;
 

--- a/repo/repo-sql-impl/src/main/java/com/evolveum/midpoint/repo/sql/data/common/RUser.java
+++ b/repo/repo-sql-impl/src/main/java/com/evolveum/midpoint/repo/sql/data/common/RUser.java
@@ -31,6 +31,7 @@ import com.evolveum.midpoint.xml.ns._public.common.common_3.UserType;
                 @Index(name = "iFamilyName", columnList = "familyName_orig"),
                 @Index(name = "iGivenName", columnList = "givenName_orig"),
                 @Index(name = "iEmployeeNumber", columnList = "employeeNumber"),
+                @Index(name = "iPersonalNumber", columnList = "personalNumber"),
                 @Index(name = "iUserNameOrig", columnList = "name_orig") })
 @ForeignKey(name = "fk_user")
 @Persister(impl = MidPointJoinedPersister.class)
@@ -45,6 +46,7 @@ public class RUser extends RFocus {
     private RPolyString honorificPrefix;
     private RPolyString honorificSuffix;
     private String employeeNumber;
+    private String personalNumber;
     private Set<RPolyString> organizationalUnit;
     private RPolyString title;
     private RPolyString nickName;
@@ -92,6 +94,10 @@ public class RUser extends RFocus {
 
     public String getEmployeeNumber() {
         return employeeNumber;
+    }
+
+    public String getPersonalNumber() {
+        return personalNumber;
     }
 
     @Embedded
@@ -149,6 +155,10 @@ public class RUser extends RFocus {
         this.employeeNumber = employeeNumber;
     }
 
+    public void setPersonalNumber(String personalNumber) {
+        this.personalNumber = personalNumber;
+    }
+
     public void setFamilyName(RPolyString familyName) {
         this.familyName = familyName;
     }
@@ -185,6 +195,7 @@ public class RUser extends RFocus {
         repo.setHonorificPrefix(RPolyString.copyFromJAXB(jaxb.getHonorificPrefix()));
         repo.setHonorificSuffix(RPolyString.copyFromJAXB(jaxb.getHonorificSuffix()));
         repo.setEmployeeNumber(jaxb.getEmployeeNumber());
+        repo.setPersonalNumber(jaxb.getPersonalNumber());
         repo.setAdditionalName(RPolyString.copyFromJAXB(jaxb.getAdditionalName()));
         repo.setTitle(RPolyString.copyFromJAXB(jaxb.getTitle()));
         repo.setNickName(RPolyString.copyFromJAXB(jaxb.getNickName()));

--- a/repo/system-init/src/main/resources/initial-objects/role/041-role-approver.xml
+++ b/repo/system-init/src/main/resources/initial-objects/role/041-role-approver.xml
@@ -84,6 +84,7 @@
         <item>fullName</item>
         <item>employeeType</item>
         <item>employeeNumber</item>
+        <item>personalNumber</item>
     </authorization>
     <authorization id="6">
         <name>roles-read</name>

--- a/repo/system-init/src/main/resources/initial-objects/role/042-role-reviewer.xml
+++ b/repo/system-init/src/main/resources/initial-objects/role/042-role-reviewer.xml
@@ -46,6 +46,7 @@
         <item>fullName</item>
         <item>employeeType</item>
         <item>employeeNumber</item>
+        <item>personalNumber</item>
     </authorization>
     <authorization id="5">
         <name>roles-read</name>

--- a/tools/generate-midpoint-users-xml-example-template.xml
+++ b/tools/generate-midpoint-users-xml-example-template.xml
@@ -13,6 +13,7 @@
         <givenName>%%GIVEN_NAME%%</givenName>
         <familyName>%%FAMILY_NAME%%</familyName>
         <employeeNumber>E%%ID%%</employeeNumber>
+        <personalNumber>E%%ID%%</personalNumber>
     </user>
 
 


### PR DESCRIPTION
Documentation suggests that personalNumber should be used going forward in place of employeeNumber. Currently personalNumber isn't included in the RUser object and therefore can't be used for correlation easily, error message here:

2023-10-19 09:16:01,117 [REPOSITORY] [http-nio-8080-exec-3] ERROR (com.evolveum.midpoint.repo.sql.helpers.BaseHelper): General checked exception occurred.
com.evolveum.midpoint.repo.sqlbase.QueryException: Couldn't find a proper data item to query, given base entity Ent:RUser (jaxb=UserType) and this filter: EQUAL:
  PATH: personalNumber
  DEF: PPD:{.../common/common-3}personalNumber {xsd:}string[0,1],RAM
  VALUE:
    00000000

Updated code to allow personalNumber to behave exactly like employeeNumber at this point. Also updated PostgreSQL schema to include an index for this.