### PR TITLE
Various improvements to resource wizard and sync task GUIdes

### DIFF
--- a/docs/admin-gui/resource-wizard/configuration-resource-panels.adoc
+++ b/docs/admin-gui/resource-wizard/configuration-resource-panels.adoc
@@ -2,6 +2,7 @@
 :page-since: "4.9"
 :page-visibility: hidden
 
-== Configuration of resource wizard panels
+== Configuration of Resource Wizard Panels
 
-Some wizard panels are configurable, for more information see xref:/midpoint/reference/admin-gui/admin-gui-config/#wizard-panels[Wizard panels].
+Some wizard panels are configurable.
+See xref:/midpoint/reference/admin-gui/admin-gui-config/#wizard-panels[Wizard panels] for more information.

--- a/docs/admin-gui/resource-wizard/create-resource-using-wizard.adoc
+++ b/docs/admin-gui/resource-wizard/create-resource-using-wizard.adoc
@@ -152,4 +152,4 @@ With the resource created and configured, continue with the configuration furthe
 
 :sectnums!:
 
-include::how-to-use-lifecycle-state.adoc[]
+include::see-also.adoc[]

--- a/docs/admin-gui/resource-wizard/limitation-all.adoc
+++ b/docs/admin-gui/resource-wizard/limitation-all.adoc
@@ -1,14 +1,13 @@
 :page-toc: top
-:page-since: "4.9"
 :page-visibility: hidden
 
 == Limitations
 
-Resource wizard has several limitations as of midPoint 4.8, such as:
+Resource wizard has several limitations, such as:
 
-* expression editor supports `As is`, `Script`, `Literal` and `Generate` expressions only
-* xref:/midpoint/reference/expressions/mappings/range/[mapping ranges] are not supported
-* xref:/midpoint/reference/expressions/mappings/#mapping-domain[mapping domains] are not supported
-* correlation configuration currently supports only xref:/midpoint/reference/correlation/items-correlator/[]
+* Expression editor supports _As is_, _Script_, _Literal_ and _Generate_ expressions only.
+* xref:/midpoint/reference/expressions/mappings/range/[Mapping ranges] are not supported.
+* xref:/midpoint/reference/expressions/mappings/#mapping-domain[Mapping domains] are not supported.
+* Correlation configuration currently supports xref:/midpoint/reference/correlation/items-correlator/[] only.
 
-midPoint resource wizard won't be able to show or allow editing of these features but should tolerate them and keep them in the configuration.
+MidPoint resource wizard can't show or edit these features but tolerates them and keeps them untouched if you configure them in XML.

--- a/docs/admin-gui/resource-wizard/limitation-all.adoc
+++ b/docs/admin-gui/resource-wizard/limitation-all.adoc
@@ -8,6 +8,6 @@ Resource wizard has several limitations, such as:
 * Expression editor supports _As is_, _Script_, _Literal_ and _Generate_ expressions only.
 * xref:/midpoint/reference/expressions/mappings/range/[Mapping ranges] are not supported.
 * xref:/midpoint/reference/expressions/mappings/#mapping-domain[Mapping domains] are not supported.
-* Correlation configuration currently supports xref:/midpoint/reference/correlation/items-correlator/[] only.
+* Correlation configuration currently supports xref:/midpoint/reference/correlation/items-correlator/[the `items` correlator] only.
 
 MidPoint resource wizard can't show or edit these features but tolerates them and keeps them untouched if you configure them in XML.

