### PR TITLE
Fix cleanup after finish to remove also subtasks (#238)

### DIFF
--- a/model/model-impl/src/main/java/com/evolveum/midpoint/model/impl/trigger/CompletedTaskCleanupTriggerHandler.java
+++ b/model/model-impl/src/main/java/com/evolveum/midpoint/model/impl/trigger/CompletedTaskCleanupTriggerHandler.java
@@ -86,7 +86,7 @@ public class CompletedTaskCleanupTriggerHandler implements SingleTriggerHandler 
                 return;
             }
             LOGGER.debug("Deleting completed task {}", completedTask);
-            taskManager.deleteTask(object.getOid(), result);
+            taskManager.deleteTaskTree(object.getOid(), result);
         } catch (CommonException | RuntimeException | Error e) {
             LoggingUtils.logUnexpectedException(LOGGER, "Couldn't delete completed task {}", e, object);
             // do not retry this trigger execution

--- a/model/model-intest/src/test/resources/tasks/misc/task-cleanup-subtasks-after-completion.xml
+++ b/model/model-intest/src/test/resources/tasks/misc/task-cleanup-subtasks-after-completion.xml
@@ -1,0 +1,31 @@
+<!--
+  ~ Copyright (C) 2010-2021 Evolveum and contributors
+  ~
+  ~ This work is dual-licensed under the Apache License 2.0
+  ~ and European Union Public License. See LICENSE file for details.
+  -->
+
+<task xmlns="http://midpoint.evolveum.com/xml/ns/public/common/common-3"
+        oid="7f5eb732-9ffc-42c3-a416-ee1754f1b764">
+    <name>Test subtasks cleanup</name>
+    <ownerRef oid="00000000-0000-0000-0000-000000000002" type="UserType"/>
+    <executionState>runnable</executionState>
+    <cleanupAfterCompletion>PT0S</cleanupAfterCompletion>
+    <activity>
+        <work>
+            <noOp />
+        </work>
+        <distribution>
+            <buckets>
+                <implicitSegmentation>
+                    <numberOfBuckets>2</numberOfBuckets>
+                </implicitSegmentation>
+            </buckets>
+            <workers>
+                <workersPerNode id="5">
+                    <count>2</count>
+                </workersPerNode>
+            </workers>
+        </distribution>
+    </activity>
+</task>


### PR DESCRIPTION
**What**

Remove not just the root task, but also all its subtasks when it is cleaned up.

**Why**

When cleanup after finish is set on task, it should be auto-removed after specified duration from its completion.

However there was a bug, which caused, that only the root task was removed. If task run spawned any persistent subtasks (e.g. when number of workers per node is specified), those were not cleaned up. This change fixes it.

---------

(cherry picked from commit 4da3d2184cce9dfa7d066dd750d5e7725ac65865)