### PR TITLE
Remove max password length constraint

### DIFF
--- a/release-notes.adoc
+++ b/release-notes.adoc
@@ -47,6 +47,7 @@ Overall, midPoint 4.9 is a major step from the past into the future.
 * bug:MID-10317[] Fixed missing message when user disable fails.
 * bug:MID-10320[] Fixed ninja zip option used during export/import.
 * bug:MID-10218[] Task execution constraints added to advanced options tab.
+* bug:MID-10305[] Remove max password length constraint.
 
 === Other Improvements
 

--- a/repo/system-init/src/main/resources/initial-objects/value-policy/010-value-policy.xml
+++ b/repo/system-init/src/main/resources/initial-objects/value-policy/010-value-policy.xml
@@ -15,7 +15,6 @@
         <description>Testing string policy</description>
         <limitations>
             <minLength>8</minLength>
-            <maxLength>14</maxLength>
             <minUniqueChars>3</minUniqueChars>
             <checkAgainstDictionary>true</checkAgainstDictionary>
             <checkPattern/>


### PR DESCRIPTION
**What**

Remove constraint on maximum password length from default configuration.

**Why**

It basically goes against our documented best practice. The limitation was there because of the defaults in some external systems (AD). However we should not relent on the security just because of external systems default policies, thus this change removes the constraint.

**Fixes**: MID-10305