### PR TITLE
Remove potentially expensive resolves

### DIFF
--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/data/LinkedReferencePanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/data/LinkedReferencePanel.java
@@ -74,8 +74,8 @@ public class LinkedReferencePanel<R extends Referencable> extends BasePanel<R> {
                 if (value.getObject() == null) {
                     Task task = getPageBase().createSimpleTask(OPERATION_LOAD_REFERENCED_OBJECT);
                     OperationResult result = task.getResult();
-                    PrismObject<ObjectType> referencedObject = WebModelServiceUtils.loadObject(ref,
-                            true, getPageBase(), task, result);
+                    PrismObject<ObjectType> referencedObject = WebModelServiceUtils.resolveReferenceNoFetch(getModelObject(), getPageBase(),
+                            task, result);
                     if (referencedObject != null) {
                         value.setObject(referencedObject.clone());
                     }

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/data/column/ColumnUtils.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/data/column/ColumnUtils.java
@@ -662,7 +662,7 @@ public class ColumnUtils {
             protected IModel<String> createLinkModel(IModel<PrismContainerValueWrapper<CaseWorkItemType>> rowModel) {
                 CaseWorkItemType caseWorkItemType = unwrapRowModel(rowModel);
                 CaseType caseType = CaseTypeUtil.getCase(caseWorkItemType);
-                return Model.of(WebComponentUtil.getReferencedObjectDisplayNameAndName(caseType.getTargetRef(), true, pageBase));
+                return Model.of(WebComponentUtil.getReferencedObjectDisplayNameAndName(caseType.getTargetRef(), false, pageBase));
             }
 
             @Override

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/cases/CaseWorkItemsPanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/cases/CaseWorkItemsPanel.java
@@ -148,9 +148,7 @@ public class CaseWorkItemsPanel extends ContainerableListPanel<CaseWorkItemType,
 
     private ContainerListDataProvider<CaseWorkItemType> createProvider(IModel<Search<CaseWorkItemType>> searchModel) {
         Collection<SelectorOptions<GetOperationOptions>> options = CaseWorkItemsPanel.this.getPageBase().getOperationOptionsBuilder()
-                .item(AbstractWorkItemType.F_ASSIGNEE_REF).resolve()
-                .item(PrismConstants.T_PARENT, CaseType.F_OBJECT_REF).resolve()
-                .item(PrismConstants.T_PARENT, CaseType.F_TARGET_REF).resolve()
+                .resolveNames()
                 .build();
         ContainerListDataProvider<CaseWorkItemType> provider = new ContainerListDataProvider<>(this,
                 searchModel, options) {

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/cases/PageCases.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/cases/PageCases.java
@@ -118,7 +118,6 @@ public class PageCases extends PageAdmin {
             protected Collection<SelectorOptions<GetOperationOptions>> createOperationOptions() {
                 return getPageBase().getOperationOptionsBuilder()
                         .item(CaseType.F_OBJECT_REF).resolve()
-                        .item(CaseType.F_TARGET_REF).resolve()
                         .build();
             }
         };


### PR DESCRIPTION
Impacted versions: 4.4, 4.8, master
Type: Bugfix/optimization

Resolving references on case pages especially for ShadowTypes cause slow page load, only names needed.
All cases page and others would timeout when resolving shadows for systems that required network fetch to gather information not necessary for page display.

Bugfix should be cherrypicked to support-4.4