### PR TITLE
Docs/master/fix/update redirected xrefs.20250806

### DIFF
--- a/docs/tasks/synchronization-tasks/asynchronous-update.adoc
+++ b/docs/tasks/synchronization-tasks/asynchronous-update.adoc
@@ -42,7 +42,7 @@ we want to process updates for. The `resourceRef` is obligatory, all the other p
 
 The default behavior of Asynchronous update activity is to _stop_ when an error is encountered.
 This is to ensure that no information is lost in such cases. This behavior can be changed via
-custom xref:/midpoint/reference/tasks/task-error-handling/[error handling specification].
+custom xref:/midpoint/reference/tasks/activities/error-handling/[error handling specification].
 
 == See Also
 

--- a/docs/tasks/synchronization-tasks/live-synchronization.adoc
+++ b/docs/tasks/synchronization-tasks/live-synchronization.adoc
@@ -88,4 +88,4 @@ with `preciseTokenValue` = `true`, i.e. that it assigns sync tokens to individua
 
 The default behavior of Live synchronization activity is to _stop_ when an error is encountered.
 This is to ensure that no information is lost in such cases. This behavior can be changed via
-custom xref:/midpoint/reference/tasks/task-error-handling/[error handling specification].
+custom xref:/midpoint/reference/tasks/activities/error-handling/[error handling specification].

--- a/release-notes.adoc
+++ b/release-notes.adoc
@@ -80,8 +80,8 @@ This can be used for approval of indirect role assignments and similar cases. Se
 * There are two new functions in midPoint function library for access to "governance" users (approvers/owners): `getRoleMemberUsers`, `getServiceMemberUsers`.
 * Use delta's "visualizer" used by GUI also in notifications and other improvements in notifications. See bug:MID-6112[], bug:MID-10633[], bug:MID-10632[], bug:MID-10635[], bug:MID-10372[], bug:MID-10634[], bug:MID-10636[].
 * Built-in archetypes for organizational structures and locations.
-* xref:/midpoint/reference/roles-policies/identity-governance-rules/[Compliance-related] marks (no classification, unowned, privileged access), object collections and policies.
-* xref:/midpoint/reference/roles-policies/privileged-access/[`Privileged access` classification] automatically sets `Privileged access` mark for directly affected roles and users.
+* xrefv:/midpoint/reference/master/roles-policies/identity-governance-rules/[Compliance-related] marks (no classification, unowned, privileged access), object collections and policies.
+* xrefv:/midpoint/reference/master/roles-policies/privileged-access/[`Privileged access` classification] automatically sets `Privileged access` mark for directly affected roles and users.
 * Updated various libraries, mainly: Spring Boot, Tomcat, Hibernate, PostgresSQL JDBC driver.
 * Add OAuth 2 credential flow to mail servers notification configuration
 


### PR DESCRIPTION
- Update xref paths to reflect redirects specified in `:page-moved-from:`
(The file under the old path still exists and is accessible on localhost 
Jekyll which doesn't handle redirects. I will fix this soon™.)
- Attempt a temporary fix in release notes for 4.10 to avoid Jekyll 
complaints about invalid link. 
The linked page exists currently only in master. Live web redirects the
link correctly but Jekyll doesn't work with htaccess files and thinks it
leads to 404 on <4.9, apparently (which it would, but web solves it byt
using master in the rendered link). So, until we make the structural
changes also in 4.9 and 4.8, I opted for this dirty fix with xrefv.
