### PR TITLE
Fix non clickable part of button

### DIFF
--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/api/component/wizard/BasicWizardStepPanel.html
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/api/component/wizard/BasicWizardStepPanel.html
@@ -12,7 +12,7 @@
         <h5 class="text-center text-secondary mb-5 lh-2" wicket:id="subText"/>
 
         <wicket:child/>
-        <div class="d-flex gap-3 justify-content-center mt-5">
+        <div class="d-flex gap-3 justify-content-center mt-5" wicket:id="buttonsStrip">
             <a class="btn text-primary" wicket:id="back">
                 <i class="fas fa-arrow-left mr-1"></i>
                 <wicket:message key="WizardHeader.back"/>

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/api/component/wizard/BasicWizardStepPanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/api/component/wizard/BasicWizardStepPanel.java
@@ -7,17 +7,18 @@
 
 package com.evolveum.midpoint.gui.api.component.wizard;
 
-import com.evolveum.midpoint.gui.api.util.WebComponentUtil;
-import com.evolveum.midpoint.web.component.AjaxSubmitButton;
-import com.evolveum.midpoint.web.component.util.VisibleEnableBehaviour;
-import com.evolveum.midpoint.web.component.util.VisibleBehaviour;
-
 import org.apache.wicket.ajax.AjaxRequestTarget;
 import org.apache.wicket.ajax.markup.html.AjaxLink;
+import org.apache.wicket.markup.html.WebMarkupContainer;
 import org.apache.wicket.markup.html.basic.Label;
 import org.apache.wicket.markup.repeater.RepeatingView;
 import org.apache.wicket.model.IModel;
 import org.apache.wicket.model.Model;
