### PR TITLE
Docs/4.9/move/dead shadow concept intro

### DIFF
--- a/docs/resources/shadow/dead.adoc
+++ b/docs/resources/shadow/dead.adoc
@@ -7,59 +7,10 @@
 :page-wiki-metadata-modify-date: 2018-08-06T14:25:39.119+02:00
 :page-upkeep-status: yellow
 
-== Introduction
+Dead shadows in midPoint are remnants of deleted accounts, helping prevent their accidental re-creation and ensuring data consistency.
+Discover how to use them to maintain system integrity and troubleshoot potential issues.
 
-Ordinary xref:../[shadow objects] in midPoint represent existing resource-side objects, such as accounts and groups.
-However, sometimes there is a need to represent non-existing objects, such as accounts that were recently deleted.
-We refer to such objects as _dead shadows_.
-
-Dead shadows are very similar to ordinary "live" shadows.
-They have identifiers, metadata, resource reference, kind, intent and all the other details.
-The data are mostly "frozen" in time at the moment that the corresponding resource object (e.g. account) was deleted.
-Dead shadows has a boolean flag `dead` set to true value, to clearly distinguish them.
-
-Dead shadows are usually kept in midPoint for some time.
-There are several reasons for this behavior:
-
-* Diagnostics. Dead shadows contain information about the operation that have deleted the resource object.
-If we would just delete the shadow, there would be no place to store that information.
-Dead shadows give administrator a chance to diagnose problems with delete operations.
-
-* Pending operations: manual and semi-manual resources.
-Manual resource are very slow.
-It may take days for an operation to complete.
-The state of the operation is usually kept in the shadow.
-However, this is tricky to do for delete operations.
-Once the delete operation is completed, the shadow should be gone.
-However, for semi-manual resources, even if the delete operation is completed, the deleted account will still be present in the CSV export for hours or even days.
-We need to remember that the account was deleted recently.
-Otherwise midPoint could think that the account was re-created in the meantime, and it can re-issue a command to delete the account again.
-Dead shadows are kept to make sure that this does not happen.
-
-* Consistency mechanism.
-MidPoint may discover that a resource object has disappeared.
-For example, midPoint tries to read an account linked to a user, discovering that the account was deleted in the meantime.
-MidPoint will usually try to re-create the account.
-However, new account means new shadow, as internal identifiers (e.g. `entryUUID` or `GUID`) may be different for re-created account.
-The new account does not contain any information about the old account.
-However, the old information may be useful, e.g. to investigate the case _why_ has the original account disappeared.
-Hence the old information is kept in the dead shadow.
-
-* Handling weird delete-and-recreate situations.
-MidPoint provisioning subsystem can be quite fast, perhaps a bit too fast in some situations.
-Incorrectly configured midPoint could try to delete an account, and immediately re-create it.
-This kind of problems is usually very difficult to diagnose, as the resulting situation looks quite normal.
-However, dead shadows are an evidence that something strange happened.
-
-* Future potential.
-MidPoint has to be prepared to co-exist with many kinds of resource, from well-behaving centralized databases to all kind of weird distributed monstrosities that have never heard about CAP theorem.
-There may be temporary fluctuations in data.
-For example, in case of a distributed database, an account may be successfuly deleted on one node.
-However, the following read operation may be directed to a different node, where the previous delete operation was not propagated yet.
-In that case midPoint might naively think that the account was re-created, while the truth is that is has received an outdated data.
-Dead shadows may be helpful in detecting such situations.
-MidPoint might be able to realize that this information is outdated and resolve the situation.
-Such functionality is not present in midPoint yet, but it may come in the future.
+Refer to xref:/midpoint/architecture/concepts/shadow/dead-shadow/[] for more details on what dead shadows are and why they exist.
 
 == Managing Dead Shadows
 

--- a/docs/resources/shadow/dead.adoc
+++ b/docs/resources/shadow/dead.adoc
@@ -36,7 +36,7 @@ However, if there is need to completely disable the _dead shadow_ functionality,
 * There must be at most one "live" shadow for each resource object (account).
 There may be any number of dead shadows.
 
-* Shadows are never reused.
+* Dead shadows are never reused.
 
 ** Once shadow is dead it stays dead.
 There is no way to resurrect it.

--- a/docs/resources/shadow/index.adoc
+++ b/docs/resources/shadow/index.adoc
@@ -39,6 +39,8 @@ Resource Object Shadows are also called simply "shadows" or "shadow objects".
 
 |===
 
