### PR TITLE
feat: add OAuth 2 credential flow to mail servers

### DIFF
--- a/docs/misc/notifications/configuration.adoc
+++ b/docs/misc/notifications/configuration.adoc
@@ -35,28 +35,45 @@ For the time being, here we show a sample configuration, hopefully self-explanat
         <name>main</name>
         <!-- There can be more servers if necessary; they are tried in the specified order. -->
         <server>
-            <host>smtp.gmail.com</host>
+            <host>smtp.outlook.com</host>
             <!--
             Specify port: 25, 587 (e.g. MS Exchange and TLS) or other based on your mail server.
             You can skip the port definition altogether to use default (25).
             -->
             <port>587</port>
-            <username>abc@gmail.com</username>
-            <password>
-                <clearValue>abcdef</clearValue>
-            </password>
-            <!-- Other transportSecurity options: none, starttlsEnabled, starttlsRequired -->
-            <transportSecurity>starttlsRequired</transportSecurity>
+            <auth>
+                <oauth2>
+                    <username>abc@myorg.onmicrosoft.com</username>
+                    <clientId>client-uuid</clientId>
+                    <clientSecret>
+                        <clearValue>abcdef</clearValue>
+                    </clientSecret>
+                    <tokenEndpoint>https://login.microsoftonline.com/tenant-uuid/oauth2/v2.0/token</tokenEndpoint>
+                    <scope>https://outlook.office365.com/.default</scope>
+                </oauth2>
+            </auth>
         </server>
 
-        <server> <!-- Second server -->
-           . . .
+        <server> <!-- Second server using basic auth -->
+            <host>smtp.gmail.com</host>
+            <port>587</port>
+            <auth>
+                <basic>
+                    <username>abc@gmail.com</username>
+                    <password>
+                        <clearValue>abcdef</clearValue>
+                    </password>
+                    <!-- Other transportSecurity options: none, starttlsEnabled, starttlsRequired -->
+                    <transportSecurity>starttlsRequired</transportSecurity>
+                </basic>
+            </auth>
         </server>
         <server> <!-- Third server -->
            . . .
         </server>
 
-        <defaultFrom>abc@gmail.com</defaultFrom>
+        <!-- the mailbox used to send emails from -->
+        <defaultFrom>abc@myorg.com</defaultFrom>
         <!-- standard javax.mail debugging; it is going to stdout (midpoint.out)! -->
         <debug>true</debug>
         <!--
@@ -70,6 +87,8 @@ For the time being, here we show a sample configuration, hopefully self-explanat
 
 *Ensure your SMTP server will accept multiple connection (message rate limit)* as midPoint notifications are being sent as the objects are created, e.g. one user can have 15 accounts or one organization 40 entitlements created at the same time.
 This is especially important for Microsoft Exchange, where the default limit seems to be very low (5 connections per minute).
+
+Please note that although the OAuth 2 configuration should work with all providers that have support for client credentials flow, it has been tested on Microsoft O365 only.
 
 Also please note that SSL-related settings for mail messaging are currently experimental (e.g. there is no support for setting certificate validation-related properties; default behavior of `javax.mail` implementation is used).
 You may also need to store the mail server self-signed SSL certificate in your Java "cacerts" keystore.

--- a/infra/schema/src/main/resources/xml/ns/public/common/common-notifications-3.xsd
+++ b/infra/schema/src/main/resources/xml/ns/public/common/common-notifications-3.xsd
@@ -440,9 +440,83 @@
                 <xsd:annotation>
                     <xsd:documentation>
                         How to authenticate to the mail server.
+
+                        DEPRECATED: use new MailAuthenticationType instead.
                     </xsd:documentation>
                     <xsd:appinfo>
                         <a:displayName>MailServerConfigurationType.username</a:displayName>