+
+import com.evolveum.midpoint.gui.api.util.WebComponentUtil;
+import com.evolveum.midpoint.web.component.AjaxSubmitButton;
+import com.evolveum.midpoint.web.component.util.VisibleBehaviour;
+import com.evolveum.midpoint.web.component.util.VisibleEnableBehaviour;
 
 /**
  * @author lskublik
@@ -31,6 +32,7 @@ public class BasicWizardStepPanel<T> extends WizardStepPanel<T> {
     private static final String ID_BACK = "back";
     private static final String ID_EXIT = "exit";
 
+    private static final String ID_BUTTONS_STRIP = "buttonsStrip";
     private static final String ID_CUSTOM_BUTTONS = "customButtons";
 
     private static final String ID_SUBMIT = "submit";
@@ -61,6 +63,14 @@ public class BasicWizardStepPanel<T> extends WizardStepPanel<T> {
         secondaryText.add(new VisibleBehaviour(() -> getSubTextModel().getObject() != null));
         add(secondaryText);
 
+        WebMarkupContainer buttonsStrip = new WebMarkupContainer(ID_BUTTONS_STRIP);
+        buttonsStrip.setOutputMarkupPlaceholderTag(true);
+        buttonsStrip.setVisible(isExitButtonVisible()
+                || isSubmitVisible()
+                || getBackBehaviour().isVisible()
+                || getNextBehaviour().isVisible());
+        add(buttonsStrip);
+
         AjaxLink back = new AjaxLink<>(ID_BACK) {
 
             @Override
@@ -72,7 +82,7 @@ public class BasicWizardStepPanel<T> extends WizardStepPanel<T> {
         back.setOutputMarkupId(true);
         back.setOutputMarkupPlaceholderTag(true);
         WebComponentUtil.addDisabledClassBehavior(back);
-        add(back);
+        buttonsStrip.add(back);
 
         AjaxLink exit = new AjaxLink<>(ID_EXIT) {
 
@@ -87,10 +97,10 @@ public class BasicWizardStepPanel<T> extends WizardStepPanel<T> {
         exit.setOutputMarkupId(true);
         exit.setOutputMarkupPlaceholderTag(true);
         WebComponentUtil.addDisabledClassBehavior(exit);
-        add(exit);
+        buttonsStrip.add(exit);
 
         RepeatingView customButtons = new RepeatingView(ID_CUSTOM_BUTTONS);
-        add(customButtons);
+        buttonsStrip.add(customButtons);
         initCustomButtons(customButtons);
 
         AjaxSubmitButton submit = new AjaxSubmitButton(ID_SUBMIT) {
@@ -112,7 +122,7 @@ public class BasicWizardStepPanel<T> extends WizardStepPanel<T> {
         submit.setOutputMarkupId(true);
         submit.setOutputMarkupPlaceholderTag(true);
         WebComponentUtil.addDisabledClassBehavior(submit);
-        add(submit);
+        buttonsStrip.add(submit);
 
         Label submitLabel = new Label(ID_SUBMIT_LABEL, getSubmitLabelModel());
         submit.add(submitLabel);
@@ -133,7 +143,7 @@ public class BasicWizardStepPanel<T> extends WizardStepPanel<T> {
         next.setOutputMarkupId(true);
         next.setOutputMarkupPlaceholderTag(true);
         WebComponentUtil.addDisabledClassBehavior(next);
-        add(next);
+        buttonsStrip.add(next);
 
         Label nextLabel = new Label(ID_NEXT_LABEL, getNextLabelModel());
         next.add(nextLabel);
@@ -184,15 +194,15 @@ public class BasicWizardStepPanel<T> extends WizardStepPanel<T> {
     }
 
     protected AjaxSubmitButton getNext() {
-        return (AjaxSubmitButton) get(ID_NEXT);
+        return (AjaxSubmitButton) get(createComponentPath(ID_BUTTONS_STRIP, ID_NEXT));
     }
 
     protected AjaxLink getBack() {
-        return (AjaxLink) get(ID_BACK);
+        return (AjaxLink) get(createComponentPath(ID_BUTTONS_STRIP, ID_BACK));
     }
 
     protected AjaxSubmitButton getSubmit() {
-        return (AjaxSubmitButton) get(ID_SUBMIT);
+        return (AjaxSubmitButton) get(createComponentPath(ID_BUTTONS_STRIP, ID_SUBMIT));
     }
 
     protected IModel<String> getTextModel() {

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/component/wizard/AbstractWizardStepPanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/component/wizard/AbstractWizardStepPanel.java
@@ -6,21 +6,16 @@
  */
 package com.evolveum.midpoint.gui.impl.component.wizard;
 
-import com.evolveum.midpoint.gui.api.component.wizard.BasicWizardStepPanel;
-import com.evolveum.midpoint.gui.api.util.WebComponentUtil;
-import com.evolveum.midpoint.gui.impl.page.admin.ObjectDetailsModels;
-
-import com.evolveum.midpoint.web.component.message.FeedbackAlerts;
-
-import com.evolveum.midpoint.web.component.util.VisibleEnableBehaviour;
-
-import com.evolveum.midpoint.xml.ns._public.common.common_3.ContainerPanelConfigurationType;
-import com.evolveum.midpoint.xml.ns._public.common.common_3.GuiObjectDetailsPageType;
-import com.evolveum.midpoint.xml.ns._public.common.common_3.ObjectType;
-
 import org.apache.wicket.ajax.AjaxRequestTarget;
 import org.apache.wicket.markup.html.WebMarkupContainer;
 import org.apache.wicket.model.IModel;
+
+import com.evolveum.midpoint.gui.api.component.wizard.BasicWizardStepPanel;
+import com.evolveum.midpoint.gui.api.util.WebComponentUtil;
+import com.evolveum.midpoint.gui.impl.page.admin.ObjectDetailsModels;
+import com.evolveum.midpoint.web.component.message.FeedbackAlerts;
+import com.evolveum.midpoint.web.component.util.VisibleEnableBehaviour;
+import com.evolveum.midpoint.xml.ns._public.common.common_3.*;
 
 /**
  * @author lskublik

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/schema/component/BasicDefinitionPanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/schema/component/BasicDefinitionPanel.java
@@ -6,6 +6,12 @@
  */
 package com.evolveum.midpoint.gui.impl.page.admin.schema.component;
 
