### PR TITLE
Docs/4.9/remove/links on images

### DIFF
--- a/docs/admin-gui/resource-wizard/association-type/index.adoc
+++ b/docs/admin-gui/resource-wizard/association-type/index.adoc
@@ -13,13 +13,13 @@ Typically, this is used to configure how account/group membership is defined and
 
 After clicking on btn:[Configure association type], you will see a table of association types.
 
-image::association-type-table.png[link=association-type-table.png,100%,title=Table of association types]
+image::association-type-table.png[100%,title=Table of association types]
 
 Click btn:[Add association type] to start configuring new association type.
 
 The first step in creating a new association is to select the type of association (by clicking on it), which is predefined by capabilities or connector.
 
-image::choice-association-type.png[link=choice-association-type.png,100%,title=Select association]
+image::choice-association-type.png[100%,title=Select association]
 
 After selecting the association, you will see a four-step wizard. The first step allows you to configure the basic settings:
 
@@ -27,20 +27,20 @@ After selecting the association, you will see a four-step wizard. The first step
 * *Description* allows a short description to be entered
 * *Lifecycle state* allows defining the lifecycle state, e.g. `Proposed` for xref:/midpoint/reference/admin-gui/simulations/[simulation] of the association configuration
 
-image::step-1-association-type-basic-config.png[link=step-1-association-type-basic-config.png,100%,title=Basic configuration]
+image::step-1-association-type-basic-config.png[100%,title=Basic configuration]
 
 Click btn:[Next: Subjects] to continue in the association type definition wizard.
 
 In the second step you have to select the subject (as the object type of the resource) of the association.
 If there is only one option, it will be selected and you can proceed to the next step.
 
-image::step-1-select-subject.png[link=step-1-select-subject.png,100%,title=Select subject]
+image::step-1-select-subject.png[100%,title=Select subject]
 
 Click btn:[Next: Objects] to continue in the association type definition wizard.
 
 The next step is very similar to the previous one, but you select the object (as the object type of the resource) of association.
 
-image::step-1-select-object.png[link=step-1-select-object.png,100%,title=Select object]
+image::step-1-select-object.png[100%,title=Select object]
 
 Click btn:[Next: Data for association] to continue in the association type definition wizard.
 
@@ -56,7 +56,7 @@ TIP: If in doubt, use `Undefined` or `True`.
 
 NOTE: /midpoint/reference/concepts/mark/[] can redefine association (membership) tolerance.
 
-image::step-1-specify-data-for-association.png[link=step-1-specify-data-for-association.png,100%,title=Specify the data for association]
+image::step-1-specify-data-for-association.png[100%,title=Specify the data for association]
 
 Click btn:[Save settings] to save the association type configuration.
 
@@ -70,7 +70,7 @@ allowing to access the first and last steps without parts for selecting subjects
 
 *Object* tile allows to return back to object selection.
 
-image::choice-part.png[link=choice-part.png,100%,title=Association wizard]
+image::choice-part.png[100%,title=Association wizard]
 
 include::../configuration-resource-panels.adoc[]
 

--- a/docs/admin-gui/resource-wizard/association-type/subject/index.adoc
+++ b/docs/admin-gui/resource-wizard/association-type/subject/index.adoc
@@ -5,7 +5,7 @@
 
 Configuration for a subject starts with a screen with three options.
 
-image::choice-part.png[link=choice-part.png,100%,title=Subject wizard]
+image::choice-part.png[100%,title=Subject wizard]
 
 *Select Subject* tile allows selecting the subject.
 

--- a/docs/admin-gui/resource-wizard/association-type/subject/provisioning-from-resource/index.adoc
+++ b/docs/admin-gui/resource-wizard/association-type/subject/provisioning-from-resource/index.adoc
@@ -5,11 +5,11 @@
 
 On this page we create provisioning rule(s) to specify how midPoint should read the association information and transform it to midPoint data, typically assignments.
 
-image::table-new.png[link=table-new.png,100%,title=Provisioning from resource]
+image::table-new.png[100%,title=Provisioning from resource]
 
 Click btn:[Add provisioning rule] to create a new provisioning rule.
 
-image::step-1-basic-configuration.png[link=step-1-basic-configuration.png,100%,title=Main configuration of association inbound mapping]
+image::step-1-basic-configuration.png[100%,title=Main configuration of association inbound mapping]
 
 We can configure basic attributes of the provisioning rule:
 
@@ -21,7 +21,7 @@ Click btn:[Save settings].
 
 Further configuration is required.
 
-image::choice-part.png[link=choice-part.png,100%,title=Provisioning from resource wizard]
+image::choice-part.png[100%,title=Provisioning from resource wizard]
 
 *Basic Attributes* tile allows returning back to the basic provisioning rule attributes definition.
 Other tiles are described below.
@@ -30,7 +30,7 @@ Other tiles are described below.
 
 In this step, you can configure the mapping for reading the associations (inbound).
 