+                        <a:deprecated>true</a:deprecated>
+                        <a:deprecatedSince>4.10</a:deprecatedSince>
+                        <a:plannedRemoval>5.0</a:plannedRemoval><!-- TODO: check version or remove -->
+                    </xsd:appinfo>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="password" type="t:ProtectedStringType" minOccurs="0">
+                <xsd:annotation>
+                    <xsd:documentation>
+                        How to authenticate to the mail server.
+
+                        DEPRECATED: use new MailAuthenticationType instead.
+                    </xsd:documentation>
+                    <xsd:appinfo>
+                        <a:displayName>MailServerConfigurationType.password</a:displayName>
+                        <a:deprecated>true</a:deprecated>
+                        <a:deprecatedSince>4.10</a:deprecatedSince>
+                        <a:plannedRemoval>5.0</a:plannedRemoval><!-- TODO: check version or remove -->
+                    </xsd:appinfo>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="transportSecurity" type="tns:MailTransportSecurityType" minOccurs="0">
+                <xsd:annotation>
+                    <xsd:documentation>
+                        How to ensure transport-level security when sending the message.
+
+                        DEPRECATED: use new MailAuthenticationType instead.
+                    </xsd:documentation>
+                    <xsd:appinfo>
+                        <a:displayName>MailServerConfigurationType.transportSecurity</a:displayName>
+                        <a:deprecated>true</a:deprecated>
+                        <a:deprecatedSince>4.10</a:deprecatedSince>
+                        <a:plannedRemoval>5.0</a:plannedRemoval><!-- TODO: check version or remove -->
+                    </xsd:appinfo>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="auth" type="tns:MailAuthenticationType" minOccurs="0"/>
+        </xsd:sequence>
+    </xsd:complexType>
+
+    <xsd:complexType name="MailAuthenticationType">
+        <xsd:annotation>
+            <xsd:documentation>
+                Configuration of a particular mail server authentication.
+            </xsd:documentation>
+            <xsd:appinfo>
+                <a:displayName>MailAuthenticationType.details</a:displayName>
+            </xsd:appinfo>
+        </xsd:annotation>
+        <xsd:choice>
+            <xsd:element name="basic" type="tns:BasicAuthenticationType"/>
+            <xsd:element name="oauth2" type="tns:OAuth2CredentialsType"/>
+        </xsd:choice>
+    </xsd:complexType>
+
+    <xsd:complexType name="BasicAuthenticationType">
+        <xsd:annotation>
+            <xsd:documentation>
+                Configuration of a username/password based authentication.
+            </xsd:documentation>
+            <xsd:appinfo>
+                <a:displayName>BasicAuthenticationType.details</a:displayName>
+            </xsd:appinfo>
+        </xsd:annotation>
+        <xsd:sequence>
+            <xsd:element name="username" type="xsd:string" minOccurs="0">
+                <xsd:annotation>
+                    <xsd:documentation>
+                        How to authenticate to the mail server.
+                    </xsd:documentation>
+                    <xsd:appinfo>
+                        <a:displayName>BasicAuthenticationType.username</a:displayName>
                     </xsd:appinfo>
                 </xsd:annotation>
             </xsd:element>
@@ -452,7 +526,7 @@
                         How to authenticate to the mail server.
                     </xsd:documentation>
                     <xsd:appinfo>
-                        <a:displayName>MailServerConfigurationType.password</a:displayName>
+                        <a:displayName>BasicAuthenticationType.password</a:displayName>
                     </xsd:appinfo>
                 </xsd:annotation>
             </xsd:element>
@@ -462,7 +536,72 @@
                         How to ensure transport-level security when sending the message.
                     </xsd:documentation>
                     <xsd:appinfo>
-                        <a:displayName>MailServerConfigurationType.transportSecurity</a:displayName>
+                        <a:displayName>BasicAuthenticationType.transportSecurity</a:displayName>
+                    </xsd:appinfo>
+                </xsd:annotation>
+            </xsd:element>
+        </xsd:sequence>
+    </xsd:complexType>
+
+    <xsd:complexType name="OAuth2CredentialsType">
+        <xsd:annotation>
+            <xsd:documentation>
+                Configuration of OAuth 2.0 authentication.
+
+                EXPERIMENTAL, tested for O365.
+            </xsd:documentation>
+            <xsd:appinfo>
+                <a:displayName>OAuth2CredentialsType.details</a:displayName>
+            </xsd:appinfo>
+        </xsd:annotation>
+        <xsd:sequence>
+            <xsd:element name="username" type="xsd:string">
+                <xsd:annotation>
+                    <xsd:documentation>
+                        User on the authentication server.
+                    </xsd:documentation>
+                    <xsd:appinfo>
+                        <a:displayName>OAuth2CredentialsType.username</a:displayName>
+                    </xsd:appinfo>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="clientId" type="xsd:string">
+                <xsd:annotation>
+                    <xsd:documentation>
+                        Client ID from the authentication server.
+                    </xsd:documentation>
+                    <xsd:appinfo>
+                        <a:displayName>OAuth2CredentialsType.clientId</a:displayName>
+                    </xsd:appinfo>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="clientSecret" type="t:ProtectedStringType">
+                <xsd:annotation>
+                    <xsd:documentation>
+                        Client secret from the authentication server.
+                    </xsd:documentation>
+                    <xsd:appinfo>
+                        <a:displayName>OAuth2CredentialsType.clientSecret</a:displayName>
+                    </xsd:appinfo>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="tokenEndpoint" type="xsd:anyURI">
+                <xsd:annotation>
+                    <xsd:documentation>
+                        URL where midpoint can obtain access tokens.
+                    </xsd:documentation>
+                    <xsd:appinfo>
+                        <a:displayName>OAuth2CredentialsType.tokenEndpoint</a:displayName>
+                    </xsd:appinfo>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="scope" type="xsd:string">
+                <xsd:annotation>
+                    <xsd:documentation>
+                        Scope to be requested, for example "https://outlook.office365.com/.default" for o365.
+                    </xsd:documentation>
+                    <xsd:appinfo>
+                        <a:displayName>OAuth2CredentialsType.scope</a:displayName>
                     </xsd:appinfo>
                 </xsd:annotation>
             </xsd:element>
