### PR TITLE
Fix REST APIs when exclude parameter is not present

### DIFF
--- a/model/rest-impl/src/main/java/com/evolveum/midpoint/rest/impl/ModelRestController.java
+++ b/model/rest-impl/src/main/java/com/evolveum/midpoint/rest/impl/ModelRestController.java
@@ -271,7 +271,9 @@ public class ModelRestController extends AbstractRestController {
             } else {
                 object = model.getObject(clazz, id, getOptions, task, result);
             }
-            removeExcludes(object, exclude);
+            if (exclude != null) {
+                removeExcludes(object, exclude);
+            }
 
             response = createResponse(HttpStatus.OK, object, result);
         } catch (Exception ex) {
@@ -650,7 +652,9 @@ public class ModelRestController extends AbstractRestController {
 
             ObjectListType listType = new ObjectListType();
             for (PrismObject<? extends ObjectType> o : objects) {
-                removeExcludes(o, exclude);
+                if (exclude != null) {
+                    removeExcludes(o, exclude);
+                }
                 listType.getObject().add(o.asObjectable());
             }
 


### PR DESCRIPTION
**What**

Fix NPEs caused by missing `exclude` parameter in some get/search endpoints.

**Fixes:** MID-10216

(cherry picked from commit 5d531fa0574570f4c3c175f11dd9e949a32684dc)