-image::step-2-mapping.png[link=step-2-mapping.png,100%,title=Provisioning from resource mappings]
+image::step-2-mapping.png[100%,title=Provisioning from resource mappings]
 
 Create a new mapping using btn:[Add inbound] that defines the transformation of association data from resource to midPoint data (inbound):
 
@@ -48,7 +48,7 @@ Click btn:[Save mappings] when done to return to the previous page from which yo
 
 In this step, you can configure synchronization rules for provisioning. This section specifies how midPoint reacts when a new synchronization event is detected.
 
-image::step-3-synchronization-table.png[link=step-3-synchronization-table.png,100%,title=Synchronization]
+image::step-3-synchronization-table.png[100%,title=Synchronization]
 
 Click btn:[Add reaction] to add a new row in the table.
 
@@ -77,12 +77,12 @@ Click btn:[Save synchronization settings] when done to return to the previous pa
 In this step, you can configure correlation rules for provisioning.
 Define a new correlation rule to specify how midPoint should correlate the associations to assignments.
 
-image::step-4-correlation-rule-table.png[link=step-4-correlation-rule-table.png,100%,title=Correlation rules]
+image::step-4-correlation-rule-table.png[100%,title=Correlation rules]
 
 When you click on btn:[Edit] in item menu you will see table for items of correlation rule.
 If associations correspond to assignments, you typically want to use (inbound mapping for) `targetRef` property (of the assignment) as correlation item.
 
-image::step-4-correlation-items.png[link=step-4-correlation-items.png,100%,title=Configuration of correlation items]
+image::step-4-correlation-items.png[100%,title=Configuration of correlation items]
 
 Click btn:[Confirm settings] when finished to return to the previous page for correlation rules, but you must save your changes.
 

--- a/docs/admin-gui/resource-wizard/association-type/subject/provisioning-to-resource/index.adoc
+++ b/docs/admin-gui/resource-wizard/association-type/subject/provisioning-to-resource/index.adoc
@@ -5,13 +5,13 @@
 
 On this page we can create provisioning rule(s) to specify how midPoint should create the association information and transform it to resource data, typically from assignments.
 
-image::table-new.png[link=table-new.png,100%,title=Provisioning to resource]
+image::table-new.png[100%,title=Provisioning to resource]
 
 The first steps are the same as for provisioning from resources, we need to create a new rule.
 
 Click btn:[Add provisioning rule] to create a new provisioning rule.
 
-image::step-1-basic-configuration.png[link=step-1-basic-configuration.png,100%,title=Main configuration of association outbound mapping]
+image::step-1-basic-configuration.png[100%,title=Main configuration of association outbound mapping]
 
 We can configure basic attributes of the provisioning rule:
 
@@ -23,7 +23,7 @@ Click btn:[Save settings].
 
 Further configuration is required.
 
-image::choice-part.png[link=choice-part.png,100%,title=Provisioning to resource wizard]
+image::choice-part.png[100%,title=Provisioning to resource wizard]
 
 *Basic Attributes* tile allows returning back to the basic provisioning rule attributes definition.
 Other tiles are described below.
@@ -32,7 +32,7 @@ Other tiles are described below.
 
 In this step, you can configure the mapping for creating the associations (outbound).
 
-image::step-2-mapping.png[link=step-2-mapping.png,100%,title=Provisioning to resource mappings]
+image::step-2-mapping.png[100%,title=Provisioning to resource mappings]
 
 Create a new mapping using btn:[Add outbound] that defines the transformation of midPoint data to association data (outbound).
 

--- a/docs/admin-gui/resource-wizard/object-type/activation/index.adoc
+++ b/docs/admin-gui/resource-wizard/object-type/activation/index.adoc
@@ -20,7 +20,7 @@ We can use predefined mappings (rules) for many interesting situations.
 
 The table contains the list of inbound activation mappings.
 
-image::step-6-activation-inbounds.png[link=step-6-activation-inbounds.png, 100%, title=Empty inbound table for activation]
+image::step-6-activation-inbounds.png[100%, title=Empty inbound table for activation]
 
 Click btn:[Add inbound] to add a new inbound activation mapping.
 
@@ -29,8 +29,8 @@ Then configure details for mapping as appropriate for the activation scenario.
 
 [%autowidth, cols="a,a", frame=none, grid=none, role=center]
 |===
-| image::step-6-activation-inbound-add.png[link=step-6-activation-inbound-add.png, 100%, title=Popup for adding of new inbound activation mapping]
-| image::step-6-activation-inbound-full.png[link=step-6-activation-inbound-full.png, 100%, title=Activation table with inbound mapping for administrative status]
+| image::step-6-activation-inbound-add.png[100%, title=Popup for adding of new inbound activation mapping]
+| image::step-6-activation-inbound-full.png[100%, title=Activation table with inbound mapping for administrative status]
 
 |===
 
@@ -44,7 +44,7 @@ Click btn:[Save mappings] when done to return to the previous page from which yo
 
 The table contains the list of outbound activation mappings.
 
