### PR TITLE
Fix change of immutable object caused by preview

### DIFF
--- a/model/model-impl/src/main/java/com/evolveum/midpoint/model/impl/controller/transformer/DataAccessProcessor.java
+++ b/model/model-impl/src/main/java/com/evolveum/midpoint/model/impl/controller/transformer/DataAccessProcessor.java
@@ -70,7 +70,7 @@ public class DataAccessProcessor {
             if (mutable.isEmpty()) {
                 // let's make it explicit (note that the log message may show empty object if it was originally mutable)
                 // TODO decide if this is really correct approach
-                SecurityUtil.logSecurityDeny(value, "because the subject has not access to any item");
+                SecurityUtil.logSecurityDeny(value, "because the subject has no access to any item");
                 throw new AuthorizationException("Access denied");
             }
             //noinspection unchecked
@@ -132,9 +132,8 @@ public class DataAccessProcessor {
         }
     }
 
-    public @NotNull <O extends ObjectType> PrismEntityOpConstraints.ForValueContent applyReadConstraints(
-            LensElementContext<O> elementContext, PrismEntityOpConstraints.ForValueContent readConstraints)
-            throws AuthorizationException {
+    public <O extends ObjectType> void applyReadConstraints(LensElementContext<O> elementContext,
+            PrismEntityOpConstraints.ForValueContent readConstraints) throws AuthorizationException {
         var decision = readConstraints.getDecision();
         if (decision == AccessDecision.ALLOW) {
             // no-op
@@ -148,7 +147,6 @@ public class DataAccessProcessor {
             elementContext.forEachDelta(delta ->
                     applyReadConstraintsToDelta(delta, readConstraints));
         }
-        return readConstraints;
     }
 
     private void applyReadConstraintsToMutableValue(

--- a/model/model-impl/src/main/java/com/evolveum/midpoint/model/impl/lens/LensContext.java
+++ b/model/model-impl/src/main/java/com/evolveum/midpoint/model/impl/lens/LensContext.java
@@ -470,6 +470,11 @@ public class LensContext<F extends ObjectType> implements ModelContext<F>, Clone
         projectionContexts.add(projectionContext);
     }
 
+    public void replaceProjectionContexts(Collection<LensProjectionContext> projectionContexts) {
+        this.projectionContexts.clear();
+        this.projectionContexts.addAll(projectionContexts);
+    }
+
     /**
      * BEWARE!
      *

--- a/model/model-intest/src/test/java/com/evolveum/midpoint/model/intest/security/AbstractInitializedSecurityTest.java
+++ b/model/model-intest/src/test/java/com/evolveum/midpoint/model/intest/security/AbstractInitializedSecurityTest.java
@@ -142,6 +142,7 @@ public abstract class AbstractInitializedSecurityTest extends AbstractInitialize
     protected static final TestObject<RoleType> ROLE_SEARCH_USER_ASSIGNMENT_TARGET_REF = TestObject.file(TEST_DIR, "role-search-user-assignment-targetRef.xml", "2ed2c64e-0045-41ed-b825-2bf6ce552084");
     protected static final TestObject<RoleType> ROLE_USER_MODIFY = TestObject.file(TEST_DIR, "role-user-modify.xml", "710395da-ddd9-11e9-9d81-cf471cec8185");
     protected static final TestObject<RoleType> ROLE_USER_ADD = TestObject.file(TEST_DIR, "role-user-add.xml", "aa662e3c-ddd9-11e9-afe9-ab216a2d304b");
+    protected static final TestObject<RoleType> ROLE_ROLE_ADD_READ_SOME = TestObject.file(TEST_DIR, "role-user-add-read-some.xml", "d70b7695-cb99-4cbf-83b1-f18652844845");
     protected static final TestObject<RoleType> ROLE_APPLICATION_1 = TestObject.file(TEST_DIR, "role-application-1.xml", "00000000-0000-0000-0000-00000000aaa1");
     protected static final TestObject<RoleType> ROLE_APPLICATION_2 = TestObject.file(TEST_DIR, "role-application-2.xml", "00000000-0000-0000-0000-00000000aaa2");
     protected static final TestObject<RoleType> ROLE_BUSINESS_1 = TestObject.file(TEST_DIR, "role-business-1.xml", "00000000-0000-0000-0000-00000000aab1");
@@ -203,7 +204,7 @@ public abstract class AbstractInitializedSecurityTest extends AbstractInitialize
     protected static final XMLGregorianCalendar JACK_VALID_TO_LONG_AHEAD = XmlTypeConverter.createXMLGregorianCalendar(10000000000000L);
 
     protected static final int NUMBER_OF_ALL_USERS = 13;
-    protected static final int NUMBER_OF_IMPORTED_ROLES = 78;
+    protected static final int NUMBER_OF_IMPORTED_ROLES = 79;
     protected static final int NUMBER_OF_ALL_ORGS = 11;
 
     protected String userRumRogersOid;
@@ -291,6 +292,7 @@ public abstract class AbstractInitializedSecurityTest extends AbstractInitialize
         repoAdd(ROLE_END_USER, initResult);
         repoAdd(ROLE_USER_MODIFY, initResult);
         repoAdd(ROLE_USER_ADD, initResult);
+        repoAdd(ROLE_ROLE_ADD_READ_SOME, initResult);
         repoAdd(ROLE_MANAGER_FULL_CONTROL, initResult);
         repoAdd(ROLE_MANAGER_USER_ADMIN, initResult);
         repoAdd(ROLE_SELF_TASK_OWNER, initResult);

--- a/model/model-intest/src/test/java/com/evolveum/midpoint/model/intest/security/TestSecurityBasic.java
+++ b/model/model-intest/src/test/java/com/evolveum/midpoint/model/intest/security/TestSecurityBasic.java
@@ -11,6 +11,7 @@ import static com.evolveum.midpoint.schema.constants.SchemaConstants.RI_ACCOUNT_
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.testng.AssertJUnit.*;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -1234,6 +1235,24 @@ public class TestSecurityBasic extends AbstractInitializedSecurityTest {
         assertDeleteAllow();
 
         assertGlobalStateUntouched();
+    }
+
+    @Test
+    public void test221AutzJackObjectAddPreview() throws CommonException, IOException {
+        given("Jack has authorization to add new users");
+        cleanupAutzTest(USER_JACK_OID);
+        assignRole(USER_JACK_OID, ROLE_ROLE_ADD_READ_SOME.oid);
+        login(USER_JACK_USERNAME);
+
+        when();
+        ObjectDelta<RoleType> userToAddDelta = createObject(RoleType.class, "Jack's role").createAddDelta();
+        Task task = getTestTask();
+        OperationResult result = task.getResult();
+        ModelContext<RoleType> previewContext = previewChanges(userToAddDelta, null, task, result);
+
+        then();
+        assertPreviewContext(previewContext)
+                .focusContext().objectNew().assertName("Jack's role");
     }
 
     @Test

--- a/model/model-intest/src/test/resources/security/role-user-add-read-some.xml
+++ b/model/model-intest/src/test/resources/security/role-user-add-read-some.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2010-2019 Evolveum and contributors
+  ~
+  ~ This work is dual-licensed under the Apache License 2.0
+  ~ and European Union Public License. See LICENSE file for details.
+  -->
+<role oid="d70b7695-cb99-4cbf-83b1-f18652844845" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xmlns="http://midpoint.evolveum.com/xml/ns/public/common/common-3"
+>
+    <name>Add role</name>
+<!-- ***** GUI ***** -->
+    <authorization>
+        <action>http://midpoint.evolveum.com/xml/ns/public/security/authorization-3#roles</action>
+        <action>http://midpoint.evolveum.com/xml/ns/public/security/authorization-3#role</action>
+        <action>http://midpoint.evolveum.com/xml/ns/public/security/authorization-3#roleDetails</action>
+    </authorization>
+
+<!-- ***** Model ***** -->
+
+    <authorization>
+        <action>http://midpoint.evolveum.com/xml/ns/public/security/authorization-model-3#get</action>
+        <object>
+            <type>RoleType</type>
+        </object>
+        <item>name</item>
+        <item>description</item>
+        <item>subtype</item>
+        <item>displayName</item>
+        <item>requestable</item>
+        <item>assignment</item>
+        <item>inducement</item>
+        <item>archetypeRef</item>
+    </authorization>
+
+    <authorization>
+        <action>http://midpoint.evolveum.com/xml/ns/public/security/authorization-model-3#add</action>
+        <object>
+            <type>RoleType</type>
+        </object>
+    </authorization>
+
+</role>

--- a/release-notes.adoc
+++ b/release-notes.adoc
@@ -33,6 +33,7 @@ The {release-version} release brings security, stability and miscellaneous bugfi
 * Fixed cleanup of finished tasks which has configured "cleanup after finish" parameter. See bug:MID-10272[].
 * bug:MID-10213[] Fix synchronization of large number of tasks (>10 000).
 * bug:MID-10270[] Summary panel for roles now uses display name and identifier (same as for organizations and services).
+* Fix error during preview of changes. See bug:MID-10204[].
 
 == Changes with Respect To Version 4.8.4
 


### PR DESCRIPTION
**What**

Fix an error caused by change of immutable object (in this case immutable delta), which happens during preview of "create role" changes. But it could potentially happen during any "create" operation.

**Notes**

This error could be fixed in various ways. Some of considered solutions:
- Add `modifyEachObject` and `modifyEachDelta` methods to `ElementState` and to `LensElementContext`. These methods would allow to modify internal deltas/objects by internally cloning them if they are immutable.
- Cloning whole `LensContext` before passing it to the `SchemaTransformer` for application of security constraints.
- Cloning `LensFocusContext` and `LensProjectionContext` before passing them to the `DataAccessProcessor`.

It's important to say, that **none** from mentioned solutions is very good. So I simply chose the one which I see as a lesser evil, the third one. Here are my arguments:

**Add `modifyEach*` methods**

This solution seemed to me as the most compelling. However, during more research I have understood, that deltas and objects in the `ElementState` should not be changed "just like that" without a big amount of care. Changes of already immutable objects/deltas could cause that whole `ElementState` would be invalid. It could be a problem especially, if it was changed before or during clockwork execution. Even though there already are methods, which allows to modify primary/secondary deltas, they are commented as a "dangerous". I don't think, it would be wise to add yet another set of methods, which somebody could (what means "will") misuse.

**Cloning whole `LensContext`**

To be honest I haven't think about this approach very much. It simply seems to me as a too big chunk of data to clone without a reason.

**Clonging `LensFocusContext` and `LensProjectionContext`

This method seems to me as a compromise between cloning too much data and modifying potentially "living" state. It also does not require addition of any new "modification" methods to the `ElementState` class which in turn reduce the risk of misuse.

**Proper solution**

Based on my current understanding, the best solution, would be to limit data which are needed for a preview. If I understand it correctly, the data which are necessary to display a preview are just deltas. So I think, the proper solution would be to sent just those to the UI. Of course if more data are needed, than those could be sent too, but definitely not whole `LensContext`.

If data sent to UI would be limited, we could simply apply the security constraints just to those deltas and not bother with whole `LensContext` which would be "dropped" anyway (since it's just preview).

**Fixes**: MID-10204

(cherry picked from commit a55cbe43936a67ff4fa2f49559e2dcfd96f19f87)