+Refer to xref:/midpoint/architecture/concepts/shadow/[] to learn more about the concept of shadows.
+
 Following figure illustrates the way how user, shadows and resource objects work together.
 User (`<user>`) and account shadow (`<account>`) are midPoint objects stored in midPoint identity repository.
 More precisely only the parts shown in black are stored in the repository, the parts shown in blue and fetched from the resource on demand.

--- a/docs/resources/shadow/index.adoc
+++ b/docs/resources/shadow/index.adoc
@@ -1,4 +1,4 @@
-= Shadow Objects
+= Shadow objects
 :page-wiki-name: Shadow Objects
 :page-wiki-id: 655431
 :page-wiki-metadata-create-user: semancik
@@ -6,79 +6,76 @@
 :page-wiki-metadata-modify-user: semancik
 :page-wiki-metadata-modify-date: 2013-02-04T19:17:24.173+01:00
 :page-upkeep-status: orange
+// TODO: many links here lead to architecture/archive. We need to revise the article and update references.
 
-midPoint works with two distinct concepts that represent objects on the resources such as accounts, groups, permissions, etc.
+MidPoint works with two distinct concepts that represent objects on the resources, such as accounts, groups, permissions, etc.
+These concepts are resource objects and their connected resource object shadows.
 
-* *Resource Objects* are real objects on the target resources.
+* *Resource objects* are real objects on the target resources.
 These are LDAP entries, lines in `/etc/passwd` files, database rows, etc.
-Access to Resource Objects is provided by provisioning frameworks such as Identity Connectors, OpenPTK or other.
+Access to resource objects is provided by provisioning frameworks such as xref:/connectors/[identity connectors], OpenPTK, or others.
 
-* *Resource Object Shadows* are objects in IDM repository.
-There are short pieces of XML that usually contain basic information about resource object and are just pointer to the real resource objects.
-The shadows may cache the information from resource objects to speed up access.
-How much or how little information is kept in the shadow objects is a specified by system (resource) configuration.
-Resource Object Shadows are also called simply "shadows" or "shadow objects".
+* *Resource object shadows* are objects in an IDM repository.
+They are short pieces of XML that usually contain basic information about the related resource object and are just pointers to the real resource object.
+Resource object shadows may cache the information from their particular resource object to speed up information access.
+How much or how little information is cached in the resource object shadow is specified by system (resource) configuration.
+Resource object shadows are also called simply "shadows" or "shadow objects".
 
 [%autowidth]
 |===
 |  Type  |  Stored in  |  Identified by  |  Schema  |  Content
 
-|  Resource Object
-|  natively on resource
-|  any identifier
-|  any schema
-|  all resource object data
+|  Resource object
+|  Natively on the resource
+|  Any identifier
+|  Any schema
+|  All resource object data
 
-
-|  Resource Object Shadow
-|  local IDM repository
+|  Resource object shadow
+|  Local midPoint repository database
 |  OID
-|  fixed midPoint schema
-|  common resource object data
-
+|  Fixed midPoint schema
+|  Common resource object data
 
 |===
 
 Refer to xref:/midpoint/architecture/concepts/shadow/[] to learn more about the concept of shadows.
 
-Following figure illustrates the way how user, shadows and resource objects work together.
-User (`<user>`) and account shadow (`<account>`) are midPoint objects stored in midPoint identity repository.
-More precisely only the parts shown in black are stored in the repository, the parts shown in blue and fetched from the resource on demand.
-User and account shadow objects are _linked_. It means that the user is an _owner_ of the specified account.
-User and all owned accounts are xref:/midpoint/reference/synchronization/introduction/[synchronized] using xref:/midpoint/reference/expressions/mappings/inbound-mapping/[inbound] and xref:/midpoint/reference/expressions/mappings/outbound-mapping/[outbound] expressions.
+== How object references work in midPoint
+
+The figure below illustrates the way how references between user, shadows connected to the user, and the resource objects represented by the shadows work together.
+
+The user (`<user>`) and account shadow (`<account>`) objects are midPoint objects stored in midPoint repository database.
+More precisely only the parts shown in black are stored in the repository, the parts in blue are fetched from the resource on demand.
 
 image::schemas-shadow.png[]
 
+User and account shadow objects are _linked_. It means that the user is an _owner_ of the specified account.
+User and all accounts owned by the user are xref:/midpoint/reference/synchronization/introduction/[synchronized] using xref:/midpoint/reference/expressions/mappings/inbound-mapping/[inbound] and xref:/midpoint/reference/expressions/mappings/outbound-mapping/[outbound] mappings.
 
