### PR TITLE
Fix cleanup after finish to remove also subtasks

### DIFF
--- a/model/model-impl/src/main/java/com/evolveum/midpoint/model/impl/trigger/CompletedTaskCleanupTriggerHandler.java
+++ b/model/model-impl/src/main/java/com/evolveum/midpoint/model/impl/trigger/CompletedTaskCleanupTriggerHandler.java
@@ -86,7 +86,7 @@ public class CompletedTaskCleanupTriggerHandler implements SingleTriggerHandler 
                 return;
             }
             LOGGER.debug("Deleting completed task {}", completedTask);
-            taskManager.deleteTask(object.getOid(), result);
+            taskManager.deleteTaskTree(object.getOid(), result);
         } catch (CommonException | RuntimeException | Error e) {
             LoggingUtils.logUnexpectedException(LOGGER, "Couldn't delete completed task {}", e, object);
             // do not retry this trigger execution

--- a/model/model-intest/src/test/java/com/evolveum/midpoint/model/intest/tasks/TestMiscTasks.java
+++ b/model/model-intest/src/test/java/com/evolveum/midpoint/model/intest/tasks/TestMiscTasks.java
@@ -252,18 +252,18 @@ public class TestMiscTasks extends AbstractInitializedModelIntegrationTest {
 
     /**
      * Tests if cleanup after task finish removes also subtasks, not just parent task
-     * <p>
+     *
      * Test for MID-10272
      */
     @Test
     public void test140CleanSubtasksAfterFinish() throws Exception {
         given("Noop task with more workers per node is added.");
-        final OperationResult result = new OperationResult(TestMiscTasks.class + ".test140CleanSubtasksAfterFinish");
+        OperationResult result = getTestOperationResult();
         addTask(TASK_CLEANUP_SUBTASKS_AFTER_COMPLETION, result);
         waitForTaskCloseOrSuspend(TASK_CLEANUP_SUBTASKS_AFTER_COMPLETION.oid, 10000);
 
-        final Task taskTree = this.taskManager.getTaskTree(TASK_CLEANUP_SUBTASKS_AFTER_COMPLETION.oid, result);
-        final List<String> subtasksOids = taskTree.listSubtasksDeeply(true, result).stream()
+        Task taskTree = this.taskManager.getTaskTree(TASK_CLEANUP_SUBTASKS_AFTER_COMPLETION.oid, result);
+        List<String> subtasksOids = taskTree.listSubtasksDeeply(true, result).stream()
                 .map(Task::getOid)
                 .toList();
 

--- a/model/model-intest/src/test/java/com/evolveum/midpoint/model/intest/tasks/TestMiscTasks.java
+++ b/model/model-intest/src/test/java/com/evolveum/midpoint/model/intest/tasks/TestMiscTasks.java
@@ -6,11 +6,11 @@
  */
 package com.evolveum.midpoint.model.intest.tasks;
 
+import static com.evolveum.midpoint.schema.constants.MidPointConstants.NS_RI;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import static com.evolveum.midpoint.schema.constants.MidPointConstants.NS_RI;
-
 import java.io.File;
+import java.util.List;
 import javax.xml.namespace.QName;
 
 import org.springframework.test.annotation.DirtiesContext;
@@ -50,6 +50,9 @@ public class TestMiscTasks extends AbstractInitializedModelIntegrationTest {
             TestObject.file(TEST_DIR, "task-delete-incomplete-raw.xml", "d0053e62-9d48-4c1e-ace8-a8feb1f35f91");
     private static final TestObject<TaskType> TASK_DELETE_SELECTED_USERS =
             TestObject.file(TEST_DIR, "task-delete-selected-users.xml", "623f261c-4c63-445b-a714-dcde118f227c");
+    private static final TestObject<TaskType> TASK_CLEANUP_SUBTASKS_AFTER_COMPLETION =
+            TestObject.file(TEST_DIR, "task-cleanup-subtasks-after-completion.xml",
+                    "7f5eb732-9ffc-42c3-a416-ee1754f1b764");
     private static final TestTask TASK_EXECUTE_CHANGES_LEGACY =
             new TestTask(TEST_DIR, "task-execute-changes.xml", "1dce894e-e76c-4db5-9318-0fa5b55261da");
     private static final TestTask TASK_EXECUTE_CHANGES_SINGLE =
@@ -245,6 +248,41 @@ public class TestMiscTasks extends AbstractInitializedModelIntegrationTest {
         assertUser(user2.getOid(), "after")
                 .display()
                 .assertName("user-to-delete-2-indestructible");
+    }
+
+    /**
+     * Tests if cleanup after task finish removes also subtasks, not just parent task
+     * <p>
+     * Test for MID-10272
+     */
+    @Test
+    public void test140CleanSubtasksAfterFinish() throws Exception {
+        given("Noop task with more workers per node is added.");
+        final OperationResult result = new OperationResult(TestMiscTasks.class + ".test140CleanSubtasksAfterFinish");
+        addTask(TASK_CLEANUP_SUBTASKS_AFTER_COMPLETION, result);
+        waitForTaskCloseOrSuspend(TASK_CLEANUP_SUBTASKS_AFTER_COMPLETION.oid, 10000);
+
+        final Task taskTree = this.taskManager.getTaskTree(TASK_CLEANUP_SUBTASKS_AFTER_COMPLETION.oid, result);
+        final List<String> subtasksOids = taskTree.listSubtasksDeeply(true, result).stream()
+                .map(Task::getOid)
+                .toList();
+
+        when("Task trigger scanner executes.");
+        importObjectFromFile(TASK_TRIGGER_SCANNER_FILE);
+        waitForTaskStart(TASK_TRIGGER_SCANNER_OID);
+        waitForTaskFinish(TASK_TRIGGER_SCANNER_OID);
+
+        then("After task trigger scanner executes, Noop task should be deleted as well as all its worker "
+                + "subtasks");
+        // Just to make sure, that we have correct task definition which results in subtasks creation.
+        assertThat(subtasksOids)
+                .withFailMessage(() -> "There are no subtasks, but at least one is expected. Check task definition xml")
+                .hasSizeGreaterThan(0);
+
+        assertNoObject(TaskType.class, TASK_CLEANUP_SUBTASKS_AFTER_COMPLETION.oid);
+        for (String subtaskOid : subtasksOids) {
+            assertNoObject(TaskType.class, subtaskOid);
+        }
     }
 
     /** Tests the legacy form of "execute changes" task. */

--- a/model/model-intest/src/test/resources/tasks/misc/task-cleanup-subtasks-after-completion.xml
+++ b/model/model-intest/src/test/resources/tasks/misc/task-cleanup-subtasks-after-completion.xml
@@ -1,0 +1,31 @@
+<!--
+  ~ Copyright (C) 2010-2021 Evolveum and contributors
+  ~
+  ~ This work is dual-licensed under the Apache License 2.0
+  ~ and European Union Public License. See LICENSE file for details.
+  -->
+
+<task xmlns="http://midpoint.evolveum.com/xml/ns/public/common/common-3"
+        oid="7f5eb732-9ffc-42c3-a416-ee1754f1b764">
+    <name>Test subtasks cleanup</name>
+    <ownerRef oid="00000000-0000-0000-0000-000000000002" type="UserType"/>
+    <executionState>runnable</executionState>
+    <cleanupAfterCompletion>PT0S</cleanupAfterCompletion>
+    <activity>
+        <work>
+            <noOp />
+        </work>
+        <distribution>
+            <buckets>
+                <implicitSegmentation>
+                    <numberOfBuckets>2</numberOfBuckets>
+                </implicitSegmentation>
+            </buckets>
+            <workers>
+                <workersPerNode id="5">
+                    <count>2</count>
+                </workersPerNode>
+            </workers>
+        </distribution>
+    </activity>
+</task>


### PR DESCRIPTION
**What**

Remove not just root task, but also all its subtasks when it is cleaned-up.

**Why**

When cleanup after finish is set on task, it should be auto removed after specified duration from its completion.

However there was a bug, which caused, that only the root task was removed. If task run spawned any persistent subtasks (e.g. when number of workers per node is specified), those were not cleaned up. This change fixes it.