### PR TITLE
Optimize reviewer notifications from certification

### DIFF
--- a/docs/diag/performance.adoc
+++ b/docs/diag/performance.adoc
@@ -75,3 +75,33 @@ For fast resources with the need of instant reporting, we suggest using the (exp
 (It can be done at any level: system configuration, resource, or object type.)
 
 Finally, if the shadow caching is not needed, it is recommended to turn it off.
+
+[#_database_tuning]
+== Database performance tuning
+
+If you are using native repository, and you observe that some action sometimes takes an unusual amount of time to finish, you may consider to try following Postgres tuning.
+
+=== Postgres autovacuum nap time
+
+Some midPoint actions may cause a big amount of inserts, followed by complex select (e.g. Opening certification campaign stage).
+In such situations, it may happen that the select will be executed before Postgres will even detect the need for `VACUUM`/`ANALYZE` operations (caused by big number of inserts).
+From our observations, such select could sometimes take a very long time (if at all) to finish.
+
+Even though we try to optimize such cases in the code, it sometimes may be necessary to mitigate this issues by lowering the autovacuum nap time Postgres configuration option.
+This property says, how big delay should be between two subsequent checks for need of `VACUUM`/`ANALYZE` operations.
+The default is 1 minute.
+We suggest you to experiment with lowering of that value to tens of seconds.
+
+NOTE: The autovacuum nap time does not directly affect the execution of the `VACUUM`/`ANALYZE` operations.
+It only affects how often the check for need of `VACUUM`/`ANALYZE` will run.
+So indirectly, it *MAY* but doesn't *HAVE TO* cause bigger number of `VACUUM`/`ANALYZE` executions.
+
+Autovacuum nap time can be configured in the postgresql.conf file in the AUTOVACUUM section:
+[source,conf]
+----
+autovacuum_naptime = 10s
+----
+
+WARNING: The autovacuum nap time is considered per database.
+That means, if your Postgres instance hosts more databases, each of those databases will be checked for need of `VACUUM`/`ANALYZE` once per period.
+Consequently, if the Postgres instance have N databases, there will be a check executed each `naptime/N` seconds, each time for different database.

--- a/infra/schema/src/main/java/com/evolveum/midpoint/schema/util/CertCampaignTypeUtil.java
+++ b/infra/schema/src/main/java/com/evolveum/midpoint/schema/util/CertCampaignTypeUtil.java
@@ -75,16 +75,6 @@ public class CertCampaignTypeUtil {
         return null;
     }
 
-    // to be used in tests (beware: there could be more work items)
-    // TODO move to a test class
-    public static AccessCertificationWorkItemType findWorkItem(AccessCertificationCaseType _case, int stageNumber, int iteration,
-            String reviewerOid) {
-        return _case.getWorkItem().stream()
-                .filter(wi -> wi.getStageNumber() == stageNumber && norm(wi.getIteration()) == iteration
-                        && ObjectTypeUtil.containsOid(wi.getAssigneeRef(), reviewerOid))
-                .findFirst().orElse(null);
-    }
-
     public static AccessCertificationWorkItemType findWorkItem(AccessCertificationCaseType _case, long workItemId) {
         return _case.getWorkItem().stream()
                 .filter(wi -> wi.getId() != null && wi.getId() == workItemId)
@@ -596,7 +586,7 @@ public class CertCampaignTypeUtil {
         Set<String> oids = new HashSet<>();
         for (AccessCertificationCaseType aCase : caseList) {
             for (AccessCertificationWorkItemType workItem : aCase.getWorkItem()) {
-                if (workItem.getCloseTimestamp() == null) {
+                if (workItem.getCloseTimestamp() == null) { // This basically means current active stage
                     for (ObjectReferenceType reviewerRef : workItem.getAssigneeRef()) {
                         oids.add(reviewerRef.getOid());
                     }

--- a/infra/schema/src/main/java/com/evolveum/midpoint/schema/util/cases/WorkItemTypeUtil.java
+++ b/infra/schema/src/main/java/com/evolveum/midpoint/schema/util/cases/WorkItemTypeUtil.java
@@ -119,4 +119,13 @@ public class WorkItemTypeUtil {
     public static String getEscalationLevelDisplayName(AbstractWorkItemType workItem) {
         return getEscalationLevelDisplayName(workItem.getEscalationLevel());
     }
+
+    public static boolean isWithoutOutcome(AccessCertificationWorkItemType workItem) {
+        return getOutcome(workItem) == null;
+    }
+
+    public static boolean isOpened(AccessCertificationWorkItemType workItem) {
+        return workItem.getCloseTimestamp() == null;
+    }
+
 }

--- a/model/certification-impl/src/main/java/com/evolveum/midpoint/certification/impl/task/AccessCertificationStageManagementRun.java
+++ b/model/certification-impl/src/main/java/com/evolveum/midpoint/certification/impl/task/AccessCertificationStageManagementRun.java
@@ -132,8 +132,6 @@ public abstract class AccessCertificationStageManagementRun<
             updateHelper.modifyObjectPreAuthorized(AccessCertificationDefinitionType.class, campaign.getDefinitionRef().getOid(), deltas, task, result);
         }
 
-        //////
-
         super.afterRun(result);
     }
 

--- a/model/certification-impl/src/test/java/com/evolveum/midpoint/certification/test/AccessCertificationEventListenerStub.java
+++ b/model/certification-impl/src/test/java/com/evolveum/midpoint/certification/test/AccessCertificationEventListenerStub.java
@@ -1,0 +1,74 @@
+package com.evolveum.midpoint.certification.test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.evolveum.midpoint.certification.api.AccessCertificationEventListener;
+import com.evolveum.midpoint.schema.result.OperationResult;
+import com.evolveum.midpoint.task.api.Task;
+import com.evolveum.midpoint.xml.ns._public.common.common_3.*;
+
+public final class AccessCertificationEventListenerStub implements AccessCertificationEventListener {
+
+    private final List<ReviewRequestEvent> reviewRequestedEvents;
+
+    public AccessCertificationEventListenerStub() {
+        this.reviewRequestedEvents = new ArrayList<>();
+    }
+
+    @Override
+    public void onCampaignStart(AccessCertificationCampaignType campaign, Task task, OperationResult result) {
+    }
+
+    @Override
+    public void onCampaignEnd(AccessCertificationCampaignType campaign, Task task, OperationResult result) {
+    }
+
+    @Override
+    public void onCampaignStageStart(AccessCertificationCampaignType campaign, Task task, OperationResult result) {
+    }
+
+    @Override
+    public void onCampaignStageDeadlineApproaching(AccessCertificationCampaignType campaign, Task task,
+            OperationResult result) {
+    }
+
+    @Override
+    public void onCampaignStageEnd(AccessCertificationCampaignType campaign, Task task, OperationResult result) {
+    }
+
+    @Override
+    public void onReviewRequested(ObjectReferenceType reviewerOrDeputyRef, ObjectReferenceType actualReviewerRef,
+            List<AccessCertificationCaseType> cases, AccessCertificationCampaignType campaign, Task task,
+            OperationResult result) {
+        this.reviewRequestedEvents.add(new ReviewRequestEvent(
+                reviewerOrDeputyRef.getOid(),
+                actualReviewerRef.getOid(),
+                cases.stream().map(c -> c.asPrismContainerValue().getId()).toList(),
+                campaign.getOid()));
+    }
+
+    @Override
+    public void onReviewDeadlineApproaching(ObjectReferenceType reviewerOrDeputyRef,
+            ObjectReferenceType actualReviewerRef, List<AccessCertificationCaseType> cases,
+            AccessCertificationCampaignType campaign, Task task, OperationResult result) {
+    }
+
+    boolean reviewRequestedEventSentTo(String reviewerOrDeputy, String actualReviewer,
+            List<Long> casesIds, String campaignOid) {
+        return this.reviewRequestedEvents.contains(
+                new ReviewRequestEvent(reviewerOrDeputy, actualReviewer, casesIds, campaignOid));
+    }
+
+    void reset() {
+        this.reviewRequestedEvents.clear();
+    }
+
+    private record ReviewRequestEvent(
+            String reviewerOrDeputy,
+            String actualReviewer,
+            List<Long> casesIds,
+            String campaignOid) {
+    }
+
+}

--- a/model/certification-impl/src/test/java/com/evolveum/midpoint/certification/test/TestCertificationBasic.java
+++ b/model/certification-impl/src/test/java/com/evolveum/midpoint/certification/test/TestCertificationBasic.java
@@ -31,7 +31,6 @@ import com.evolveum.midpoint.schema.util.ObjectTypeUtil;
 
 import com.evolveum.midpoint.util.exception.*;
 
-import org.jetbrains.annotations.NotNull;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.testng.annotations.Test;
@@ -572,8 +571,7 @@ public class TestCertificationBasic extends AbstractCertificationTest {
         AccessCertificationCaseType superuserCase = findCase(caseList, USER_ADMINISTRATOR_OID, ROLE_SUPERUSER_OID);
 
         when();
-        AccessCertificationWorkItemType workItem =
-                CertCampaignTypeUtil.findWorkItem(superuserCase, 1, 1, USER_ADMINISTRATOR_OID);
+        AccessCertificationWorkItemType workItem = findWorkItem(superuserCase, 1, 1, USER_ADMINISTRATOR_OID);
         long id = superuserCase.asPrismContainerValue().getId();
         certificationService.recordDecision(campaignOid, id, workItem.getId(), ACCEPT, "no comment", task, result);
 
@@ -609,8 +607,7 @@ public class TestCertificationBasic extends AbstractCertificationTest {
         AccessCertificationCaseType ceoCase = findCase(caseList, USER_JACK_OID, ROLE_CEO_OID);
 
         when();
-        AccessCertificationWorkItemType workItem =
-                CertCampaignTypeUtil.findWorkItem(ceoCase, 1, 1, USER_ADMINISTRATOR_OID);
+        AccessCertificationWorkItemType workItem = findWorkItem(ceoCase, 1, 1, USER_ADMINISTRATOR_OID);
         // reviewerRef will be taken from the current user
         long id = ceoCase.asPrismContainerValue().getId();
         certificationService.recordDecision(campaignOid, id, workItem.getId(), ACCEPT, "ok", task, result);
@@ -648,8 +645,7 @@ public class TestCertificationBasic extends AbstractCertificationTest {
         when();
         // reviewerRef will be taken from the current user
         long id = ceoCase.asPrismContainerValue().getId();
-        AccessCertificationWorkItemType workItem =
-                CertCampaignTypeUtil.findWorkItem(ceoCase, 1, 1, USER_ADMINISTRATOR_OID);
+        AccessCertificationWorkItemType workItem = findWorkItem(ceoCase, 1, 1, USER_ADMINISTRATOR_OID);
         certificationService.recordDecision(campaignOid, id, workItem.getId(), REVOKE, "no way", task, result);
 
         then();

--- a/model/certification-impl/src/test/java/com/evolveum/midpoint/certification/test/TestCertificationNotifications.java
+++ b/model/certification-impl/src/test/java/com/evolveum/midpoint/certification/test/TestCertificationNotifications.java
@@ -1,0 +1,197 @@
+package com.evolveum.midpoint.certification.test;
+
+import static com.evolveum.midpoint.xml.ns._public.common.common_3.AccessCertificationResponseType.*;
+import static com.evolveum.midpoint.xml.ns._public.common.common_3.ActivationStatusType.*;
+import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.AssertJUnit.assertFalse;
+import static org.testng.AssertJUnit.assertTrue;
+
+import java.io.File;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import javax.xml.datatype.XMLGregorianCalendar;
+
+import org.jetbrains.annotations.NotNull;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import com.evolveum.midpoint.prism.PrismObject;
+import com.evolveum.midpoint.prism.impl.binding.AbstractMutableContainerable;
+import com.evolveum.midpoint.schema.result.OperationResult;
+import com.evolveum.midpoint.schema.util.ObjectTypeUtil;
+import com.evolveum.midpoint.schema.util.cases.WorkItemTypeUtil;
+import com.evolveum.midpoint.task.api.Task;
+import com.evolveum.midpoint.test.util.TestUtil;
+import com.evolveum.midpoint.util.exception.CommunicationException;
+import com.evolveum.midpoint.util.exception.ConfigurationException;
+import com.evolveum.midpoint.util.exception.ExpressionEvaluationException;
+import com.evolveum.midpoint.util.exception.ObjectAlreadyExistsException;
+import com.evolveum.midpoint.util.exception.ObjectNotFoundException;
+import com.evolveum.midpoint.util.exception.SchemaException;
+import com.evolveum.midpoint.util.exception.SecurityViolationException;
+import com.evolveum.midpoint.xml.ns._public.common.common_3.*;
+
+@ContextConfiguration(locations = { "classpath:ctx-certification-test-main.xml" })
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+public class TestCertificationNotifications extends AbstractCertificationTest {
+    private static final File CERT_DEF_USER_ASSIGNMENT_BASIC_FILE =
+            new File(COMMON_DIR, "certification-of-eroot-user-assignments-notifications.xml");
+
+    private AccessCertificationDefinitionType certificationDefinition;
+    private String campaignOid;
+    private AccessCertificationEventListenerStub eventListenerStub;
+
+    @Override
+    public void initSystem(Task initTask, OperationResult initResult) throws Exception {
+        super.initSystem(initTask, initResult);
+
+        this.certificationDefinition = repoAddObjectFromFile(CERT_DEF_USER_ASSIGNMENT_BASIC_FILE,
+                AccessCertificationDefinitionType.class, initResult).asObjectable();
+        this.eventListenerStub = new AccessCertificationEventListenerStub();
+        this.certificationManager.registerCertificationEventListener(this.eventListenerStub);
+        importTriggerTask(initResult);
+    }
+
+    @BeforeMethod
+    private void resetEventListenerStub() {
+        this.eventListenerStub.reset();
+    }
+
+    @Test
+    public void test100StartCampaign() throws Exception {
+        given("Campaign has been created.");
+        final Task task = getTestTask();
+        final OperationResult result = task.getResult();
+        this.campaignOid = this.certificationService
+                .createCampaign(this.certificationDefinition.getOid(), task, result)
+                .getOid();
+        this.clock.resetOverride();
+        final XMLGregorianCalendar startedAfter = this.clock.currentTimeXMLGregorianCalendar();
+
+        when("First campaign stage has started.");
+        this.certificationService.openNextStage(this.campaignOid, task, result);
+
+        then("Notifications should be sent to all assigned reviewers.");
+        result.computeStatus();
+        TestUtil.assertInProgressOrSuccess(result);
+
+        final List<PrismObject<TaskType>> tasks = getFirstStageTasks(this.campaignOid, startedAfter, result);
+        assertEquals("Unexpected number of related tasks", 1, tasks.size());
+        waitForTaskFinish(tasks.get(0).getOid());
+
+        final AccessCertificationCampaignType campaign = getCampaignWithCases(this.campaignOid);
+        display("Campaign in stage 1", campaign);
+
+        assertSanityAfterCampaignStart(campaign, this.certificationDefinition, 7);
+        final List<AccessCertificationCaseType> certCases = campaign.getCase();
+        checkAllCasesSanity(certCases);
+
+        final List<Long> casesWithAdminAsReviewer = getCaseIds(filterReviewerCases(certCases, USER_ADMINISTRATOR_OID));
+        assertTrue("", this.eventListenerStub.reviewRequestedEventSentTo(USER_ADMINISTRATOR_OID, USER_ADMINISTRATOR_OID,
+                casesWithAdminAsReviewer, this.campaignOid));
+        assertTrue("", this.eventListenerStub.reviewRequestedEventSentTo(USER_ADMINISTRATOR_DEPUTY_NO_ASSIGNMENTS_OID,
+                USER_ADMINISTRATOR_OID, casesWithAdminAsReviewer, this.campaignOid));
+
+        final List<Long> casesWithBobAsReviewer = getCaseIds(filterReviewerCases(certCases, USER_BOB_OID));
+        assertTrue("", this.eventListenerStub.reviewRequestedEventSentTo(USER_BOB_OID, USER_BOB_OID,
+                casesWithBobAsReviewer, this.campaignOid));
+        assertTrue("", this.eventListenerStub.reviewRequestedEventSentTo(USER_BOB_DEPUTY_NO_ASSIGNMENTS_OID, USER_BOB_OID,
+                casesWithBobAsReviewer, this.campaignOid));
+        assertTrue("", this.eventListenerStub.reviewRequestedEventSentTo(USER_BOB_DEPUTY_FULL_OID, USER_BOB_OID,
+                casesWithBobAsReviewer, this.campaignOid));
+
+        final List<Long> casesWithJackAsReviewer = getCaseIds(filterReviewerCases(certCases, USER_JACK_OID));
+        assertTrue("", this.eventListenerStub.reviewRequestedEventSentTo(USER_JACK_OID, USER_JACK_OID,
+                casesWithJackAsReviewer, this.campaignOid));
+    }
+
+    @Test
+    public void test110Escalate() throws Exception {
+        given("Two reviewers (Bob and Jack) has replied to all work items, while the last (Admin) has not.");
+        final Task task = getTestTask();
+        final OperationResult result = task.getResult();
+
+        List<AccessCertificationCaseType> certCases = this.queryHelper.searchCases(this.campaignOid, null, result);
+        recordNotDecidedDecision(certCases, USER_BOB_OID, task, result);
+        recordNotDecidedDecision(certCases, USER_JACK_OID, task, result);
+
+        when("Period for escalation has passed and there still are work items without replies.");
+        this.clock.resetOverride();
+        this.clock.overrideDuration("P2D"); // first escalation is at P1D
+        waitForTaskNextRun(TASK_TRIGGER_SCANNER_OID, 20000, true);
+
+        then("Notifications should be sent to the person (Admin) who has unanswered work items and to the person "
+                + "(Jack) handling escalations.");
+        result.computeStatus();
+        TestUtil.assertSuccess(result);
+
+        certCases = this.queryHelper.searchCases(this.campaignOid, null, result);
+        final List<Long> casesWithAdminAsReviewer = getCaseIds(filterReviewerCases(certCases, USER_ADMINISTRATOR_OID));
+        assertTrue("", this.eventListenerStub.reviewRequestedEventSentTo(USER_ADMINISTRATOR_OID, USER_ADMINISTRATOR_OID,
+                casesWithAdminAsReviewer, this.campaignOid));
+        assertTrue("", this.eventListenerStub.reviewRequestedEventSentTo(USER_ADMINISTRATOR_DEPUTY_NO_ASSIGNMENTS_OID,
+                USER_ADMINISTRATOR_OID, casesWithAdminAsReviewer, this.campaignOid));
+
+        // Jack replied to all his work items, so here he should be notified only about escalated cases (that means
+        // cases with work items, where Admin is a reviewer). Thus, we use the same cases list as above for the admin.
+        assertTrue("", this.eventListenerStub.reviewRequestedEventSentTo(USER_JACK_OID, USER_JACK_OID,
+                casesWithAdminAsReviewer, this.campaignOid));
+
+        final List<Long> casesWithBobAsReviewer = getCaseIds(filterReviewerCases(certCases, USER_BOB_OID));
+        assertFalse("", this.eventListenerStub.reviewRequestedEventSentTo(USER_BOB_OID, USER_BOB_OID,
+                casesWithBobAsReviewer, this.campaignOid));
+        assertFalse("", this.eventListenerStub.reviewRequestedEventSentTo(USER_BOB_DEPUTY_NO_ASSIGNMENTS_OID,
+                USER_BOB_OID, casesWithBobAsReviewer, this.campaignOid));
+        assertFalse("", this.eventListenerStub.reviewRequestedEventSentTo(USER_BOB_DEPUTY_FULL_OID, USER_BOB_OID,
+                casesWithBobAsReviewer, this.campaignOid));
+    }
+
+    private void checkAllCasesSanity(Collection<AccessCertificationCaseType> caseList) {
+        assertEquals("Wrong number of certification cases", 7, caseList.size());
+        checkCaseSanity(caseList, USER_ADMINISTRATOR_OID, ROLE_SUPERUSER_OID, userAdministrator);
+        checkCaseSanity(caseList, USER_ADMINISTRATOR_OID, ROLE_COO_OID, userAdministrator);
+        checkCaseSanity(caseList, USER_ADMINISTRATOR_OID, ROLE_CEO_OID, userAdministrator);
+        checkCaseSanity(caseList, USER_ADMINISTRATOR_OID, ORG_EROOT_OID, userAdministrator);
+        checkCaseSanity(caseList, USER_JACK_OID, ROLE_CEO_OID, userJack, ORG_GOVERNOR_OFFICE_OID, ORG_SCUMM_BAR_OID, ENABLED);
+        checkCaseSanity(caseList, USER_JACK_OID, ORG_EROOT_OID, userJack);
+    }
+
+    private static @NotNull List<Long> getCaseIds(List<AccessCertificationCaseType> certCases) {
+        return certCases.stream()
+                .map(AbstractMutableContainerable::getId)
+                .toList();
+    }
+
+    private void recordNotDecidedDecision(Collection<AccessCertificationCaseType> certCases, String reviewerOid,
+            Task task, OperationResult result)
+            throws SchemaException, ExpressionEvaluationException, SecurityViolationException, CommunicationException,
+            ConfigurationException, ObjectNotFoundException, ObjectAlreadyExistsException {
+        final Map<Long, List<AccessCertificationWorkItemType>> workItemsToDecide =
+                mapActiveStageWorkItemsWithoutOutcomeToCaseIds(certCases, reviewerOid);
+        for (Map.Entry<Long, List<AccessCertificationWorkItemType>> entry : workItemsToDecide.entrySet()) {
+            final long caseId = entry.getKey();
+            final List<AccessCertificationWorkItemType> workItems = entry.getValue();
+            for (final AccessCertificationWorkItemType workItem : workItems) {
+                this.certificationService.recordDecision(this.campaignOid, caseId, workItem.getId(),
+                        NOT_DECIDED, "", task, result);
+            }
+        }
+    }
+
+    private static Map<Long, List<AccessCertificationWorkItemType>> mapActiveStageWorkItemsWithoutOutcomeToCaseIds(
+            Collection<AccessCertificationCaseType> certCases, String reviewerOid) {
+        final Map<Long, List<AccessCertificationWorkItemType>> reviewerWorkItems = new HashMap<>();
+        for (final AccessCertificationCaseType aCase : certCases) {
+            reviewerWorkItems.put(aCase.getId(), aCase.getWorkItem().stream()
+                    .filter(WorkItemTypeUtil::isWithoutOutcome)
+                    .filter(WorkItemTypeUtil::isOpened) // this means it is from active stage
+                    .filter(wi -> ObjectTypeUtil.containsOid(wi.getAssigneeRef(), reviewerOid))
+                    .toList());
+        }
+        return reviewerWorkItems;
+    }
+}

--- a/model/certification-impl/src/test/java/com/evolveum/midpoint/certification/test/TestEscalation.java
+++ b/model/certification-impl/src/test/java/com/evolveum/midpoint/certification/test/TestEscalation.java
@@ -12,14 +12,12 @@ import com.evolveum.midpoint.prism.PrismContext;
 import com.evolveum.midpoint.prism.PrismObject;
 import com.evolveum.midpoint.schema.result.OperationResult;
 import com.evolveum.midpoint.schema.util.CertCampaignTypeUtil;
-import com.evolveum.midpoint.schema.util.task.ActivityStateUtil;
 import com.evolveum.midpoint.schema.util.task.TaskInformation;
 import com.evolveum.midpoint.task.api.Task;
 import com.evolveum.midpoint.test.util.TestUtil;
 import com.evolveum.midpoint.util.DebugUtil;
 import com.evolveum.midpoint.xml.ns._public.common.common_3.*;
 
-import org.jetbrains.annotations.NotNull;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.testng.annotations.Test;
@@ -214,9 +212,8 @@ public class TestEscalation extends AbstractCertificationTest {
 
         // WHEN
         when();
-        AccessCertificationWorkItemType workItem =
-                CertCampaignTypeUtil.findWorkItem(superuserCase, 1, 1, USER_ADMINISTRATOR_OID);
-        long id = superuserCase.asPrismContainerValue().getId();
+        AccessCertificationWorkItemType workItem = findWorkItem(superuserCase, 1, 1, USER_ADMINISTRATOR_OID);
+        long id = superuserCase.getId();
         certificationService.recordDecision(campaignOid, id, workItem.getId(), ACCEPT, "no comment", task, result);
 
         // THEN
@@ -268,7 +265,7 @@ public class TestEscalation extends AbstractCertificationTest {
         AccessCertificationCaseType ceoCase = findCase(caseList, USER_JACK_OID, ROLE_CEO_OID);
         display("CEO case after escalation", ceoCase);
 
-        AccessCertificationWorkItemType workItem = CertCampaignTypeUtil.findWorkItem(ceoCase, 1, 1, USER_ADMINISTRATOR_OID);
+        AccessCertificationWorkItemType workItem = findWorkItem(ceoCase, 1, 1, USER_ADMINISTRATOR_OID);
         assertObjectRefs("assignees", false, workItem.getAssigneeRef(), USER_JACK_OID, USER_ADMINISTRATOR_OID);
         assertEquals("Wrong originalAssignee OID", USER_ADMINISTRATOR_OID, workItem.getOriginalAssigneeRef().getOid());
         final WorkItemEscalationLevelType newEscalationLevel = new WorkItemEscalationLevelType().number(1).name("jack-level");
@@ -284,7 +281,7 @@ public class TestEscalation extends AbstractCertificationTest {
         assertEquals("Wrong new escalation level", newEscalationLevel, event.getNewEscalationLevel());
 
         AccessCertificationCaseType superuserCase = findCase(caseList, USER_ADMINISTRATOR_OID, ROLE_SUPERUSER_OID);
-        AccessCertificationWorkItemType superuserWorkItem = CertCampaignTypeUtil.findWorkItem(superuserCase, 1, 1,
+        AccessCertificationWorkItemType superuserWorkItem = findWorkItem(superuserCase, 1, 1,
                 USER_ADMINISTRATOR_OID);
         //noinspection SimplifiedTestNGAssertion
         assertEquals("Escalation info present even if it shouldn't be", null, superuserWorkItem.getEscalationLevel());
@@ -333,7 +330,7 @@ public class TestEscalation extends AbstractCertificationTest {
 
         AccessCertificationCaseType ceoCase = findCase(caseList, USER_JACK_OID, ROLE_CEO_OID);
         display("CEO case after escalation", ceoCase);
-        AccessCertificationWorkItemType workItem = CertCampaignTypeUtil.findWorkItem(ceoCase, 1, 1, USER_ELAINE_OID);
+        AccessCertificationWorkItemType workItem = findWorkItem(ceoCase, 1, 1, USER_ELAINE_OID);
         assertNotNull("No work item found", workItem);
         assertObjectRefs("assignees", false, workItem.getAssigneeRef(), USER_ELAINE_OID);
         assertEquals("Wrong originalAssignee OID", USER_ADMINISTRATOR_OID, workItem.getOriginalAssigneeRef().getOid());
@@ -352,7 +349,7 @@ public class TestEscalation extends AbstractCertificationTest {
         assertEquals("Wrong new escalation level", newEscalationLevel, event.getNewEscalationLevel());
 
         AccessCertificationCaseType superuserCase = findCase(caseList, USER_ADMINISTRATOR_OID, ROLE_SUPERUSER_OID);
-        AccessCertificationWorkItemType superuserWorkItem = CertCampaignTypeUtil.findWorkItem(superuserCase, 1, 1,
+        AccessCertificationWorkItemType superuserWorkItem = findWorkItem(superuserCase, 1, 1,
                 USER_ADMINISTRATOR_OID);
         //noinspection SimplifiedTestNGAssertion
         assertEquals("Escalation info present even if it shouldn't be", null, superuserWorkItem.getEscalationLevel());

--- a/model/certification-impl/src/test/java/com/evolveum/midpoint/certification/test/TestManualEscalation.java
+++ b/model/certification-impl/src/test/java/com/evolveum/midpoint/certification/test/TestManualEscalation.java
@@ -214,7 +214,7 @@ public class TestManualEscalation extends AbstractCertificationTest {
 
         // WHEN
         when();
-        AccessCertificationWorkItemType workItem = CertCampaignTypeUtil.findWorkItem(superuserCase, 1, 1, USER_ADMINISTRATOR_OID);
+        AccessCertificationWorkItemType workItem = findWorkItem(superuserCase, 1, 1, USER_ADMINISTRATOR_OID);
         long id = superuserCase.asPrismContainerValue().getId();
         certificationService.recordDecision(campaignOid, id, workItem.getId(), ACCEPT, "no comment", task, result);
 
@@ -268,7 +268,7 @@ public class TestManualEscalation extends AbstractCertificationTest {
         AccessCertificationCaseType ceoCase = findCase(caseList, USER_JACK_OID, ROLE_CEO_OID);
         display("CEO case after escalation", ceoCase);
 
-        AccessCertificationWorkItemType workItem = CertCampaignTypeUtil.findWorkItem(ceoCase, 1, 1, USER_ADMINISTRATOR_OID);
+        AccessCertificationWorkItemType workItem = findWorkItem(ceoCase, 1, 1, USER_ADMINISTRATOR_OID);
         assertObjectRefs("assignees", false, workItem.getAssigneeRef(), USER_JACK_OID, USER_ADMINISTRATOR_OID);
         assertEquals("Wrong originalAssignee OID", USER_ADMINISTRATOR_OID, workItem.getOriginalAssigneeRef().getOid());
         final WorkItemEscalationLevelType newEscalationLevel = new WorkItemEscalationLevelType().number(1).name("ESC-1");
@@ -313,7 +313,7 @@ public class TestManualEscalation extends AbstractCertificationTest {
 
         AccessCertificationCaseType ceoCase = findCase(caseList, USER_JACK_OID, ROLE_CEO_OID);
         display("CEO case after escalation", ceoCase);
-        AccessCertificationWorkItemType workItem = CertCampaignTypeUtil.findWorkItem(ceoCase, 1, 1, USER_ELAINE_OID);
+        AccessCertificationWorkItemType workItem = findWorkItem(ceoCase, 1, 1, USER_ELAINE_OID);
         assertNotNull("No work item found", workItem);
         assertObjectRefs("assignees", false, workItem.getAssigneeRef(), USER_ELAINE_OID);
         assertEquals("Wrong originalAssignee OID", USER_ADMINISTRATOR_OID, workItem.getOriginalAssigneeRef().getOid());
@@ -349,7 +349,7 @@ public class TestManualEscalation extends AbstractCertificationTest {
 
         // WHEN
         when();
-        AccessCertificationWorkItemType workItem = CertCampaignTypeUtil.findWorkItem(ceoCase, 1, 1, USER_ELAINE_OID);
+        AccessCertificationWorkItemType workItem = findWorkItem(ceoCase, 1, 1, USER_ELAINE_OID);
         long id = ceoCase.asPrismContainerValue().getId();
         DelegateWorkItemActionType action = new DelegateWorkItemActionType()
                 .approverRef(USER_ADMINISTRATOR_OID, UserType.COMPLEX_TYPE)
@@ -368,7 +368,7 @@ public class TestManualEscalation extends AbstractCertificationTest {
         ceoCase = findCase(caseList, USER_JACK_OID, ROLE_CEO_OID);
         display("CEO case after escalation", ceoCase);
         assertEquals("changed case ID", Long.valueOf(id), ceoCase.asPrismContainerValue().getId());
-        workItem = CertCampaignTypeUtil.findWorkItem(ceoCase, 1, 1, USER_ADMINISTRATOR_OID);
+        workItem = findWorkItem(ceoCase, 1, 1, USER_ADMINISTRATOR_OID);
         assertNotNull("No work item found", workItem);
         assertObjectRefs("assignees", false, workItem.getAssigneeRef(), USER_ADMINISTRATOR_OID, USER_JACK_OID);
         assertEquals("Wrong originalAssignee OID", USER_ADMINISTRATOR_OID, workItem.getOriginalAssigneeRef().getOid());

--- a/model/certification-impl/src/test/resources/common/certification-of-eroot-user-assignments-notifications.xml
+++ b/model/certification-impl/src/test/resources/common/certification-of-eroot-user-assignments-notifications.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0"?>
+<!--
+  ~ Copyright (c) 2010-2017 Evolveum and contributors
+  ~
+  ~ This work is dual-licensed under the Apache License 2.0
+  ~ and European Union Public License. See LICENSE file for details.
+  -->
+
+<accessCertificationDefinition
+        xmlns='http://midpoint.evolveum.com/xml/ns/public/common/common-3'
+        xmlns:q="http://prism.evolveum.com/xml/ns/public/query-3"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        oid="399e117a-baaa-4e59-b845-21bb838cb7bc">
+    <name>Basic User Assignment Certification (ERoot only) to test certification notifications</name>
+    <handlerUri>http://midpoint.evolveum.com/xml/ns/public/certification/handlers-3#direct-assignment</handlerUri>
+    <scopeDefinition xsi:type="AccessCertificationAssignmentReviewScopeType">
+        <objectType>UserType</objectType>
+        <searchFilter>
+            <q:org>
+                <q:orgRef>
+                    <q:oid>00000000-8888-6666-0000-300000000000</q:oid>
+                    <q:scope>SUBTREE</q:scope>
+                </q:orgRef>
+            </q:org>
+        </searchFilter>
+        <relation>default</relation>        <!-- the default -->
+    </scopeDefinition>
+    <remediationDefinition>
+        <style>reportOnly</style>
+    </remediationDefinition>
+    <stageDefinition>
+        <number>1</number>
+        <duration>P14D</duration>
+        <reviewerSpecification>
+            <useObjectManager>
+                <allowSelf>false</allowSelf>
+            </useObjectManager>
+            <reviewerExpression>
+                <script>
+                    <code><![CDATA[
+                        import com.evolveum.midpoint.xml.ns._public.common.common_3.ObjectReferenceType
+                        import com.evolveum.midpoint.xml.ns._public.common.common_3.UserType
+
+                        // If target is ERoot organization and object is Admin user
+                        if (certificationCase.getTargetRef().getOid().equals("00000000-8888-6666-0000-300000000000")
+                          && certificationCase.getObjectRef().getOid().equals("00000000-0000-0000-0000-000000000002")) {
+                            def jackReference = new ObjectReferenceType()
+                            jackReference.setOid("c0c010c0-d34d-b33f-f00d-111111111111")
+                            jackReference.setType(UserType.COMPLEX_TYPE)
+                            return jackReference
+                        }
+                        ]]></code>
+                </script>
+            </reviewerExpression>
+            <defaultReviewerRef oid="00000000-0000-0000-0000-000000000002" type="UserType" />   <!-- administrator -->
+            <additionalReviewerRef oid="c0c010c0-d34d-b33f-f00d-111111111134" type="UserType" /> <!-- bob -->
+        </reviewerSpecification>
+        <timedActions>
+            <time>
+                <value>P1D</value>
+            </time>
+            <actions>
+                <escalate>
+                    <approverRef oid="c0c010c0-d34d-b33f-f00d-111111111111" type="UserType"/>   <!-- jack -->
+                    <delegationMethod>addAssignees</delegationMethod>
+                    <escalationLevelName>jack-level</escalationLevelName>
+                </escalate>
+            </actions>
+        </timedActions>
+    </stageDefinition>
+</accessCertificationDefinition>

--- a/model/certification-impl/src/test/resources/common/user-bob.xml
+++ b/model/certification-impl/src/test/resources/common/user-bob.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
   ~ Copyright (c) 2010-2017 Evolveum and contributors
   ~
@@ -5,7 +6,8 @@
   ~ and European Union Public License. See LICENSE file for details.
   -->
 
-<user oid="c0c010c0-d34d-b33f-f00d-111111111134">
+<user oid="c0c010c0-d34d-b33f-f00d-111111111134"
+      xmlns="http://midpoint.evolveum.com/xml/ns/public/common/common-3">
     <name>bob</name>
     <parentOrgRef oid="00000000-8888-6666-0000-200000000002" type="OrgType"/>
     <assignment>

--- a/release-notes.adoc
+++ b/release-notes.adoc
@@ -1,10 +1,10 @@
 ---
 layout: release
-release-version: '4.9.1'
+release-version: '4.9.2'
 visibility: hidden
 ---
-= MidPoint 4.9.1 "Verne" - Update 1
-:release-version: 4.9.1
+= MidPoint 4.9.2 "Verne" - Update 2
+:release-version: 4.9.2
 :page-visibility: hidden
 :page-liquid:
 :page-toc: top
@@ -34,6 +34,10 @@ Overall, midPoint 4.9 is a major step from the past into the future.
 {% endcapture %}
 {% include release-dedication.html content=dedicationContent %}
 ++++
+
+== Changes with Respect To Version 4.9.1
+
+* bug:MID-10225[] Fix issue where opening of certification campaign stage hangs indefinitely.
 
 == Changes with Respect To Version 4.9
 


### PR DESCRIPTION
**What**

Optimize and simplify the queries (and code) used to select reviewers who should receive "required review" notifications.

**Why**

The previous implementation tended to cause opening of certification campaign stages to hang indefinitely\*. These freezes seem to be caused by a large number of inserts followed by more complex select.

It looks like rapid inserts causes need for the DB to do vacuum/analyze operations, but those operations are run periodically with certain delay. If the select operation hits the DB before the "autovacuuming" period (called nap time) elapses, it may appear to freeze\* in the DB without any sign of real activity.

Lowering the "autovacuum nap time" configuration option seems to mitigate this issue. By default, this option is set to 1 minute. During local testing, setting it to 10 seconds helped (although this was only limited manual testing).

\*We are not sure if this freeze is just temporary and the select would eventually finish or if it gets stuck forever.

**Notes**

Originally, the `notifyReviewers` method executed two queries. The first query was simple and did not cause any issues. However, the second query, which involved joins over three different tables (or in fact, nested selects in an `exists` clause), caused problems.

After several iterations, I decided to use a single query to load all cases with open work items, map these to reviewers in code, and then send notifications based on that mapping. Open work items are those whose `closeTimestamp` is null, generally meaning they belong to the currently opened stage.

This approach has pros and cons:

**Disadvantages:**
- Loads a large number of cases into memory
- Filtering happens in code (no fancy index optimizations)

**Advantages:**
- Only one DB round trip (though technically not entirely true due to iterative search)
- Much simpler query
- The same cases are not read more than once for reviewers with open work items

Note that when a notification is sent, all of the reviewer's cases from the current stage are included, not just those where the reviewer has work items without replies. This is one of the reasons I chose to load all the cases.

Regarding the iterative search, in this case it probably has only one benefit and that is it does not have limit on number of returned items in total. The non iterative search has limit of 10 000 records.

**Fixes**: MID-10225

(cherry picked from commit 16293b749feba5031a5aa3543988eba980e7ac0e)