-
-Shadows are automatically "synchronized" with resource objects.
 A change of a shadow results in a change of a resource object.
 In fact, shadows are little more than a projections of resource objects.
-Only the most important parts of a shadow are stored in midPoint identity repository.
-Usually only the identifiers are stored and therefore the shadow acts as a "mapping" object between xref:/midpoint/devel/prism/concepts/object-identifier/[OID] and native identifiers (e.g. LDAP DN, UUID, ...).
+Only the most important parts of a shadow are stored in midPoint repository.
+Usually, only the identifiers are stored and therefore the shadow acts as a "mapping" object between xref:/midpoint/devel/prism/concepts/object-identifier/[OID] and native resource identifiers (e.g. LDAP DN, UUID, ...).
 
+== What is the structure of a resource object shadow
 
-== Resource Object Shadow
+Resource object shadows have a fixed schema.
+They are defined in xref:/midpoint/architecture/archive/data-model/midpoint-common-schema/[midPoint common schema] and are (indirect) subtypes of xref:/midpoint/devel/prism/schema/[object].
+Therefore they are identified by xref:/midpoint/devel/prism/concepts/object-identifier/[OID], can be stored in the repository, the client code may use a `name` property as a human-readable name, etc.
+In short, they are usual identity objects in the midPoint system.
 
-Resource Object Shadows have a fixed schema.
-Resource Object Shadows are defined in xref:/midpoint/architecture/archive/data-model/midpoint-common-schema/[MidPoint Common Schema] and are (indirect) subtypes of xref:/midpoint/devel/prism/schema/[Object]. Therefore they are identified by xref:/midpoint/devel/prism/concepts/object-identifier/[OID], can be stored in the repository, the client code may use a `name` property as a human-readable name, etc.
-To make it short, they are usual identity objects in the midPoint system.
-
-Resource Object Shadows have one additional extensibility point: the `attributes` element.
-This element is used to store attributes of the object that are not fixed to midPoint static schema.
+Resource object shadows have one additional extensibility point: the `attributes` element.
+This element is used to store attributes of the resource object that are not fixed to midPoint static schema.
 Attributes that are fetched from the resource may be stored in this element.
-Attributes that can have different form and different meaning for each individual resource instance.
-The schema for the `attributes` element is not fixed, it is just `xsd:any` wildcard.
-However we assume that all the elements under the `attributes` tag will be in a form of xref:/midpoint/devel/prism/schema/[properties].
+These attributes can have different form and different meaning for each individual resource instance.
+The schema for the `attributes` element is not fixed, it is just an `xsd:any` wild card.
+However, midPoint expects that all the elements under the `attributes` tag are in the form of xref:/midpoint/devel/prism/schema/[properties].
 
-The name for "shadow" object was chosen from the lack of better names.
-We wanted to avoid "replica", "copy", "proxy" or similar heavily-overloaded terms.
-We also wanted to make sure that the shadow objects will not get confused with the real resource objects.
+=== Resource object shadow example
 
-
-=== Resource Object Shadow Example
-
-Following form of shadow object is provided by the xref:/midpoint/architecture/archive/subsystems/provisioning/provisioning-service-interface/[Provisioning Service Interface]. It has most of the interesting attributes that were probably freshly fetched from the resource.
+The following form of shadow object is provided by the xref:/midpoint/architecture/archive/subsystems/provisioning/provisioning-service-interface/[provisioning service interface].
+It has most of the interesting attributes that were probably freshly fetched from the resource.
 
 .Shadow object when retrieved from provisioning
 [source,xml]
@@ -99,7 +96,7 @@ Following form of shadow object is provided by the xref:/midpoint/architecture/a
 
 ----
 
-Following form of shadow object will be stored in the repository.
+The following form of shadow object will be stored in the repository.
 It contains only the very basic information, usually only the identifiers.
 It may contain cached data as well, but that is not mandatory.
 
@@ -118,34 +115,35 @@ It may contain cached data as well, but that is not mandatory.
 
 ----
 
-Default namespace in both examples points to the xref:/midpoint/architecture/archive/data-model/midpoint-common-schema/[MidPoint Common Schema]. The `ds1` prefix is bound to the resource schema namespace, schema specific to the resource instance.
+Default namespace in both examples points to the xref:/midpoint/architecture/archive/data-model/midpoint-common-schema/[midPoint common schema]. The `ds1` prefix is bound to the resource schema namespace, schema specific to the resource instance.
 See the xref:/midpoint/reference/resources/resource-schema/[Resource Schema] page for more details.
 