+import org.apache.wicket.Component;
+import org.apache.wicket.ajax.AjaxRequestTarget;
+import org.apache.wicket.behavior.AttributeAppender;
+import org.apache.wicket.markup.html.WebMarkupContainer;
+import org.apache.wicket.model.IModel;
+
 import com.evolveum.midpoint.gui.api.prism.wrapper.ItemVisibilityHandler;
 import com.evolveum.midpoint.gui.api.prism.wrapper.PrismContainerValueWrapper;
 import com.evolveum.midpoint.gui.impl.page.admin.assignmentholder.AssignmentHolderDetailsModel;
@@ -15,22 +21,11 @@ import com.evolveum.midpoint.gui.impl.prism.panel.ItemPanelSettingsBuilder;
 import com.evolveum.midpoint.gui.impl.prism.panel.vertical.form.VerticalFormDefaultContainerablePanel;
 import com.evolveum.midpoint.gui.impl.prism.panel.vertical.form.VerticalFormPrismContainerValuePanel;
 import com.evolveum.midpoint.prism.Containerable;
-import com.evolveum.midpoint.web.application.PanelDisplay;
-import com.evolveum.midpoint.web.application.PanelInstance;
 import com.evolveum.midpoint.web.component.prism.ItemVisibility;
 import com.evolveum.midpoint.web.component.util.VisibleBehaviour;
 import com.evolveum.midpoint.web.component.util.VisibleEnableBehaviour;
-import com.evolveum.midpoint.xml.ns._public.common.common_3.MappingType;
-import com.evolveum.midpoint.xml.ns._public.common.common_3.OperationTypeType;
-import com.evolveum.midpoint.xml.ns._public.common.common_3.SchemaType;
+import com.evolveum.midpoint.xml.ns._public.common.common_3.*;
 import com.evolveum.midpoint.xml.ns._public.prism_schema_3.DefinitionType;
-import com.evolveum.midpoint.xml.ns._public.prism_schema_3.EnumerationValueTypeDefinitionType;
-
-import org.apache.wicket.Component;
-import org.apache.wicket.ajax.AjaxRequestTarget;
-import org.apache.wicket.behavior.AttributeAppender;
-import org.apache.wicket.markup.html.WebMarkupContainer;
-import org.apache.wicket.model.IModel;
 
 /**
  * @author lskublik
@@ -48,7 +43,8 @@ public abstract class BasicDefinitionPanel<C extends Containerable>
     @Override
     protected void onInitialize() {
         super.onInitialize();
-        add(AttributeAppender.append("class", "mt-n4 mb-n5"));
+        // To compensate big margin set on BasicWizardStepPanel root div
+        add(AttributeAppender.append("class", "mt-n4"));
     }
 
     @Override

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/util/VisibleEnableBehaviour.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/util/VisibleEnableBehaviour.java
@@ -34,10 +34,20 @@ public class VisibleEnableBehaviour extends Behavior {
 
     private final SerializableSupplier<Boolean> enabled;
 
+    /**
+     *
+     * @deprecated use {@link #VisibleEnableBehaviour(SerializableSupplier, SerializableSupplier)} instead
+     */
+    @Deprecated
     public VisibleEnableBehaviour() {
         this(null);
     }
 
+    /**
+     *
+     * @deprecated use {@link #VisibleEnableBehaviour(SerializableSupplier, SerializableSupplier)} instead
+     */
+    @Deprecated
     public VisibleEnableBehaviour(@Nullable SerializableSupplier<Boolean> visible) {
         this(visible, null);
     }