@@ -2334,7 +2473,7 @@
                     <xsd:element name="server" type="tns:MailServerConfigurationType" minOccurs="0" maxOccurs="unbounded">
                         <xsd:annotation>
                             <xsd:documentation>
-                                Configuration of a particular mail server host. If there are more of them, they are tried
+                                Configuration of a particular smtp server host. If there are more of them, they are tried
                                 one after another. If there is none, mail messages are not sent.
                             </xsd:documentation>
                             <xsd:appinfo>

--- a/model/authentication-impl/src/main/java/com/evolveum/midpoint/authentication/impl/OAuth2TokenRetrievalException.java
+++ b/model/authentication-impl/src/main/java/com/evolveum/midpoint/authentication/impl/OAuth2TokenRetrievalException.java
@@ -1,0 +1,7 @@
+package com.evolveum.midpoint.authentication.impl;
+
+public class OAuth2TokenRetrievalException extends Exception {
+    public OAuth2TokenRetrievalException(String message) {
+        super(message);
+    }
+}

--- a/model/authentication-impl/src/main/java/com/evolveum/midpoint/authentication/impl/util/OAuth2TokenService.java
+++ b/model/authentication-impl/src/main/java/com/evolveum/midpoint/authentication/impl/util/OAuth2TokenService.java
@@ -1,0 +1,52 @@
+package com.evolveum.midpoint.authentication.impl.util;
+
+import com.evolveum.midpoint.authentication.impl.OAuth2TokenRetrievalException;
+import com.evolveum.midpoint.xml.ns._public.common.common_3.OAuth2CredentialsType;
+import org.springframework.security.oauth2.client.AuthorizedClientServiceOAuth2AuthorizedClientManager;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClient;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientManager;
+import org.springframework.security.oauth2.client.OAuth2AuthorizeRequest;
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
+import org.springframework.security.oauth2.client.registration.InMemoryClientRegistrationRepository;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientService;
+import org.springframework.security.oauth2.client.InMemoryOAuth2AuthorizedClientService;
+import org.springframework.security.oauth2.core.AuthorizationGrantType;
+
+/**
+ * Utility class for OAuth2 token retrieval using Spring Security's OAuth2 client infrastructure.
+ */
+public class OAuth2TokenService {
+
+    public static final String REGISTRATION_ID = "mail-oauth2";
+
+    /**
+     * Retrieves an OAuth2 access token using client credentials flow.
+     */
+    public static String getAccessToken(OAuth2CredentialsType oauth2Credentials, String clientSecret) throws OAuth2TokenRetrievalException {
+        ClientRegistration clientRegistration = ClientRegistration.withRegistrationId(REGISTRATION_ID)
+                .clientId(oauth2Credentials.getClientId())
+                .clientSecret(clientSecret)
+                .tokenUri(oauth2Credentials.getTokenEndpoint())
+                .authorizationGrantType(AuthorizationGrantType.CLIENT_CREDENTIALS)
+                .scope(oauth2Credentials.getScope())
+                .build();
+
+        InMemoryClientRegistrationRepository repo = new InMemoryClientRegistrationRepository(clientRegistration);
+        OAuth2AuthorizedClientService service = new InMemoryOAuth2AuthorizedClientService(repo);
+        OAuth2AuthorizedClientManager manager = new AuthorizedClientServiceOAuth2AuthorizedClientManager(repo, service);
+
+        OAuth2AuthorizeRequest authorizeRequest = OAuth2AuthorizeRequest.withClientRegistrationId(REGISTRATION_ID)
+                .principal(oauth2Credentials.getUsername())
+                .build();
+
+        OAuth2AuthorizedClient authorizedClient = manager.authorize(authorizeRequest);
+        if (authorizedClient == null) {
+            throw new OAuth2TokenRetrievalException("Failed to authorize client");
+        }
+        if (authorizedClient.getAccessToken() == null) {
+            throw new OAuth2TokenRetrievalException("Failed to retrieve access token");
+        }
+
+        return authorizedClient.getAccessToken().getTokenValue();
+    }
+}

--- a/model/notifications-impl/pom.xml
+++ b/model/notifications-impl/pom.xml
@@ -67,6 +67,11 @@
         </dependency>
         <dependency>
             <groupId>com.evolveum.midpoint.model</groupId>
+            <artifactId>authentication-impl</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.evolveum.midpoint.model</groupId>
             <artifactId>cases-api</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/model/notifications-impl/src/main/java/com/evolveum/midpoint/transport/impl/MailMessageTransport.java