-
-== Resource Object
+== Resource object
 
 Resource objects are native objects on the resource represented as XML.
-They have no fixed structure, except that they should be constructed from xref:/midpoint/devel/prism/schema/[properties]. They are quite formless because we cannot predict all the possible objects that a target resource can have and may be interesting to identity management.
+They have no fixed structure, except that they should be constructed from xref:/midpoint/devel/prism/schema/[properties].
+They are quite formless because we cannot predict all the possible objects that a target resource can have and may be interesting to identity management.
 There may be _projects_, _workgroups-that-are-almost-but-not-quite-entirely-unlike-organizational-units_, _server clusters_, _coffee machines_, _kangaroos_, or any other type of objects that we cannot imagine now.
 
 Resource objects will not be stored in midPoint repository.
 They cannot as they have no fixed structure and therefore they have no OID.
 Resource objects are not directly used by stock midPoint logic.
 Stock midPoint code always works with shadow objects, not resource objects.
-As resource objects have no fixed schema it is very difficult to write _generic_ code that work with them.
-Resource objects are more like necessary evil than something that we really want in IDM system.
+As resource objects have no fixed schema, it is very difficult to write _generic_ code that would work with them.
+Resource objects are more like necessary evil than something that we really want in an IDM system.
 The sole purpose of resource objects is to be available to customized business logic.
 
 [NOTE]
 ====
-The operation that work with resource objects are not yet implemented in provisioning interface.
+The operations that work with resource objects are not yet implemented in provisioning interface.
 
 ====
 
 
-=== Resource Object Example
+=== Resource object example
 
-Following example shows the same object but represented as resource object using xref:/midpoint/reference/resources/resource-schema/[Resource Schema]. This is really not a typical example, it is provided here only for comparison with the shadow object.
+The following example shows the same object but represented as resource object using xref:/midpoint/reference/resources/resource-schema/[resource schema].
+This is really not a typical example, it is provided here only for comparison with the shadow object.
 
 .Resource Object
 [source,xml]
@@ -161,7 +159,7 @@ Following example shows the same object but represented as resource object using
 
 ----
 
-More "typical" example of resource object is provided below.
+More typical example of resource object is provided below.
 
 .Resource Object
 [source,xml]
@@ -176,31 +174,30 @@ More "typical" example of resource object is provided below.
 
 ----
 
-If it looks fictional it may be caused by the fact that it is fictional.
+If it looks fictional, it may be caused by the fact that it is fictional.
 If we could define appropriate type, stereotype or class of typical resource object that are found in IDM deployments now, we would do it.
 We would create appropriate (static) type of shadow objects for them.
-But, similarly to kangaroos that are not frequently used in IDM deployments, the resource objects are really designed only to support the unexpected, strange and exotic cases.
+But, similarly to the fact that kangaroos are not frequently used in IDM deployments, the resource objects are really designed only to support the unexpected, strange, and exotic cases.
 
+=== Resource object identification
 
-=== Resource Object Identification
-
-Resource object are identified by whatever native identifier is there.
-That may be DN for LDAP, username and groupname for traditional systems, numeric uids, guid, UUIDs, GUID, nsUniqueIds or even some combination of several identifiers.
+Resource objects are identified by whatever native identifier the resource uses.
+It may be `DN` for LDAP, `username` and `groupname` for traditional systems, numeric `uids`, `guid`, `UUIDs`, `GUID`, `nsUniqueIds` or even some combination of several identifiers.
 We cannot really dictate any fixed identifier type, format or scheme.
 
-Therefore we have chosen not choose a common identifier.
-Every connector will choose or suggest an identification mechanism for each resource object type.
-The connector will announce the identification mechanism in the xref:/midpoint/reference/resources/resource-schema/[Resource Schema] using the xref:/midpoint/reference/resources/resource-schema/[Resource Schema Annotations].
+Therefore, we have chosen not to choose a common identifier.
+Every connector will choose or suggest an identification mechanism for each the resource object type.
+The connector will announce the identification mechanism in the xref:/midpoint/reference/resources/resource-schema/[resource schema] using the xref:/midpoint/reference/resources/resource-schema/[resource schema annotations].
 
-[.red]#TODO: maybe an example?#
+// TODO: maybe an example?
 
 
 == See Also
 
 * xref:/midpoint/reference/resources/resource-schema/[]
 