-image::step-6-activation-outbounds.png[link=step-6-activation-outbounds.png, 100%, title=Empty outbound table for activation]
+image::step-6-activation-outbounds.png[100%, title=Empty outbound table for activation]
 
 Click btn:[Add outbound] to add a new outbound activation mapping.
 
@@ -53,14 +53,14 @@ Then configure details for mapping as appropriate for the activation scenario.
 
 [%autowidth, cols="a,a", frame=none, grid=none, role=center]
 |===
-| image::step-6-activation-outbound-add.png[link=step-6-activation-outbound-add.png, 100%, title=Popup for adding of new outbound activation mapping]
-| image::step-6-activation-outbound-full.png[link=step-6-activation-outbound-full.png, 100%, title=Activation table with outbound mapping for administrative status and predefined mappings for 'Disable instead of delete' and 'Delayed delete' configuration]
+| image::step-6-activation-outbound-add.png[100%, title=Popup for adding of new outbound activation mapping]
+| image::step-6-activation-outbound-full.png[100%, title=Activation table with outbound mapping for administrative status and predefined mappings for 'Disable instead of delete' and 'Delayed delete' configuration]
 |===
 
 Predefined mapping configurations contain only one configuration step.
 
 .Predefined details configuration for 'Delayed delete'
-image::step-6-predefined-details.png[link=step-6-predefined-details.png,100%,title=Predefined details configuration for 'Delayed delete']
+image::step-6-predefined-details.png[100%,title=Predefined details configuration for 'Delayed delete']
 
 Each mapping also allows setting *Lifecycle state*.
 This can be used during xref:/midpoint/reference/admin-gui/simulations/[Simulations], e.g. specifying lifecycle state as `Proposed` will be used only to simulate the activation mapping, `Draft` disables the activation mapping etc.

--- a/docs/admin-gui/resource-wizard/object-type/capability/index.adoc
+++ b/docs/admin-gui/resource-wizard/object-type/capability/index.adoc
@@ -12,6 +12,6 @@ Capabilities can be also _configured_, e.g. for LDAP resources, you can define w
 TIP: Capabilities can be configured also on the resource level, not just for specific object types by navigating to resource's *Details* panel.
 
 .Capabilities configuration
-image::step-5-capabilities.png[link=step-5-capabilities.png,100%,title=Capabilities configuration]
+image::step-5-capabilities.png[100%,title=Capabilities configuration]
 
 Click btn:[Save capabilities] when done to return to the previous page from which you started the capabilities editor.

--- a/docs/admin-gui/resource-wizard/object-type/credentials/index.adoc
+++ b/docs/admin-gui/resource-wizard/object-type/credentials/index.adoc
@@ -11,7 +11,7 @@ Use the credentials mappings to either pass or generate the password.
 TIP: The `as is` mappings are very simple as midPoint implies that the password will be passed from midPoint user password to resource object password (if supported by the resource and connector) or vice versa.
 
 
-image::step-7-credentials.png[link=step-7-credentials.png,100%,title=Configuration of credentials]
+image::step-7-credentials.png[100%,title=Configuration of credentials]
 
 Each mapping also allows setting *Lifecycle state*.
 This can be used during xref:/midpoint/reference/admin-gui/simulations/[Simulations], e.g. specifying lifecycle state as `Proposed` will be used only to simulate the credentials mapping, `Draft` disables the credentials mapping etc.

--- a/docs/admin-gui/resource-wizard/object-type/index.adoc
+++ b/docs/admin-gui/resource-wizard/object-type/index.adoc
@@ -28,7 +28,7 @@ If you need to *edit an existing object type*:
 . Select the icon:circle[] *Basic attributes* tile to get into the same wizard as when you set up a new object type. +
     The other options are covered by different resource wizard tutorials.
 
-image::object-type-table.webp[link=object-type-table.webp,100%,title=List of object types]
+image::object-type-table.webp[100%,title=List of object types]
 
 == Basic attributes
 
@@ -54,7 +54,7 @@ Later, when you set up roles and more account types, you'll also use the entitle
 Learn more about kinds, intents, and object classes: xref:/midpoint/reference/resources/shadow/kind-intent-objectclass/[]
 ====
 
-image::step-1-object-type-basic-config.webp[link=step-1-object-type-basic-config.webp, 100%, title=Basic configuration of object type]
+image::step-1-object-type-basic-config.webp[100%, title=Basic configuration of object type]
 
 == Specify the Resource Data
 
@@ -90,7 +90,7 @@ If you change filtering conditions for an existing object type, you then need to
 * xref:/midpoint/reference/resources/resource-configuration/schema-handling/classification/[]
 * xref:/midpoint/reference/resources/resource-configuration/schema-handling/delineation/[]
 
-image::step-1-object-type-resource-data.webp[link=step-1-object-type-resource-data.webp, 100%,title=Resource data]
+image::step-1-object-type-resource-data.webp[100%,title=Resource data]
 
 == Specify the midPoint Data
 
