### PR TITLE
Bump org.apache.cxf:cxf-rt-transports-http from 4.0.1 to 4.0.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -207,7 +207,7 @@
 
         <commons.io.version>2.13.0</commons.io.version>
         <commons.cli>1.5.0</commons.cli>
-        <cxf.version>4.0.1</cxf.version>
+        <cxf.version>4.0.5</cxf.version>
         <cxf-xjc.version>3.3.1</cxf-xjc.version>
         <wss4j.version>2.3.3</wss4j.version>
         <opendj.version>2.6.2</opendj.version>


### PR DESCRIPTION
Similar to these two changes in later versions:
- https://github.com/Evolveum/midpoint/pull/219/commits/1ec9415f2dc518233954e390a8292c44318f83b4 (4.0.1 -> 4.0.4)
- https://github.com/Evolveum/midpoint/commit/0eff1cd01fc27e20fa6dadac3961e33e427e2fca (4.0.4 -> 4.0.5)

Solves vulnerabilities including: 
CVE-2024-28752
Critical

This is what the package maintainer tells us about this finding

A SSRF vulnerability using the Aegis DataBinding in versions of Apache CXF before 4.0.4, 3.6.3 and 3.5.8 allows an attacker to perform SSRF style attacks on webservices that take at least one parameter of any type. Users of other data bindings (including the default databinding) are not impacted.