+++ b/model/notifications-impl/src/main/java/com/evolveum/midpoint/transport/impl/MailMessageTransport.java
@@ -42,6 +42,8 @@ import com.evolveum.midpoint.util.logging.TraceManager;
 import com.evolveum.midpoint.xml.ns._public.common.common_3.*;
 import com.evolveum.prism.xml.ns._public.types_3.ProtectedStringType;
 import com.evolveum.prism.xml.ns._public.types_3.RawType;
+import com.evolveum.midpoint.authentication.impl.OAuth2TokenRetrievalException;
+import com.evolveum.midpoint.authentication.impl.util.OAuth2TokenService;
 
 /**
  * Message transport sending mail messages.
@@ -67,7 +69,6 @@ public class MailMessageTransport implements Transport<MailTransportConfiguratio
 
     @Override
     public void send(Message mailMessage, String transportName, SendingContext ctx, OperationResult parentResult) {
-
         OperationResult result = parentResult.createSubresult(DOT_CLASS + "send");
         result.addArbitraryObjectCollectionAsParam("mailMessage recipient(s)", mailMessage.getTo());
         result.addParam("mailMessage subject", mailMessage.getSubject());
@@ -77,16 +78,34 @@ public class MailMessageTransport implements Transport<MailTransportConfiguratio
             TransportUtil.logToFile(logToFile, formatToFileOld(mailMessage), LOGGER);
         }
         String redirectToFile = configuration.getRedirectToFile();
-        int optionsForFilteringRecipient = TransportUtil.optionsForFilteringRecipient(configuration);
+        if (redirectToFile != null && TransportUtil.optionsForFilteringRecipient(configuration) == 0) {
+            TransportUtil.appendToFile(redirectToFile, formatToFileOld(mailMessage), LOGGER, result);
+            return;
+        }
 
+        filterAndSetRecipients(mailMessage, ctx, result);
+
+        if (isRecipientsOrServersEmpty(mailMessage, result)) {
+            return;
+        }
+
+        sendViaMailServers(mailMessage, ctx, result);
+    }
+
+    /**
+     * Filters recipients using {@link TransportUtil#validateRecipient(List, List, List, GeneralTransportConfigurationType, Task, OperationResult, ExpressionFactory, ExpressionProfile, Trace)
+     * TransportUtil.validateRecipient()} and assigns them to the mailMessage parameter.
+     */
+    private void filterAndSetRecipients(Message mailMessage, SendingContext ctx, OperationResult result) {
+        int optionsForFilteringRecipient = TransportUtil.optionsForFilteringRecipient(configuration);
         List<String> allowedRecipientTo = new ArrayList<>();
         List<String> forbiddenRecipientTo = new ArrayList<>();
         List<String> allowedRecipientCc = new ArrayList<>();
         List<String> forbiddenRecipientCc = new ArrayList<>();
         List<String> allowedRecipientBcc = new ArrayList<>();
         List<String> forbiddenRecipientBcc = new ArrayList<>();
-
         var task = ctx.task();
+        String redirectToFile = configuration.getRedirectToFile();
         if (optionsForFilteringRecipient != 0) {
             TransportUtil.validateRecipient(allowedRecipientTo, forbiddenRecipientTo,
                     mailMessage.getTo(), configuration, task, result,
@@ -109,26 +128,28 @@ public class MailMessageTransport implements Transport<MailTransportConfiguratio
                 mailMessage.setCc(allowedRecipientCc);
                 mailMessage.setBcc(allowedRecipientBcc);
             }
-
-        } else if (redirectToFile != null) {
-            TransportUtil.appendToFile(redirectToFile, formatToFileOld(mailMessage), LOGGER, result);
-            return;
         }
+    }
 
+    /**
+     * Validates presence of at least one recipient and mail server and logs whichever fails.
+     *
+     * @return true if any check fails, otherwise false
+     */
+    private boolean isRecipientsOrServersEmpty(Message mailMessage, OperationResult result) {
+        int optionsForFilteringRecipient = TransportUtil.optionsForFilteringRecipient(configuration);
         if (optionsForFilteringRecipient != 0 && mailMessage.getTo().isEmpty()) {
             String msg = "No recipient found after recipient validation.";
             LOGGER.debug(msg);
             result.recordSuccess();
-            return;
+            return true;
         }
-
         if (configuration.getServer().isEmpty()) {
             String msg = "Mail server(s) are not defined, mail notification to " + mailMessage.getTo() + " will not be sent.";
             LOGGER.warn(msg);
             result.recordWarning(msg);
-            return;
+            return true;
         }
-
         Collection<String> actualTo = filterBlankMailRecipients(mailMessage.getTo(), "to", mailMessage.getSubject());
         Collection<String> actualCc = filterBlankMailRecipients(mailMessage.getCc(), "cc", mailMessage.getSubject());
         Collection<String> actualBcc = filterBlankMailRecipients(mailMessage.getBcc(), "bcc", mailMessage.getSubject());
@@ -136,25 +157,172 @@ public class MailMessageTransport implements Transport<MailTransportConfiguratio
             String msg = "No recipients found after excluding blank ones; the message will not be sent";
             LOGGER.warn(msg);
             result.recordWarning(msg);
-            return;
+            return true;
         }
