### PR TITLE
Updated cron example in index.adoc

### DIFF
--- a/docs/tasks/task-manager/index.adoc
+++ b/docs/tasks/task-manager/index.adoc
@@ -163,7 +163,7 @@ MidPoint currently supports two styles of schedule definition for recurring task
 
 * Interval-based scheduling repeats a task every N seconds.
 * Cron-like scheduling provides the ability to specify starting times using a link:https://en.wikipedia.org/wiki/Cron[cron expression].
-    ** For example, to schedule a task to run every Sunday at 03:45, you would use the following pattern: `45 03 * * 7` (minute: 45, hour: 3, day: any, month: any, week day: 7 (Sunday)).
+    ** For example, to schedule a task to run every Sunday at 03:45, you would use the following pattern: `0 45 03 ? * 7` (second: 0, minute: 45, hour: 3, day: any, month: any, week day: 7 (Sunday)).
     ** For more information on these expressions, see the link:https://www.quartz-scheduler.org/documentation/quartz-2.3.0/tutorials/crontrigger.html[Quartz documentation].
 
 ==== Recurring Tasks Can Be Tightly or Loosely Bound


### PR DESCRIPTION
Fixed the cron example to include seconds and day-of-month, based on Quartz examples. 

The existing cron example does not work within midPoint, based on experience with 4.9. The existing example is based on standard cron, but I was getting Quartz repository errors within midPoint when I copied and modified the example into "Schedule/Cron-like pattern" configuration of a task.

I have tested the new example within our instance of midPoint 4.9 and verified that it would function as the example states it should. The task would run at 3:45AM every Sunday.