--- a/docs/admin-gui/resource-wizard/object-type/activation/index.adoc
+++ b/docs/admin-gui/resource-wizard/object-type/activation/index.adoc
@@ -67,8 +67,6 @@ This can be used during xref:/midpoint/reference/admin-gui/simulations/[Simulati
 
 Click btn:[Save settings] when done to return to the previous page from which you started the activation editor.
 
-include::../../configuration-resource-panels.adoc[]
-
-include::../../how-to-use-lifecycle-state.adoc[]
-
 include::../../limitation-all.adoc[]
+
+include::../../see-also.adoc[]

--- a/docs/admin-gui/resource-wizard/object-type/credentials/index.adoc
+++ b/docs/admin-gui/resource-wizard/object-type/credentials/index.adoc
@@ -20,8 +20,6 @@ Click btn:[Save settings] when done to return to the previous page from which yo
 
 NOTE: You don't need any credentials mappings if you are not managing the passwords in the resource (e.g. if you are using SSO with another system).
 
-include::../../configuration-resource-panels.adoc[]
+include::../../limitation-all.adoc[]
 
-include::../../how-to-use-lifecycle-state.adoc[]
-
-include::../../limitation-mapping.adoc[]
+include::../../see-also.adoc[]

--- a/docs/admin-gui/resource-wizard/object-type/index.adoc
+++ b/docs/admin-gui/resource-wizard/object-type/index.adoc
@@ -6,7 +6,7 @@
 :page-display-order: 20
 
 In midPoint, configuring object types is the key to defining the structure of different identity objects, such as users, roles, and resources.
-This guide is here to guide you through the basic steps involved in setting up object types.
+This guide describes the basic steps involved in setting up object types.
 It also provides links to follow-up materials for more advanced configurations.
 
 You can configure the object types for xref:/midpoint/reference/resources/resource-configuration/schema-handling/[schema handling], essentially defining the behavior of midPoint with respect to the resource.
@@ -41,7 +41,7 @@ Define the basic information about the object type.
 * *Default*: Specifies if the provided intent should be used as a default in case you define multiple intents for the same object kind.
 	Select `True` if you use only a single intent.
 * *Lifecycle state*: Set to _Proposed_ before you finish the setup and test it.
-	Refer to the xref:#how-to-use-lifecycle-state[brief guide on using lifecycle states] for more details.
+	Refer to the xref:/midpoint/reference/concepts/object-lifecycle/[] for more details.
 
 Click btn:[Next: Resource data] to continue to the next object type configuration screen.
 
@@ -145,8 +145,6 @@ After you confirm whether your settings produce expected results, you can choose
 * xref:./credentials/[Credentials]: Configure mappings for credentials (e.g., passwords).
 * xref:./policies/[Policies]: Configure the resource operation policies.
 
-include::../configuration-resource-panels.adoc[]
-
-include::../how-to-use-lifecycle-state.adoc[]
-
 include::../limitation-all.adoc[]
+
+include::../see-also.adoc[]

--- a/docs/admin-gui/resource-wizard/object-type/mapping/index.adoc
+++ b/docs/admin-gui/resource-wizard/object-type/mapping/index.adoc
@@ -109,8 +109,6 @@ This is useful to override attribute visibility, its display name, tolerance etc
 | image::step-2-mappings-override-detail-limitations.png[link=step-2-mappings-override-detail-limitations.png, 100%, title=Detailed configuration of attribute override - limitations configuration]
 |===
 
-include::../../configuration-resource-panels.adoc[]
+include::../../limitation-all.adoc[]
 
-include::../../how-to-use-lifecycle-state.adoc[]
-
-include::../../limitation-mapping.adoc[]
+include::../../see-also.adoc[]

--- a/docs/admin-gui/resource-wizard/object-type/policies/index.adoc
+++ b/docs/admin-gui/resource-wizard/object-type/policies/index.adoc
@@ -24,6 +24,4 @@ image::step-8-marking.png[link=step-8-marking.png,100%,title=Configuration of ma
 
 Click btn:[Save marking rules] when done to return to the previous page from which you started the marking editor.
 
-include::../../configuration-resource-panels.adoc[]
-
-include::../../how-to-use-lifecycle-state.adoc[]
+include::../../see-also.adoc[]

--- a/docs/admin-gui/resource-wizard/object-type/synchronization/index.adoc
+++ b/docs/admin-gui/resource-wizard/object-type/synchronization/index.adoc
@@ -60,6 +60,4 @@ For non-authoritative target systems, though, you would probably want to use the
 
 Refer to xref:/midpoint/reference/schema/focus-and-projections/[] for an explanation of the term _focus_. In the most basic scenarios when synchronizing users and their accounts, _focus_ corresponds to the user object in midPoint.
 
-include::../../configuration-resource-panels.adoc[]
-
-include::../../how-to-use-lifecycle-state.adoc[]
+include::../../see-also.adoc[]

--- a/docs/admin-gui/resource-wizard/see-also.adoc
+++ b/docs/admin-gui/resource-wizard/see-also.adoc
@@ -1,0 +1,9 @@
+:page-toc: top
+:page-visibility: hidden
+
+== See Also
+
+Here are additional resources to explore:
+
+* xref:/midpoint/reference/concepts/object-lifecycle/[]: Gain a deeper understanding of object lifecycle management in midPoint.
+* xref:/midpoint/reference/admin-gui/admin-gui-config/#wizard-panels[]: See configuration options for certain wizard panels and the GUI in general.

--- a/docs/tasks/synchronization-tasks/import-and-reconciliation/gui.adoc
+++ b/docs/tasks/synchronization-tasks/import-and-reconciliation/gui.adoc
@@ -40,7 +40,14 @@ skip the steps that are not relevant for you.
 === Configuration
 
 On this screen, fill in the basic task attributes, such as the task name or a description of its purpose.
-We suggest giving the task a descriptive name so that you can easily recognize it later in the task list.
+
+We suggest giving the task a descriptive name so that you can easily recognize it later in the task list. +
+For example:
+
+* _HRIS import - preview : development_
+* _HRIS import - real : production_
+* _LDAP reconciliation - simulation_
+* _LDAP reconciliation - preview : production_
 
 Click btn:[Next: Resource objects] to continue to the next screen.
 
@@ -64,7 +71,7 @@ The mode and configuration give a fair number of options.
 Let's cover the basics here:
 
 * If you want to simulate and ensure the task doesn't modify data, select *Mode*: _Preview_ and *Predefined* (configuration): _Development_.
-* If you want to actually import, reconcile, or synchronize the objects (i.e., create focal objects for the resource objects), select *Mode*: _Undefined_ and *Predefined* (configuration): _Production_.
+* If you want to actually import, reconcile, or synchronize the objects, select *Mode*: _Undefined_ and *Predefined* (configuration): _Production_.
 
 Refer to these resources for more information on the topic:
 


### PR DESCRIPTION
This PR encompasses multiple loosely related changes: I updated the
Task GUIde with task naming examples and changed one wording to reflect
the GUIde is no longer about import tasks only (done in
3c411cf524b4b472007f21961f832076cee7ddf6 ). Furthermore, I removed
includes of the configuration panels and lifecycle summary in the
resource object wizard GUIdes because they are superfluous and
distracting. Instead, I linked the relevant articles. Lastly, I polished
the limitations-all.adoc and used that one in all the resource wizard
articles (except for correlation which is handles in another branch
currently) to make the limitations easier to manage, among other things.
