### PR TITLE
Support metadata exclusion in REST get/search APIs

### DIFF
--- a/docs/interfaces/rest/operations/raw/operation-prop-search.adoc
+++ b/docs/interfaces/rest/operations/raw/operation-prop-search.adoc
@@ -8,12 +8,20 @@ the `exclude` parameter in your query request. The attribute which is
 mentioned after the equals sign will be excluded. In case of excluding
 multiple attributes, specify each exclude with an `&` character after each
 other.
+You can also exclude metadata from desired path using special `@metadata` attribute name.
+However, excluding attributes from within the metadata is not supported, only whole metadata could be excluded.
 
 *Example*:
 
+Following will remove
+
+- metadata from the root object
+- metadata from the `assignment` object
+- `value` object on the path `credentials/password`
+
 [source,bash]
 ----
-?exclude=metadata&exclude=credentials/password/value
+?exclude=@metadata&exclude=assignment/@metadata&exclude=credentials/password/value
 ----
 
 

--- a/release-notes.adoc
+++ b/release-notes.adoc
@@ -54,6 +54,7 @@ Overall, midPoint 4.9 is a major step from the past into the future.
 * bug:MID-10317[] Fixed missing message when user disable fails.
 * bug:MID-10320[] Fixed ninja zip option used during export/import.
 * bug:MID-10218[] Task execution constraints added to advanced options tab.
+* bug:MID-10216[] Support exclusion of metadata in `get`/`search` rest APIs.
 * bug:MID-10305[] Remove max password length constraint.
 
 == Changes With Respect To Version 4.8


### PR DESCRIPTION
**What**

Allow user to exclude metadata from specified paths

**Why**

So far use could exclude normal data, but not metadata even though documentation contained examples also with metadata exclusion. Now metadata exclusion is supported as well.

**Fixes**: MID-10216

(cherry picked from commit 2dfbce298b6ae455c8d9359b027ef273a8e3afd1)