@@ -50,10 +60,9 @@ public class VisibleEnableBehaviour extends Behavior {
     /**
      * @return Default implementation returns true even if underlying supplier returns null (this is because of backward compatibility of this class)
      *
-     * @deprecated use {@link #VisibleEnableBehaviour(SerializableSupplier)} instead
-     * This method doesn't properly handle null values (when behaviour can't decide on whether component should be visible or not).
+     * This method doesn't properly handle situations, when underlying supplier itself is null (when behaviour can't
+     * decide on whether component should be visible or not). In such case, it returns {@code true}.
      */
-    @Deprecated
     public boolean isVisible() {
         if (visible == null) {
             return true;
@@ -64,10 +73,9 @@ public class VisibleEnableBehaviour extends Behavior {
     /**
      * @return Default implementation returns true even if underlying supplier returns null (this is because of backward compatibility of this class)
      *
-     * @deprecated use {@link #VisibleEnableBehaviour(SerializableSupplier, SerializableSupplier)} instead.
-     * This method doesn't properly handle null values (when behaviour can't decide on whether component should be enabled or not).
+     * This method doesn't properly handle situations, when underlying supplier itself is null (when behaviour can't
+     * decide on whether component should be enabled or not). In such case, it returns {@code true}.
      */
-    @Deprecated
     public boolean isEnabled() {
         if (enabled == null) {
             return true;

--- a/release-notes.adoc
+++ b/release-notes.adoc
@@ -51,6 +51,7 @@ Overall, midPoint 4.9 is a major step from the past into the future.
 * bug:MID-10305[] Remove max password length constraint.
 * bug:MID-10048[] Fix ClassCastException when creating duplicates of object types with new archetype
 * bug:MID-9300[] Secure schema usage in PostgresSQL (not using public schema).
+* bug:MID-10278[] Fix non-clickable part of a button in Edit Schema popup panel.
 
 === Other Improvements
 


### PR DESCRIPTION
**What**

Fix the issue where the top part of the button on schema edit wizard popup was not clickable.

**Notes**

The problem was caused by the `mb-n5` css class set on the top `div` in modal body:

```html
<div class="modal-body" id="id16c">
    <div class="mt-n4 mb-n5"> <!-- HERE -->
```

It was set in the `BasicDefinitionPanel` and it looks like that class was added to the `div` to compensate the `mt-5` class in an underlying `div` with usual (in this case hidden) wizard buttons (next, back, exit, submit) which is defined in `BasicWizardStepPanel` and its `BasicWizardStepPanel.html` HTML file.

```html
<div class="d-flex gap-3 justify-content-center mt-5"> <!-- HERE -->
    <!-- Bellow links are basically hidden back/next/submit/exit buttons
    -->
    <a id="id1dd" hidden="" data-wicket-placeholder=""></a>
    <a id="id1de" hidden="" data-wicket-placeholder=""></a>
    <a id="id1df" hidden="" data-wicket-placeholder=""></a>
    <a id="id1e0" hidden="" data-wicket-placeholder=""></a>
</div>
```

However the negative `mb-n5` margin caused that the `div` "overflowed" through the wizard body to the wizard footer where the buttons of schema edit wizard popup are placed, and it covered top part of the button, making it un-clickable.

I decided to fix this problem by hiding whole `div` with original wizard buttons (next, back, ...) if none of those buttons is visible. Then I could remove the `mb-n5`.

Note that there is yet another css class `mt-n4` in the same `div`. This as well looks to me as kind of compensation of a big `mt-5` margin in the underlying `div`.

```html
<div class="d-flex flex-column align-items-center mt-5">
```

That `div` is as well defined in the `BasicWizardStepPanel` and its `BasicWizardStepPanel.html` HTML file.

I tried to make that `mt-5` margin customizable, by adding a `wicket:id` to the corresponding `div` and creating new `WebMarkupContainer` for it (similarly as I did with the "buttons strip"), with the attribute appender which would modify (add) correct margin based on the new `protected` method which could be overridden by subclasses. However, I realized that adding `wicket:id` to that `div` would mean a lot of changes in a lot of subclasses, because it changes the "path" on which the "children" (`wicket:children`) of the subclasses are placed.

Because I wasn't able to find any solution, which would not require changes in subclasses, I decided to leave this part as it is.

**Fixes:** MID-10278