### PR TITLE
fix: off-by-one error in generate-name-jsmith-8-2

### DIFF
--- a/config/initial-objects/object-templates/380-object-template-person.xml
+++ b/config/initial-objects/object-templates/380-object-template-person.xml
@@ -10,7 +10,7 @@ oid="00000000-0000-0000-0000-000000000380">
 <name>Person Object Template</name>
 <description>Object template for Person users, contains mappings to generate fullName and username. Please enable appropriate mappings as needed.</description>
     <iterationSpecification>
-        <maxIterations>99</maxIterations>
+        <maxIterations>98</maxIterations>
         <tokenExpression>
             <description>The iteration starts with empty string, then a number is appended, starting with 2 (skipping 1), 3, ... up to 99.</description>
             <documentation>


### PR DESCRIPTION
If the Iteration reaches 99 it would create jsmith100, which is longer than two characters.  
Tested on 4.8 with maxIterations = 3, generate-name-jsmith-8-2 creates jsmith4 but not jsmith 5. 