### PR TITLE
Change assumed size of page in repository cache test

### DIFF
--- a/release-notes.adoc
+++ b/release-notes.adoc
@@ -77,6 +77,7 @@ Now it's possible to define characters that are accepted in the password, but no
 The default password policy was updated in this regard.
 See bug:MID-9541[].
 * Stopped displaying some shadow operational properties (like the synchronization timestamp, iteration, and so on) among changes in simulation results. See bug:MID-9737[] and bug:MID-9986[].
+* bug:MID-10048[] Fix ClassCastException when creating duplicates of object types with new archetype
 
 == Changes With Respect To Version 4.8
 

--- a/repo/repo-cache/src/test/java/com/evolveum/midpoint/repo/cache/TestRepositoryCache.java
+++ b/repo/repo-cache/src/test/java/com/evolveum/midpoint/repo/cache/TestRepositoryCache.java
@@ -6,23 +6,24 @@
  */
 package com.evolveum.midpoint.repo.cache;
 
+import static com.evolveum.midpoint.prism.util.PrismTestUtil.displayCollection;
+import static com.evolveum.midpoint.prism.util.PrismTestUtil.getPrismContext;
+import static com.evolveum.midpoint.repo.sqale.SqaleRepositoryService.REPOSITORY_IMPL_NAME;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.testng.AssertJUnit.assertEquals;
 import static org.testng.AssertJUnit.fail;
 
-import static com.evolveum.midpoint.prism.util.PrismTestUtil.displayCollection;
-import static com.evolveum.midpoint.prism.util.PrismTestUtil.getPrismContext;
-import static com.evolveum.midpoint.repo.sqale.SqaleRepositoryService.REPOSITORY_IMPL_NAME;
-
-import java.util.*;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
-import com.evolveum.midpoint.schema.util.SchemaDebugUtil;
-
 import jakarta.annotation.PostConstruct;
-
 import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -44,22 +45,23 @@ import com.evolveum.midpoint.repo.cache.global.GlobalQueryCache;
 import com.evolveum.midpoint.repo.cache.global.GlobalVersionCache;
 import com.evolveum.midpoint.repo.cache.local.QueryKey;
 import com.evolveum.midpoint.repo.sqale.SqaleRepositoryService;
-import com.evolveum.midpoint.schema.*;
-import com.evolveum.midpoint.schema.constants.MidPointConstants;
+import com.evolveum.midpoint.schema.GetOperationOptions;
+import com.evolveum.midpoint.schema.RepositoryDiag;
+import com.evolveum.midpoint.schema.ResultHandler;
+import com.evolveum.midpoint.schema.SearchResultList;
+import com.evolveum.midpoint.schema.SearchResultMetadata;
+import com.evolveum.midpoint.schema.SelectorOptions;
 import com.evolveum.midpoint.schema.result.OperationResult;
 import com.evolveum.midpoint.schema.statistics.CachePerformanceInformationUtil;
 import com.evolveum.midpoint.schema.statistics.RepositoryPerformanceInformationUtil;
+import com.evolveum.midpoint.schema.util.SchemaDebugUtil;
 import com.evolveum.midpoint.test.util.AbstractSpringTest;
 import com.evolveum.midpoint.test.util.InfraTestMixin;
-import com.evolveum.midpoint.util.PrettyPrinter;
 import com.evolveum.midpoint.util.caching.CachePerformanceCollector;
 import com.evolveum.midpoint.util.exception.ObjectAlreadyExistsException;
 import com.evolveum.midpoint.util.exception.ObjectNotFoundException;
 import com.evolveum.midpoint.util.exception.SchemaException;
-import com.evolveum.midpoint.xml.ns._public.common.common_3.ArchetypeType;
-import com.evolveum.midpoint.xml.ns._public.common.common_3.ObjectType;
-import com.evolveum.midpoint.xml.ns._public.common.common_3.SystemConfigurationType;
-import com.evolveum.midpoint.xml.ns._public.common.common_3.UserType;
+import com.evolveum.midpoint.xml.ns._public.common.common_3.*;
 import com.evolveum.prism.xml.ns._public.types_3.PolyStringType;
 
 @SuppressWarnings("SameParameterValue")
@@ -315,10 +317,10 @@ public class TestRepositoryCache extends AbstractSpringTest implements InfraTest
         int size = 2_000_000;
         int count = 400;
 
-        // 50 is the default "step" in paged iterative search, so we can expect we always have 50 objects in memory
+        // 100 is the default "step" in paged iterative search, so we can expect we always have 50 objects in memory
         // And "times 4" is the safety margin. It might or might not be sufficient, as System.gc() is not guaranteed to
         // really execute the garbage collection (only suggests JVM to do it).
-        long tolerance = (50 * size) * 4;
+        long tolerance = (100 * size) * 4;
 
         showMemory("Initial");
         dumpHeap("initial");


### PR DESCRIPTION
**Why**

Page size which were originally assumed wasn't correct anymore and it caused that the size limit of heap which was tested in heap usage test **may** not be big enough (for example on my system the test fails, but on our test infra it passes).

**Relates to**: MID-10048

(cherry picked from commit 8c7208da5081b04e947ee1cb51fe79307db358d2)