+        return false;
+    }
 
+    /**
+     * Tries to compose the email and send it via each server configuration until first success.
+     */
+    private void sendViaMailServers(Message mailMessage, SendingContext ctx, OperationResult result) {
+        Collection<String> actualTo = filterBlankMailRecipients(mailMessage.getTo(), "to", mailMessage.getSubject());
+        Collection<String> actualCc = filterBlankMailRecipients(mailMessage.getCc(), "cc", mailMessage.getSubject());
+        Collection<String> actualBcc = filterBlankMailRecipients(mailMessage.getBcc(), "bcc", mailMessage.getSubject());
         long start = System.currentTimeMillis();
-
-        String defaultFrom = configuration.getDefaultFrom() != null ? configuration.getDefaultFrom() : "nobody@nowhere.org";
+        boolean sent = false;
+        var task = ctx.task();
 
         for (MailServerConfigurationType mailServerConfigurationType : configuration.getServer()) {
-
             OperationResult resultForServer = result.createSubresult(DOT_CLASS + "send.forServer");
             final String host = mailServerConfigurationType.getHost();
+            MailAuthenticationType mailAuthenticationType = mailServerConfigurationType.getAuth();
+            final boolean isBasicAuth = mailAuthenticationType == null || mailAuthenticationType.getBasic() != null;
             resultForServer.addContext("server", host);
             resultForServer.addContext("port", mailServerConfigurationType.getPort());
+            resultForServer.addContext("auth_type", isBasicAuth ? "basic" : "oauth2");
 
             Properties properties = System.getProperties();
             properties.setProperty("mail.smtp.host", host);
             if (mailServerConfigurationType.getPort() != null) {
                 properties.setProperty("mail.smtp.port", String.valueOf(mailServerConfigurationType.getPort()));
             }
+
+            defineTransportSecurity(mailServerConfigurationType, properties, isBasicAuth);
+
+            if (Boolean.TRUE.equals(configuration.isDebug())) {
+                properties.put("mail.debug", "true");
+            }
+            if (LOGGER.isDebugEnabled()) {
+                LOGGER.debug("Using mail properties: ");
+                for (Object key : properties.keySet()) {
+                    if (key instanceof String && ((String) key).startsWith("mail.")) {
+                        LOGGER.debug(" - {} = {}", key, properties.get(key));
+                    }
+                }
+            }
+            task.recordStateMessage("Sending notification mail via " + host);
+            Session session = Session.getInstance(properties);
+
+            try {
+                MimeMessage mimeMessage = composeMimeMessage(session, mailMessage, actualTo, actualCc, actualBcc);
+                if (mimeMessage == null) {
+                    return;
+                }
+
+                try (jakarta.mail.Transport t = session.getTransport("smtp")) {
+                    if (isBasicAuth) {
+                        authenticateViaBasicAuth(mailServerConfigurationType, actualTo, host, resultForServer, t);
+                    } else {
+                        authenticateViaOauth(mailAuthenticationType, actualTo, host, resultForServer, t);
+                    }
+
+                    if (t.isConnected()) {
+                        t.sendMessage(mimeMessage, mimeMessage.getAllRecipients());
+                        t.close();
+                        LOGGER.debug("Message sent successfully to " + actualTo + " via server " + host + ".");
+                        resultForServer.recordSuccess();
+                        result.recordSuccess();
+                        long duration = System.currentTimeMillis() - start;
+                        task.recordStateMessage("Notification mail sent successfully via " + host + ", in " + duration + " ms overall.");
+                        task.recordNotificationOperation(name, true, duration);
+                        sent = true;
+                        break;
+                    }
+                }
+            } catch (MessagingException e) {
+                String msg = "Couldn't send mail message to " + actualTo + " via " + host + ", trying another mail server, if there is any.";
+                LoggingUtils.logException(LOGGER, msg, e);
+                resultForServer.recordFatalError(msg, e);
+                task.recordStateMessage("Error sending notification mail via " + host);
+            }
+        }
+
+        if (!sent) {
+            LOGGER.warn("No more mail servers to try, mail notification to " + actualTo + " will not be sent.");
+            result.recordWarning("Mail notification to " + actualTo + " could not be sent.");
+            task.recordNotificationOperation(name, false, System.currentTimeMillis() - start);
+        }
+    }
+
+    /**
+     * Either connects to the smtp server using the Oauth2 client credentials flow or logs reason for failure.
+     */
+    private void authenticateViaOauth(MailAuthenticationType auth, Collection<String> actualTo, String host, OperationResult resultForServer, jakarta.mail.Transport t) throws MessagingException {
+        ProtectedStringType clientSecretProtected = auth.getOauth2().getClientSecret();
+        if (clientSecretProtected == null) {
+            String msg = "Couldn't send mail message to " + actualTo + " via " + host + ", because the client secret is not set. Trying another mail server, if there is any.";
+            LOGGER.error(msg);
+            resultForServer.recordFatalError(msg);
+            return;
+        }
+
+        String clientSecret;
+        try {
+            clientSecret = transportSupport.protector().decryptString(clientSecretProtected);
+        } catch (EncryptionException e) {
+            String msg = "Couldn't send mail message to " + actualTo + " via " + host + ", because the plaintext client secret value couldn't be obtained. Trying another mail server, if there is any.";
+            LoggingUtils.logException(LOGGER, msg, e);
+            resultForServer.recordFatalError(msg, e);
+            return;
+        }
+
+        LOGGER.debug(
+                "Attempting OAuth2 authentication for user {} on endpoint {}",
+                auth.getOauth2().getUsername(),
+                auth.getOauth2().getTokenEndpoint()
+        );
+
+        String accessToken;
+        try {
+            accessToken = OAuth2TokenService.getAccessToken(auth.getOauth2(), clientSecret);
+        } catch (OAuth2TokenRetrievalException e) {
+            String msg = "Couldn't send mail message to " + actualTo + " via " + host + ", because the server didn't return the access token. Trying another mail server, if there is any.";
+            LoggingUtils.logException(LOGGER, msg, e);
+            resultForServer.recordFatalError(msg, e);
+            return;
+        }
+
+        LOGGER.debug(
+                "OAuth2 authentication successful for user {} on endpoint {}",
+                auth.getOauth2().getUsername(),
+                auth.getOauth2().getTokenEndpoint()
+        );
+
+        t.connect(host, configuration.getDefaultFrom(), accessToken);
+    }
+
+    /**
+     * Either connects to the smtp server using the basic authentication or logs reason for failure.
+     */
+    private void authenticateViaBasicAuth(MailServerConfigurationType mailServerConfigurationType, Collection<String> actualTo, String host, OperationResult resultForServer, jakarta.mail.Transport t) throws MessagingException {
+        BasicAuthenticationType basicAuth = mailServerConfigurationType.getAuth().getBasic();
+        String username = (basicAuth != null) ? basicAuth.getUsername() : mailServerConfigurationType.getUsername();
+        ProtectedStringType passwordProtected = (basicAuth != null) ? basicAuth.getPassword() : mailServerConfigurationType.getPassword();
+
+        if (StringUtils.isNotEmpty(username)) {
+            String password = null;
+            if (passwordProtected != null) {
+                try {
+                    password = transportSupport.protector().decryptString(passwordProtected);
+                } catch (EncryptionException e) {
+                    String msg = "Couldn't send mail message to " + actualTo + " via " + host + ", because the plaintext password value couldn't be obtained. Trying another mail server, if there is any.";
+                    LoggingUtils.logException(LOGGER, msg, e);
+                    resultForServer.recordFatalError(msg, e);
+                    return;
+                }
+            }
+            t.connect(mailServerConfigurationType.getUsername(), password);
+        } else {
+            t.connect();
+        }
+    }
+
+    /**
+     * Sets correct properties (http headers) for given authentication type.
+     */
+    private void defineTransportSecurity(MailServerConfigurationType mailServerConfigurationType, Properties properties, boolean isBasicAuth) {
+        if (isBasicAuth) {
             MailTransportSecurityType mailTransportSecurityType = mailServerConfigurationType.getTransportSecurity();
 
             boolean sslEnabled = false, starttlsEnable = false, starttlsRequired = false;
@@ -172,144 +340,97 @@ public class MailMessageTransport implements Transport<MailTransportConfiguratio
                         break;
                 }
             }
