### PR TITLE
Docs/4.8/improve/explain task with bucketing resume behavior

### DIFF
--- a/docs/tasks/task-manager/index.adoc
+++ b/docs/tasks/task-manager/index.adoc
@@ -284,14 +284,14 @@ For tasks with no threads allocated when their node goes down (loosely bound rec
 These tasks simply wait until their next start time comes. See also <<misfire-action,misfire action>>.
 
 .Task behavior on resume
-[INFO]
+[NOTE]
 ====
 When you resume (i.e., restart) a scheduled recurring task after it has been interrupted, it starts immediately.
 
 If you have your *task segmented to buckets* using
-`<distribution><buckets><oidSegmentation /></buckets></segmentation>`, for instance,
+`<distribution><buckets>…</buckets></segmentation>`, for instance,
 the task *resumes on the bucket boundary*, meaning it starts with the first not-yet-processed bucket.
-If the task failed to process all buckets during the previous run,
+If the task failed to process all the buckets during the previous run,
 it continues with the buckets it has not touched yet.
 It does not reprocess the buckets already processed during the last run.
 

--- a/docs/tasks/task-manager/index.adoc
+++ b/docs/tasks/task-manager/index.adoc
@@ -124,7 +124,7 @@ _Business states are to be covered in the Documentation in more detail._
         After the approval is obtained and the operation is executed, the task finishes and is closed.
     ** Single-run tasks may start
         either immediately after you create them
-        or according to a defined schedule. 
+        or according to a defined schedule.
 * Other tasks have to be repeated.
     Such tasks are *recurring*.
     ** Examples of recurring tasks include live synchronization (scheduled to run, e.g., every 5 seconds)
@@ -282,6 +282,23 @@ The restart and reschedule options make the task resilient, the suspend and clos
 
 For tasks with no threads allocated when their node goes down (loosely bound recurring tasks and scheduled single-run tasks), the `threadStopAction` attribute has no effect.
 These tasks simply wait until their next start time comes. See also <<misfire-action,misfire action>>.
+
+.Task behavior on resume
+[INFO]
+====
+When you resume (i.e., restart) a scheduled recurring task after it has been interrupted, it starts immediately.
+
+If you have your *task segmented to buckets* using
+`<distribution><buckets><oidSegmentation /></buckets></segmentation>`, for instance,
+the task *resumes on the bucket boundary*, meaning it starts with the first not-yet-processed bucket.
+If the task failed to process all buckets during the previous run,
+it continues with the buckets it has not touched yet.
+It does not reprocess the buckets already processed during the last run.
+
+Conversely, if you do not segment the task,
+the work is in one large bucket.
+On task resume, if the task has not finished processing the bucket previously, it starts all over again.
+====
 
 === Is It OK to Make Tasks Non-resilient?
 


### PR DESCRIPTION
Explain task resume behavior
    
    Explain in detail the difference between resuming an interrupted segmented and non-segmented task. This work is inspired by the
    confusion and subsequent explanation in https://support.evolveum.com/wp/10496 .