@@ -121,17 +121,17 @@ You can xref:/midpoint/reference/schema/archetypes/configuration-gui/[modify the
 
 .See also details on the built-in xref:/midpoint/reference/schema/archetypes/person/[].
 
-image::step-1-object-type-midpoint-data.webp[link=step-1-object-type-midpoint-data.webp, 100%, title=Midpoint data]
+image::step-1-object-type-midpoint-data.webp[100%, title=Midpoint data]
 
 == Further Object Type Configuration
 
 Further configuration is required.
 
-image::choice-part.png[link=choice-part.png,100%,title=Parts of object type configuration]
+image::choice-part.png[100%,title=Parts of object type configuration]
 
 First of all, we suggest you click btn:[Preview data] to display resource data according to the configuration of this particular object type.
 
-image::data-preview.png[link=data-preview.png,100%,title=Data preview of object type]
+image::data-preview.png[100%,title=Data preview of object type]
 
 After you confirm whether your settings produce expected results, you can choose your next steps to configure other parts of your object type:
 

--- a/docs/admin-gui/resource-wizard/object-type/mapping/advanced-mappings.adoc
+++ b/docs/admin-gui/resource-wizard/object-type/mapping/advanced-mappings.adoc
@@ -11,7 +11,7 @@ For basic options and a general description of mappings, refer to xref:/midpoint
 [[advanced_inbound_mappings]]
 == Advanced Inbound Mappings
 
-image::step-2-mappings-inbound.png[link=step-2-mappings-inbound.png, 100%, title=Table of inbound mappings]
+image::step-2-mappings-inbound.png[100%, title=Table of inbound mappings]
 
 In addition to the xref:/midpoint/reference/admin-gui/resource-wizard/object-type/mapping/index.adoc#inbound_mappings[basic inbound mapping settings], you can use a more advanced configuration:
 

--- a/docs/admin-gui/resource-wizard/object-type/mapping/index.adoc
+++ b/docs/admin-gui/resource-wizard/object-type/mapping/index.adoc
@@ -25,7 +25,7 @@ For a more in-depth description, see the following pages:
 == Inbound Mappings
 Inbound mapping transforms data from authoritative sources to midPoint. Typically, it is used to populate new user objects with data from an HR system.
 
-image::step-2-mappings-inbound.png[link=step-2-mappings-inbound.png, 100%, title=Table of inbound mappings]
+image::step-2-mappings-inbound.png[100%, title=Table of inbound mappings]
 
 To add an inbound mapping:
 
@@ -64,7 +64,7 @@ Click icon:shuffle[] btn:[Attribute overrides] if you need to <<attribute_overr
 
 Outbound mappings are used to populate target resource attribute values by midPoint properties.
 
-image::step-2-mappings-outbound.png[link=step-2-mappings-outbound.png, 100%, title=Table of outbound mappings]
+image::step-2-mappings-outbound.png[100%, title=Table of outbound mappings]
 
 To add an outbound mapping:
 
@@ -88,7 +88,7 @@ Click icon:shuffle[] btn:[Attribute overrides] if you need to <<attribute_overr
 Attribute configuration can be overridden beyond the context of the mappings to give you more maneuvering space, for example to override the default connector behavior.
 For more details on attributes, see the xref:/midpoint/reference/resources/resource-configuration/schema-handling/attributes/[] page.
 
-image::step-2-mappings-override.png[link=step-2-mappings-override.png, 100%, title=Table of attribute overrides]
+image::step-2-mappings-override.png[100%, title=Table of attribute overrides]
 
 . On the inbound/outbound mappings page, click icon:shuffle[] btn:[Attribute overrides].
 You can then override the following attribute parameters:

--- a/docs/admin-gui/resource-wizard/object-type/policies/index.adoc
+++ b/docs/admin-gui/resource-wizard/object-type/policies/index.adoc
@@ -17,7 +17,7 @@ This is done in the *Object type policies* section of the application, where you
 * <<classify_objects,Marking>> - Groups accounts or entitlements by filtering them and assigning marks to them.
 * <<default_operation_policy,Default Operation Policy>> - Defines the default policy for objects that have not been explicitly assigned marks in the <<classify_objects,Marking>> section.
 
-image::object-type-policies.webp[link=object-type-policies.webp,70%,title=Object type policies]
+image::object-type-policies.webp[70%,title=Object type policies]
 
 For more technical details on object marks, and to see how you can use them in your workflows, see xref:/midpoint/reference/concepts/mark[].
 
@@ -33,7 +33,7 @@ Once you have all marks created and ready to be used, classify your objects:
 . In the resource, depending on which objects you want to group, click [.nowrap]#icon:male[] *Accounts*# or [.nowrap]#icon:users[] *Entitlements*#.
 . Click [.nowrap]#icon:cog[] btn:[Configure]# and select [.nowrap]#icon:balance-scale[] *Policies*#.
 +
-image::resource-account.webp[link=resource-account.webp,100%,title=Access marks in a resource]
+image::resource-account.webp[100%,title=Access marks in a resource]
 . Click [.nowrap]#icon:tag[] btn:[Marking]#.
 . Click [.nowrap]#icon:circle-plus[] btn:[New marking rule]#.
 . Select the mark that you want to use for your group of objects.
@@ -82,11 +82,11 @@ In addition to marking objects in bulk by filtering them in the <<classify_objec
 . Go to [.nowrap]#icon:database[] *Resources*# > [.nowrap]#icon:database[] *All resources*# > resource.
 . In the resource, click [.nowrap]#icon:male[] *Accounts*#.
 +
-image::object-add-mark-01.webp[link=object-add-mark-01.webp,100%,title=Navigate to accounts]
+image::object-add-mark-01.webp[100%,title=Navigate to accounts]
 . Click the name of the account that you want to mark.
 . Go to the [.nowrap]#icon:circle[] *Marks*# tab.
 +
-image::object-add-mark-02.webp[link=object-add-mark-02.webp,100%,title=Add marks to accounts]
+image::object-add-mark-02.webp[100%,title=Add marks to accounts]
 . Click [.nowrap]#icon:plus[] btn:[Add mark]# to add a new mark.
 
 [[entitlements]]
@@ -95,7 +95,7 @@ image::object-add-mark-02.webp[link=object-add-mark-02.webp,100%,title=Add marks
 . In the resource, click [.nowrap]#icon:users[] *Entitlements*#.
 . Click the dropdown button at the far right for the entitlement you want to mark and select [.nowrap]#*Modify marks*#.
 +
-image::object-add-mark-03.webp[link=object-add-mark-03.webp,100%,title=Add marks to entitlements]
+image::object-add-mark-03.webp[100%,title=Add marks to entitlements]
 . Click [.nowrap]#icon:plus[] btn:[Add mark]# to add a new mark.
 
 [[simulations]]
@@ -106,14 +106,14 @@ image::object-add-mark-03.webp[link=object-add-mark-03.webp,100%,title=Add marks
 . For the object to which you want to assign marks, you can:
 ** Mark the object directly as _Protected_ by clicking the [.nowrap]#icon:shield-alt[] btn:[Mark as Protected]# button.
 +
-image::simulations-add-mark.webp[link=simulations-add-mark.webp,100%,title=Add marks in simulation results]
+image::simulations-add-mark.webp[100%,title=Add marks in simulation results]
 ** Assign other marks by clicking the dropdown button next to the [.nowrap]#icon:shield-alt[] btn:[Mark as Protected]# button, and selecting *Modify marks*.
 
 == Review marks
 
 You can review marked objects by going to [.nowrap]#icon:tag[] *Marks*# > [.nowrap]#icon:tag[] *Object marks*# > mark > [.nowrap]#icon:circle[] *Marked shadows*#.
 
-image::object-marks-review.webp[link=object-marks-review.webp,100%,title=Review object marks]
+image::object-marks-review.webp[100%,title=Review object marks]
 
 
 include::../../see-also.adoc[]

--- a/docs/admin-gui/resource-wizard/object-type/synchronization/index.adoc
+++ b/docs/admin-gui/resource-wizard/object-type/synchronization/index.adoc
@@ -24,9 +24,9 @@ You can access a more complex configurations for each reaction using the icon:ed
 
 [%autowidth, cols="a,a,a", frame=none, grid=none, role=center]
 |===
-| image::step-3-synch-detail-basic.png[link=step-3-synch-detail-basic.png, 100%, title=Basic configuration of synchronizatio rule]
-| image::step-3-synch-detail-action.png[link=step-3-synch-detail-action.png, 100%, title=Action for synchronization rule]
-| image::step-3-synch-detail-optional.png[link=step-3-synch-detail-optional.png, 100%, title=Optional attributes for synchronization rule]
+| image::step-3-synch-detail-basic.png[100%, title=Basic configuration of synchronizatio rule]
+| image::step-3-synch-detail-action.png[100%, title=Action for synchronization rule]
+| image::step-3-synch-detail-optional.png[100%, title=Optional attributes for synchronization rule]
 |===
 
 == Possible situations and actions

--- a/docs/admin-gui/resource-wizard/wizard-existing-resource/index.adoc
+++ b/docs/admin-gui/resource-wizard/wizard-existing-resource/index.adoc
@@ -8,11 +8,11 @@ The resource object type wizard can be used also for editing existing resource s
 
 Navigate to one of the resource object panels (*Accounts*, *Entitlements* or *Generic*), select the object type by its display name and click btn:[Configure], then select button for particular part of object type wizard.
 
-image::resource-details.png[link=resource-details.png,100%,title=Resource detail]
+image::resource-details.png[100%,title=Resource detail]
 
 The existing association configuration can be also accessed from *Configure* menu, typically for *Accounts*.
 
-image::accessing-from-accounts.png[link=accessing-from-accounts.png,100%,title=Accessing existing association configuration from accounts]
+image::accessing-from-accounts.png[100%,title=Accessing existing association configuration from accounts]
 
 
 == Wizard for task creation
@@ -32,13 +32,13 @@ All these tasks can be created as standard tasks or xref:/midpoint/reference/adm
 
 To create a new non-simulated task within the resource wizard, navigate to one of the resource object panels (*Accounts*, *Entitlements* or *Generics*) and click btn:[Tasks], then click *Create task*.
 
-image::task-wizard-menu.png[link=task-wizard-menu.png,100%,title=Task creation wizard menu]
+image::task-wizard-menu.png[100%,title=Task creation wizard menu]
 
 Keep the *Simulate task* switch set to *OFF*.
 
 Select the xref:/midpoint/reference/tasks/synchronization-tasks/[task] to be created (Import, Reconciliation, Live synchronization) by clicking one of the tiles:
 
-image::step-1-select-task-type.png[link=step-1-select-task-type.png,100%,title=Step 1: Select task type]
+image::step-1-select-task-type.png[100%,title=Step 1: Select task type]
 
 Click btn:[Create task] to start task creation wizard.
 
@@ -46,39 +46,39 @@ Define basic information for the task:
 
 * *Name* will be used as the task name. If you do not define the task name, it will be generated automatically based on the task type, resource and object type display name, e.g. `Import task: HR System: HR Person`.
 
-image::step-2-basic.png[link=step-2-basic.png,100%,title=Step 2: Enter basic task information]
+image::step-2-basic.png[100%,title=Step 2: Enter basic task information]
 
 Click btn:[Next: Resource objects] to continue with the task creation.
 
 Define resource-related information for the task.
 Normally you don't need to define anything as the task creation wizard will use the information from the resource and object type, where you have started it and *Resource*, *Kind*, *Intent* and/or *Object class* will be already predefined.
 
-image::step-3-resource.png[link=step-3-resource.png,100%,title=Step 3: Enter resource-related task information]
+image::step-3-resource.png[100%,title=Step 3: Enter resource-related task information]
 
 Click btn:[Next: Distribution] to continue with the task creation.
 
 Define distribution information for the task, currently only *Worker threads* you want to use for the task run.
 The default value is a single worker.
 
-image::step-4-distribution.png[link=step-4-distribution.png,100%,title=(Optional) Step 4: Enter distribution details]
+image::step-4-distribution.png[100%,title=(Optional) Step 4: Enter distribution details]
 
 Click btn:[Save & Run] to save and start task immediately or click btn:[Save settings] to create but not start the task.
 
 You can get to the task details either using menu:Server tasks[All tasks] or clicking *Defined tasks* menu item in the resource details.
 
-image::task-wizard-defined-tasks.png[link=task-wizard-defined-tasks.png,100%,title="List of tasks defined for the resource"]
+image::task-wizard-defined-tasks.png[100%,title="List of tasks defined for the resource"]
 
 === Simulated tasks
 
 To create a new simulated task within the resource wizard, navigate to one of the resource object panels (*Accounts*, *Entitlements* or *Generics*) and click btn:[Tasks], then click *Create task*.
 
-image::task-wizard-menu.png[link=task-wizard-menu.png,100%,title=Task creation wizard menu]
+image::task-wizard-menu.png[100%,title=Task creation wizard menu]
 
 Switch the *Simulate task* to *ON*.
 
 Select the xref:/midpoint/reference/tasks/synchronization-tasks/[task] to be created (Import, Reconciliation, Live synchronization) by clicking one of the tiles:
 
-image::step-1-select-task-type-simulated.png[link=step-1-select-task-type-simulated.png,100%,title=Step 1: Select task type (with simulation)j]
+image::step-1-select-task-type-simulated.png[100%,title=Step 1: Select task type (with simulation)j]
 
 Click btn:[Create task] to start task creation wizard.
 
@@ -87,14 +87,14 @@ Define basic information for the task:
 * *Name* will be used as the task name. If you do not define the task name, it will be generated automatically based on the task type, resource and object type display name, e.g. `Import task: HR System: HR Person`.
 In the following image we are using a custom task name `Reconciliation with AD - development simulation`.
 
-image::step-2-basic-simulated.png[link=step-2-basic-simulated.png,100%,title=Step 2: Enter basic task information]
+image::step-2-basic-simulated.png[100%,title=Step 2: Enter basic task information]
 
 Click btn:[Next: Resource objects] to continue with the task creation.
 
 Define resource-related information for the task.
 Normally you don't need to define anything as the task creation wizard will use the information from the resource and object type, where you have started it and *Resource*, *Kind*, *Intent* and/or *Object class* will be already predefined.
 
-image::step-3-resource-simulated.png[link=step-3-resource-simulated.png,100%,title=Step 3: Enter resource-related task information]
+image::step-3-resource-simulated.png[100%,title=Step 3: Enter resource-related task information]
 
 Click btn:[Next: Execution] to continue with the task creation. The "Execution" parameters can be edited only for simulated tasks.
 
@@ -109,7 +109,7 @@ This allows to configure the task xref:/midpoint/reference/admin-gui/simulations
 ** *Development* allows evaluating all configuration which is in lifecycle state `Active` or `Proposed`
 ** *Production* allows evaluating all configuration which is in lifecycle state `Active` or `Deprecated`
 
-image::step-4-execution-simulated.png[link=step-4-execution-simulated.png,100%,title=Step 4: Enter execution-related task information]
+image::step-4-execution-simulated.png[100%,title=Step 4: Enter execution-related task information]
 
 Click btn:[Next: Schedule] to continue with the task creation. The "Schedule" parameters can be edited only for reconciliation and/or live synchronization tasks.
 
@@ -120,19 +120,19 @@ TIP: Scheduling usually does not make much sense when creating a simulated task.
 * *Interval* allows defining scheduling interval in seconds
 * *Cron-like pattern* allows defining scheduling intervals via cron-like pattern
 
-image::step-5-schedule-simulated.png[link=step-5-schedule-simulated.png,100%,title=(Optional) Step 5: Enter scheduling-related task information]
+image::step-5-schedule-simulated.png[100%,title=(Optional) Step 5: Enter scheduling-related task information]
 
 Click btn:[Next: Distribution] to continue with the task creation.
 
 Define distribution information for the task, currently only *Worker threads* you want to use for the task run.
 The default value is a single worker.
 
-image::step-4-distribution.png[link=step-4-distribution.png,100%,title=(Optional) Step 6: Enter distribution details]
+image::step-4-distribution.png[100%,title=(Optional) Step 6: Enter distribution details]
 
 Click btn:[Save & Run] to save and start task immediately or click btn:[Save settings] to create but not start the task.
 
 You can get to the task details either using menu:Server tasks[All tasks] or clicking *Defined tasks* menu item in the resource details.
 
-image::task-wizard-defined-tasks.png[link=task-wizard-defined-tasks.png,100%,title="List of tasks defined for the resource"]
+image::task-wizard-defined-tasks.png[100%,title="List of tasks defined for the resource"]
 
 include::../configuration-resource-panels.adoc[]

--- a/docs/admin-gui/role-wizard/index.adoc
+++ b/docs/admin-gui/role-wizard/index.adoc
@@ -33,8 +33,8 @@ We can add governance users, member users, create inducement for a resource or v
 Members panels:
 [%autowidth, cols="a,a", frame=none, grid=none, role=center]
 |===
-| image::arw-step-3-governance.png[link=arw-step-3-governance.png, 100%, title=Panel for adding governance user]
-| image::arw-step-3-member.png[link=arw-step-3-member.png, 100%, title=Panel for adding user as member]
+| image::arw-step-3-governance.png[100%, title=Panel for adding governance user]
+| image::arw-step-3-member.png[100%, title=Panel for adding user as member]
 |===
 
 {empty} +
@@ -42,11 +42,11 @@ Configuration of provisioning:
 
 [%autowidth, cols="1a,1a", frame=none, grid=none, role=center]
 |===
-| image::arw-step-4-select-resource.png[link=arw-step-4-select-resource.png, 100%, title=Selecting of resource]
-| image::arw-step-4-select-object-type.png[link=arw-step-4-select-object-type.png,100%, title=Selecting of resource object type]
+| image::arw-step-4-select-resource.png[100%, title=Selecting of resource]
+| image::arw-step-4-select-object-type.png[100%, title=Selecting of resource object type]
 
-| image::arw-step-4-selecting-of-association.png[link=arw-step-4-selecting-of-association.png, 100%, title=Selecting of associations]
-| image::arw-step-4-configuration-of-outbound-mappings.png[link=arw-step-4-configuration-of-outbound-mappings.png, 100%, title=Configuration of outbound mappings]
+| image::arw-step-4-selecting-of-association.png[100%, title=Selecting of associations]
+| image::arw-step-4-configuration-of-outbound-mappings.png[100%, title=Configuration of outbound mappings]
 |===
 
 == Business role wizard

--- a/docs/schema/archetypes/configuration-gui/archetypes-in-object-type-wizard.adoc
+++ b/docs/schema/archetypes/configuration-gui/archetypes-in-object-type-wizard.adoc
@@ -7,7 +7,7 @@
 When xref:/midpoint/reference/admin-gui/resource-wizard/object-type/[setting up an object type], you can work with archetypes directly from the wizard.
 On the screen Specify the midPoint data of the object type setup wizard, you can select an existing archetype for the object type or create a new one, such as _Person_.
 
-image::../object-type-midpoint-data-archetype-selection.webp[link=../object-type-midpoint-data-archetype-selection.webp, 100%]
+image::../object-type-midpoint-data-archetype-selection.webp[100%]
 
 == Select an Existing Archetype
 

--- a/docs/schema/archetypes/configuration-gui/index.adoc
+++ b/docs/schema/archetypes/configuration-gui/index.adoc
@@ -31,7 +31,7 @@ Click name of an archetype to open it for editing and inspect its settings.
 	** Select a *Super archetype* if you wish the new archetype to inherit some settings of an existing archetype.
 . Click icon:save[] btn:[Save] at the top of the screen.
 
-image::archetype-gui-basic-01.webp[link=archetype-gui-basic-01.webp,100%]
+image::archetype-gui-basic-01.webp[100%]
 
 // * *Create inducement for membership* allows to create an inducement in the new archetype to construct the resource account _and_ association (membership) for focal objects with assigned role of this archetype.
 // For example, if you create a new archetype `LDAP group` for roles, by assigning role with `LDAP group` archetype to a user, new LDAP account will be created and made member of the group constructed by `LDAP group` archetype for the role.

--- a/docs/schema/archetypes/person.adoc
+++ b/docs/schema/archetypes/person.adoc
@@ -15,7 +15,7 @@ This archetype includes also a reference to *Person Object Template*, which is a
 *System configuration* includes an xref:/midpoint/reference/admin-gui/collections-views/[object collection view] for users with this archetype.
 
 .Example screenshot when using Person archetype (click for full size)
-image::person-example.png[Person archetype screenshot,width="800",link="../person-example.png"]
+image::person-example.png[Person archetype screenshot,width="800"]
 
 == Configuration
 

--- a/docs/schema/custom-schema-extension/changing-schema-extension-via-GUI/index.adoc
+++ b/docs/schema/custom-schema-extension/changing-schema-extension-via-GUI/index.adoc
@@ -48,16 +48,16 @@ And the last step contains a table where we create the specific elements we want
 
 [%autowidth, cols="a,a", frame=none, grid=none, role=center]
 |===
-| image::wizard-1.png[link=wizard-1.png, 100%, title=New schema]
-| image::wizard-2.png[link=wizard-2.png, 100%, title=Basic information about the schema]
-| image::wizard-3.png[link=wizard-3.png, 100%, title=Basic information about structural definition]
-| image::wizard-4.png[link=wizard-4.png, 100%, title=Items]
+| image::wizard-1.png[100%, title=New schema]
+| image::wizard-2.png[100%, title=Basic information about the schema]
+| image::wizard-3.png[100%, title=Basic information about structural definition]
+| image::wizard-4.png[100%, title=Items]
 |===
 
 The table only contains basic configurable attributes for the new item, if we want to configure other attributes, such as help text,
 we can display advanced configuration options by clicking the `Edit` button in the menu at the end of each row.
 
-image::wizard-4-edit.png[link=wizard-4-edit.png, 100%, title=Edit item]
+image::wizard-4-edit.png[100%, title=Edit item]
 
 If we select the `Use existing schema` option at the start of the schema creation process, we would be selecting from existing schemas
 and we would only be adding another complex type to extend another object type, so the wizard would only consist of the last two steps (Figure 3. and Figure 4.).
@@ -71,7 +71,7 @@ In the Details menu we can click on the Definitions panel, where we can add new 
 The Definitions panel consists of a list item panel that displays the complex types contained in the schema.
 The right side of the panel is a tab panel which displays a table of items or the configuration of the selected complex type.
 
-image::change.png[link=change.png, 100%, title=Definitions panel]
+image::change.png[100%, title=Definitions panel]
 
 === Limitations
 

--- a/docs/tasks/shadow-reclassification-task/gui.adoc
+++ b/docs/tasks/shadow-reclassification-task/gui.adoc
@@ -48,8 +48,8 @@ If you opt in for simulation, you'll see also the *Execution* screen in the wiza
 
 [%autowidth, cols="a,a,a", frame=none, grid=none, role=center]
 |====
-| image::../gui-shadow-reclassify-task-resource-objects-overview.webp[link=../gui-shadow-reclassify-task-resource-objects-overview.webp, title=Resource objects overview with tasks menu]
-| image::../gui-shadow-reclassify-task-wizard-start.webp[link=../gui-shadow-reclassify-task-wizard-start.webp, title=Initial screen of the task wizard]
-| image::../gui-shadow-reclassify-task-wizard-resource-objects.webp[link=../gui-shadow-reclassify-task-wizard-resource-objects.webp, title=Specify resource objects to be processed]
+| image::../gui-shadow-reclassify-task-resource-objects-overview.webp[title=Resource objects overview with tasks menu]
+| image::../gui-shadow-reclassify-task-wizard-start.webp[title=Initial screen of the task wizard]
+| image::../gui-shadow-reclassify-task-wizard-resource-objects.webp[title=Specify resource objects to be processed]
 |====
 


### PR DESCRIPTION
Remove links from images because they no longer make sense - we have the lightbox now - https://github.com/Evolveum/evolveum-jekyll/pull/4