-            properties.put("mail.smtp.ssl.enable", "" + sslEnabled);
-            properties.put("mail.smtp.starttls.enable", "" + starttlsEnable);
-            properties.put("mail.smtp.starttls.required", "" + starttlsRequired);
-            if (Boolean.TRUE.equals(configuration.isDebug())) {
-                properties.put("mail.debug", "true");
-            }
+            properties.put("mail.smtp.ssl.enable", String.valueOf(sslEnabled));
+            properties.put("mail.smtp.starttls.enable", String.valueOf(starttlsEnable));
+            properties.put("mail.smtp.starttls.required", String.valueOf(starttlsRequired));
+        } else {
+            properties.put("mail.smtp.auth", "true");
+            properties.put("mail.smtp.auth.mechanisms", "XOAUTH2");
+            properties.put("mail.smtp.starttls.enable", "true");
+        }
+    }
 
-            if (LOGGER.isDebugEnabled()) {
-                LOGGER.debug("Using mail properties: ");
-                for (Object key : properties.keySet()) {
-                    if (key instanceof String && ((String) key).startsWith("mail.")) {
-                        LOGGER.debug(" - {} = {}", key, properties.get(key));
+    /**
+     * Either creates MimeMessage or logs reason for failure.
+     *
+     * @return null if an expected error occurs, MimeMessage otherwise
+     */
+    private MimeMessage composeMimeMessage(Session session, Message mailMessage, Collection<String> actualTo, Collection<String> actualCc, Collection<String> actualBcc) throws MessagingException {
+        MimeMessage mimeMessage = new MimeMessage(session);
+        mimeMessage.setSentDate(new Date());
+        String defaultFrom = configuration.getDefaultFrom() != null ? configuration.getDefaultFrom() : "nobody@nowhere.org";
+        String from = mailMessage.getFrom() != null ? mailMessage.getFrom() : defaultFrom;
+        mimeMessage.setFrom(new InternetAddress(from));
+        for (String recipient : actualTo) {
+            mimeMessage.addRecipient(jakarta.mail.Message.RecipientType.TO, new InternetAddress(recipient));
+        }
+        for (String recipientCc : actualCc) {
+            mimeMessage.addRecipient(jakarta.mail.Message.RecipientType.CC, new InternetAddress(recipientCc));
+        }
+        for (String recipientBcc : actualBcc) {
+            mimeMessage.addRecipient(jakarta.mail.Message.RecipientType.BCC, new InternetAddress(recipientBcc));
+        }
+        mimeMessage.setSubject(mailMessage.getSubject(), StandardCharsets.UTF_8.name());
+        String contentType = mailMessage.getContentType();
+        if (StringUtils.isEmpty(contentType)) {
+            contentType = "text/plain; charset=UTF-8";
+        }
+        BodyPart messageBody = new MimeBodyPart();
+        messageBody.setContent(mailMessage.getBody(), contentType);
+        Multipart multipart = new MimeMultipart();
+        multipart.addBodyPart(messageBody);
+        for (NotificationMessageAttachmentType attachment : mailMessage.getAttachments()) {
+            if (attachment.getContent() != null || attachment.getContentFromFile() != null) {
+                String fileName;
+                BodyPart attachmentBody = new MimeBodyPart();
+                if (attachment.getContent() != null) {
+                    try {
+                        Object content = RawType.getValue(attachment.getContent());
+                        if (content == null) {
+                            throw new SchemaException();
+                        }
+                        attachmentBody.setContent(content, attachment.getContentType());
+                    } catch (SchemaException e) {
+                        LOGGER.warn("RawType " + attachment.getContent() + " isn't possible to parse.");
+                        return null;
                     }
-                }
-            }
-
-            task.recordStateMessage("Sending notification mail via " + host);
-
-            Session session = Session.getInstance(properties);
-
-            try {
-                MimeMessage mimeMessage = new MimeMessage(session);
-                mimeMessage.setSentDate(new Date());
-                String from = mailMessage.getFrom() != null ? mailMessage.getFrom() : defaultFrom;
-                mimeMessage.setFrom(new InternetAddress(from));
-
-                for (String recipient : actualTo) {
-                    mimeMessage.addRecipient(jakarta.mail.Message.RecipientType.TO, new InternetAddress(recipient));
-                }
-                for (String recipientCc : actualCc) {
-                    mimeMessage.addRecipient(jakarta.mail.Message.RecipientType.CC, new InternetAddress(recipientCc));
-                }
-                for (String recipientBcc : actualBcc) {
-                    mimeMessage.addRecipient(jakarta.mail.Message.RecipientType.BCC, new InternetAddress(recipientBcc));
-                }
-                mimeMessage.setSubject(mailMessage.getSubject(), StandardCharsets.UTF_8.name());
-                String contentType = mailMessage.getContentType();
-                if (StringUtils.isEmpty(contentType)) {
-                    contentType = "text/plain; charset=UTF-8";
-                }
-                BodyPart messageBody = new MimeBodyPart();
-                messageBody.setContent(mailMessage.getBody(), contentType);
-                Multipart multipart = new MimeMultipart();
-                multipart.addBodyPart(messageBody);
-                for (NotificationMessageAttachmentType attachment : mailMessage.getAttachments()) {
-
-                    if (attachment.getContent() != null || attachment.getContentFromFile() != null) {
-                        String fileName;
-                        BodyPart attachmentBody = new MimeBodyPart();
-                        if (attachment.getContent() != null) {
-                            try {
-                                Object content = RawType.getValue(attachment.getContent());
-                                if (content == null) {
-                                    LOGGER.warn("RawType " + attachment.getContent() + " isn't possible to parse.");
-                                    return;
-                                }
-                                attachmentBody.setContent(content, attachment.getContentType());
-                            } catch (SchemaException e) {
-                                LOGGER.warn("RawType " + attachment.getContent() + " isn't possible to parse.");
-                                return;
-                            }
-                            if (StringUtils.isBlank(attachment.getFileName())) {
-                                fileName = "attachment";
-                            } else {
-                                fileName = attachment.getFileName();
-                            }
-                        } else {
-                            if (!Files.isReadable(Paths.get(attachment.getContentFromFile()))) {
-                                LOGGER.warn("File " + attachment.getContentFromFile() + " non exist or isn't readable.");
-                                return;
-                            }
-
-                            DataSource source = new FileDataSource(attachment.getContentFromFile()) {
-                                @Override
-                                public String getContentType() {
-                                    return attachment.getContentType();
-                                }
-                            };
-                            attachmentBody.setDataHandler(new DataHandler(source));
-                            if (StringUtils.isBlank(attachment.getFileName())) {
-                                fileName = source.getName();
-                            } else {
-                                fileName = attachment.getFileName();
-                            }
-                        }
-
-                        if (!fileName.contains(".")) {
-                            fileName += MimeTypeUtil.getExtension(attachment.getContentType());
-                        }
-                        attachmentBody.setFileName(fileName);
-                        if (!StringUtils.isBlank(attachment.getContentId())) {
-                            attachmentBody.setHeader("Content-ID", attachment.getContentId());
-                        }
-
-                        multipart.addBodyPart(attachmentBody);
+                    if (StringUtils.isBlank(attachment.getFileName())) {
+                        fileName = "attachment";
                     } else {
-                        LOGGER.warn("NotificationMessageAttachmentType doesn't contain content.");
+                        fileName = attachment.getFileName();
                     }
-                }
-
-                mimeMessage.setContent(multipart);
-                try (jakarta.mail.Transport t = session.getTransport("smtp")) {
-                    if (StringUtils.isNotEmpty(mailServerConfigurationType.getUsername())) {
-                        ProtectedStringType passwordProtected = mailServerConfigurationType.getPassword();
-                        String password = null;
-                        if (passwordProtected != null) {
-                            try {
-                                password = transportSupport.protector().decryptString(passwordProtected);
-                            } catch (EncryptionException e) {
-                                String msg = "Couldn't send mail message to " + actualTo + " via " + host + ", because the plaintext password value couldn't be obtained. Trying another mail server, if there is any.";
-                                LoggingUtils.logException(LOGGER, msg, e);
-                                resultForServer.recordFatalError(msg, e);
-                                continue;
-                            }
+                } else {
+                    if (!Files.isReadable(Paths.get(attachment.getContentFromFile()))) {
+                        LOGGER.warn("File " + attachment.getContentFromFile() + " non exist or isn't readable.");
+                        return null;
+                    }
+                    DataSource source = new FileDataSource(attachment.getContentFromFile()) {
+                        @Override
+                        public String getContentType() {
+                            return attachment.getContentType();
                         }
-                        t.connect(mailServerConfigurationType.getUsername(), password);
+                    };
+                    attachmentBody.setDataHandler(new DataHandler(source));
+                    if (StringUtils.isBlank(attachment.getFileName())) {
+                        fileName = source.getName();
                     } else {
-                        t.connect();
+                        fileName = attachment.getFileName();
                     }
-                    t.sendMessage(mimeMessage, mimeMessage.getAllRecipients());
-                    LOGGER.debug("Message sent successfully to " + actualTo + " via server " + host + ".");
-                    resultForServer.recordSuccess();
-                    result.recordSuccess();
-                    long duration = System.currentTimeMillis() - start;
-                    task.recordStateMessage("Notification mail sent successfully via " + host + ", in " + duration + " ms overall.");
-                    task.recordNotificationOperation(name, true, duration);
                 }
-                return;
-            } catch (MessagingException e) {
-                String msg = "Couldn't send mail message to " + actualTo + " via " + host + ", trying another mail server, if there is any";
-                LoggingUtils.logException(LOGGER, msg, e);
-                resultForServer.recordFatalError(msg, e);
-                task.recordStateMessage("Error sending notification mail via " + host);
+                if (!fileName.contains(".")) {
+                    fileName += MimeTypeUtil.getExtension(attachment.getContentType());
+                }
+                attachmentBody.setFileName(fileName);
+                if (!StringUtils.isBlank(attachment.getContentId())) {
+                    attachmentBody.setHeader("Content-ID", attachment.getContentId());
+                }
+                multipart.addBodyPart(attachmentBody);
+            } else {
+                LOGGER.warn("NotificationMessageAttachmentType doesn't contain content.");
             }
         }
-        LOGGER.warn("No more mail servers to try, mail notification to " + actualTo + " will not be sent.");
-        result.recordWarning("Mail notification to " + actualTo + " could not be sent.");
-        task.recordNotificationOperation(name, false, System.currentTimeMillis() - start);
+        mimeMessage.setContent(multipart);
+        return mimeMessage;
     }
 
     @Override


### PR DESCRIPTION
Extend xml schema, deprecate original auth fields (need to check planned removal).
Refactor MailMessageTransport class.
Add custom error OAuth2TokenRetrievalException and utility class OAuth2TokenService.
Add oauth2 credential flow to MailMessageTransport.

Tested on two different outlook servers.