### PR TITLE
Returning total object count through X-Total-Count header when calling search REST endpoint

### DIFF
--- a/model/rest-impl/src/main/java/com/evolveum/midpoint/rest/impl/AbstractRestController.java
+++ b/model/rest-impl/src/main/java/com/evolveum/midpoint/rest/impl/AbstractRestController.java
@@ -15,6 +15,7 @@ import com.evolveum.midpoint.authentication.api.config.MidpointAuthentication;
 
 import org.jetbrains.annotations.Nullable;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
@@ -95,6 +96,11 @@ public class AbstractRestController {
 
     protected <T> ResponseEntity<?> createResponse(HttpStatus httpStatus,
             T body, OperationResult result, boolean sendOriginObjectIfNotSuccess) {
+        return createResponse(httpStatus, body, result, sendOriginObjectIfNotSuccess, null);
+    }
+
+    protected <T> ResponseEntity<?> createResponse(HttpStatus httpStatus,
+            T body, OperationResult result, boolean sendOriginObjectIfNotSuccess, HttpHeaders headers) {
         result.computeStatusIfUnknown();
 
         if (result.isPartialError()) {
@@ -103,7 +109,12 @@ public class AbstractRestController {
             return createBody(status(240), sendOriginObjectIfNotSuccess, body, result);
         }
 
-        return status(httpStatus).body(body);
+        ResponseEntity.BodyBuilder responseBuilder = status(httpStatus);
+        if (headers != null && !headers.isEmpty()) {
+            responseBuilder.headers(headers);
+        }
+
+        return responseBuilder.body(body);
     }
 
     protected ResponseEntity<?> createResponseWithLocation(

--- a/model/rest-impl/src/main/java/com/evolveum/midpoint/rest/impl/ModelRestController.java
+++ b/model/rest-impl/src/main/java/com/evolveum/midpoint/rest/impl/ModelRestController.java
@@ -20,6 +20,7 @@ import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.Validate;
 import org.jetbrains.annotations.NotNull;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -632,6 +633,7 @@ public class ModelRestController extends AbstractRestController {
             @RequestParam(value = "include", required = false) List<String> include,
             @RequestParam(value = "exclude", required = false) List<String> exclude,
             @RequestParam(value = "resolveNames", required = false) List<String> resolveNames,
+            @RequestParam(value = "returnTotalCount", required = false) Boolean returnTotalCount,
             @RequestBody QueryType queryType) {
 
         Task task = initRequest();
@@ -652,7 +654,15 @@ public class ModelRestController extends AbstractRestController {
                 listType.getObject().add(o.asObjectable());
             }
 
-            response = createResponse(HttpStatus.OK, listType, result, true);
+            HttpHeaders headers = null;
+            if (Boolean.TRUE.equals(returnTotalCount)) {
+                ObjectQuery countQuery = query.clone();
+                countQuery.setPaging(null);
+                int totalCount = modelService.countObjects(clazz, countQuery, searchOptions, task, result);
+                headers = addHeader("X-Total-Count", String.valueOf(totalCount), headers);
+            }
+
+            response = createResponse(HttpStatus.OK, listType, result, true, headers);
         } catch (Exception ex) {
             response = handleException(result, ex);
         }
@@ -660,6 +670,14 @@ public class ModelRestController extends AbstractRestController {
         result.computeStatus();
         finishRequest(task, result);
         return response;
+    }
+
+    private HttpHeaders addHeader(String headerName, String headerValue, HttpHeaders headers) {
+        if (headers == null) {
+            headers = new HttpHeaders();
+        }
+        headers.add(headerName, headerValue);
+        return headers;
     }
 
     private void removeExcludes(PrismObject<? extends ObjectType> object, List<String> exclude)


### PR DESCRIPTION
For my use case i need to have total object count information as a part of search response. For this reason i modified existing code to return total count value in X-Total-Count header.

**Example:**
If there are 2 records with name that starts with "0", request like this
```
POST http://localhost:8080/midpoint/ws/rest/users/search?options=resolveNames&returnTotalCount=true
BODY
{
    "query": {
        "filter": {
            "text": "name startsWith '0'"
        },
        "paging": {
            "orderBy": "name",
            "orderDirection": "ascending",
            "offset": "0",
            "maxSize": "1"
        }
    }
}
```
..should result with response containing 1 record in body with total count of filtered users in header with value 2.

Let me know if you want me to additionally change or add something.

Best regards