-* xref:/midpoint/reference/resources/resource-configuration/schema-handling/[Resource Schema Handling]
+* xref:/midpoint/reference/resources/resource-configuration/schema-handling/[]
 
-* xref:/midpoint/reference/resources/resource-schema/explanation/[Resource and Connector Schema Explanation]
+* xref:/midpoint/reference/resources/resource-schema/explanation/[]
 
 * xref:/midpoint/reference/resources/shadow/purpose/[]

--- a/docs/resources/shadow/index.adoc
+++ b/docs/resources/shadow/index.adoc
@@ -1,4 +1,4 @@
-= Shadow objects
+= Shadow Objects
 :page-wiki-name: Shadow Objects
 :page-wiki-id: 655431
 :page-wiki-metadata-create-user: semancik
@@ -41,7 +41,7 @@ Resource object shadows are also called simply "shadows" or "shadow objects".
 
 Refer to xref:/midpoint/architecture/concepts/shadow/[] to learn more about the concept of shadows.
 
-== How object references work in midPoint
+== How Object References Work in MidPoint
 
 The figure below illustrates the way how references between user, shadows connected to the user, and the resource objects represented by the shadows work together.
 
@@ -58,7 +58,7 @@ In fact, shadows are little more than a projections of resource objects.
 Only the most important parts of a shadow are stored in midPoint repository.
 Usually, only the identifiers are stored and therefore the shadow acts as a "mapping" object between xref:/midpoint/devel/prism/concepts/object-identifier/[OID] and native resource identifiers (e.g. LDAP DN, UUID, ...).
 
-== What is the structure of a resource object shadow
+== What Is the Structure of a Resource Object Shadow
 
 Resource object shadows have a fixed schema.
 They are defined in xref:/midpoint/architecture/archive/data-model/midpoint-common-schema/[midPoint common schema] and are (indirect) subtypes of xref:/midpoint/devel/prism/schema/[object].
@@ -72,7 +72,7 @@ These attributes can have different form and different meaning for each individu
 The schema for the `attributes` element is not fixed, it is just an `xsd:any` wild card.
 However, midPoint expects that all the elements under the `attributes` tag are in the form of xref:/midpoint/devel/prism/schema/[properties].
 
-=== Resource object shadow example
+=== Resource Object Shadow Example
 
 The following form of shadow object is provided by the xref:/midpoint/architecture/archive/subsystems/provisioning/provisioning-service-interface/[provisioning service interface].
 It has most of the interesting attributes that were probably freshly fetched from the resource.
@@ -118,7 +118,7 @@ It may contain cached data as well, but that is not mandatory.
 Default namespace in both examples points to the xref:/midpoint/architecture/archive/data-model/midpoint-common-schema/[midPoint common schema]. The `ds1` prefix is bound to the resource schema namespace, schema specific to the resource instance.
 See the xref:/midpoint/reference/resources/resource-schema/[Resource Schema] page for more details.
 
-== Resource object
+== Resource Object
 
 Resource objects are native objects on the resource represented as XML.
 They have no fixed structure, except that they should be constructed from xref:/midpoint/devel/prism/schema/[properties].
@@ -140,7 +140,7 @@ The operations that work with resource objects are not yet implemented in provis
 ====
 
 
-=== Resource object example
+=== Resource Object Example
 
 The following example shows the same object but represented as resource object using xref:/midpoint/reference/resources/resource-schema/[resource schema].
 This is really not a typical example, it is provided here only for comparison with the shadow object.
@@ -179,7 +179,7 @@ If we could define appropriate type, stereotype or class of typical resource obj
 We would create appropriate (static) type of shadow objects for them.
 But, similarly to the fact that kangaroos are not frequently used in IDM deployments, the resource objects are really designed only to support the unexpected, strange, and exotic cases.
 
-=== Resource object identification
+=== Resource Object Identification
 
 Resource objects are identified by whatever native identifier the resource uses.
 It may be `DN` for LDAP, `username` and `groupname` for traditional systems, numeric `uids`, `guid`, `UUIDs`, `GUID`, `nsUniqueIds` or even some combination of several identifiers.


### PR DESCRIPTION
Move the dead shadow conceptual intro from `/midpoint/reference/resources/shadow/dead/` to the new article /midpoint/architecture/concepts/shadow/dead-shadow/ created in https://github.com/Evolveum/docs/pull/51 . This PR includes other minor fixes in the two main shadow-related articles. The articles are quite possibly rather outdated, though, so I didn't pour too much effort into them and leave that up to the one who does a propser check and refactoring.