### PR TITLE
Don't use `Throwable` in `catch` statement

### DIFF
--- a/repo/repo-cache/src/main/java/com/evolveum/midpoint/repo/cache/invalidation/ChangeDescription.java
+++ b/repo/repo-cache/src/main/java/com/evolveum/midpoint/repo/cache/invalidation/ChangeDescription.java
@@ -231,9 +231,9 @@ public abstract class ChangeDescription {
                     + "continuing as if there might be an overlap:\n"
                     + "change description = {}\nfilter = {}", this, filter, e);
             return true;
-        } catch (Throwable t) {
+        } catch (Exception e) {
             LOGGER.warn("Couldn't match object being changed to cached query -- continuing as if there might be an overlap:\n"
-                    + "change description = {}\nfilter = {}", this, filter, t);
+                    + "change description = {}\nfilter = {}", this, filter, e);
             return true;
         }
     }


### PR DESCRIPTION
**Why**

Catching `Throwable` to "catch them all" is a bad practice, because it catches also `Error`'s which in general, should not be catched, because you "usuealy" can not do anything with them.