### PR TITLE
MID-11152 Add option to skip remaining reviewers when a certification case is already answered

### DIFF
--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/component/menu/LeftMenuPanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/component/menu/LeftMenuPanel.java
@@ -14,6 +14,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import javax.xml.namespace.QName;
 
+import com.evolveum.midpoint.gui.impl.page.admin.certification.helpers.CertMiscUtil;
 import com.evolveum.midpoint.web.page.admin.services.*;
 
 import org.apache.commons.collections4.CollectionUtils;
@@ -157,14 +158,16 @@ public class LeftMenuPanel extends BasePanel<Void> {
             @Override
             protected String load() {
                 try {
-                    AccessCertificationService acs = getPageBase().getCertificationService();
-                    Task task = getPageBase().createSimpleTask(OPERATION_LOAD_CERT_WORK_ITEM_COUNT);
-                    OperationResult result = task.getResult();
-                    int openCertWorkItems = acs.countOpenWorkItems(getPrismContext().queryFactory().createQuery(), true, null, task, result);
-                    if (openCertWorkItems == 0) {
+                    // Use method that respects collectDecisionsFromAllReviewers setting
+                    long openCertItems = CertMiscUtil.countOpenCertItems(
+                            (String) null, // all campaigns
+                            getPageBase().getPrincipal(),
+                            true, // notDecidedOnly
+                            getPageBase());
+                    if (openCertItems == 0) {
                         return null;
                     }
-                    return Integer.toString(openCertWorkItems);
+                    return Long.toString(openCertItems);
                 } catch (Exception e) {
                     LoggingUtils.logExceptionAsWarning(LOGGER, "Couldn't load certification work item count", e);
                     return null;

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/component/search/wrapper/CertItemOutcomeSearchItemWrapper.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/component/search/wrapper/CertItemOutcomeSearchItemWrapper.java
@@ -8,11 +8,15 @@ package com.evolveum.midpoint.gui.impl.component.search.wrapper;
 
 import com.evolveum.midpoint.certification.api.OutcomeUtils;
 import com.evolveum.midpoint.gui.api.page.PageBase;
+import com.evolveum.midpoint.gui.impl.page.admin.certification.helpers.CertMiscUtil;
+import com.evolveum.midpoint.prism.PrismConstants;
 import com.evolveum.midpoint.prism.PrismContext;
 import com.evolveum.midpoint.prism.path.ItemPath;
 import com.evolveum.midpoint.prism.query.ObjectFilter;
+import com.evolveum.midpoint.schema.constants.SchemaConstants;
 import com.evolveum.midpoint.schema.expression.VariablesMap;
 import com.evolveum.midpoint.util.DisplayableValue;
+import com.evolveum.midpoint.xml.ns._public.common.common_3.AccessCertificationCaseType;
 import com.evolveum.midpoint.xml.ns._public.common.common_3.AccessCertificationResponseType;
 import com.evolveum.midpoint.xml.ns._public.common.common_3.AccessCertificationWorkItemType;
 
@@ -39,9 +43,22 @@ public class CertItemOutcomeSearchItemWrapper  extends ChoicesSearchItemWrapper<
         if (AccessCertificationResponseType.NO_RESPONSE.equals(response) &&
                 AccessCertificationWorkItemType.class.equals(type)) {
             //work items without response have null outcome
-            return PrismContext.get().queryFor(type)
+            ObjectFilter noOutcomeFilter = PrismContext.get().queryFor(type)
                     .item(getPath()).isNull()
                     .buildFilter();
+
+            if (!CertMiscUtil.isCollectDecisionsFromAllReviewers(pageBase)) {
+                // Also filter by parent case not having a response yet
+                ObjectFilter caseNotDecidedFilter = PrismContext.get().queryFor(type)
+                        .exists(PrismConstants.T_PARENT)
+                        .block()
+                            .item(AccessCertificationCaseType.F_CURRENT_STAGE_OUTCOME)
+                            .eq(SchemaConstants.MODEL_CERTIFICATION_OUTCOME_NO_RESPONSE)
+                        .endBlock()
+                        .buildFilter();
+                return PrismContext.get().queryFactory().createAnd(noOutcomeFilter, caseNotDecidedFilter);
+            }
+            return noOutcomeFilter;
         }
         return PrismContext.get().queryFor(type)
                 .item(getPath()).eq(OutcomeUtils.toUri(response)).buildFilter();

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/certification/component/ActiveCampaignsPanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/certification/component/ActiveCampaignsPanel.java
@@ -67,7 +67,7 @@ public class ActiveCampaignsPanel extends CampaignsPanel {
 
             @Override
             protected LoadableDetachableModel<List<ProgressBar>> createCampaignProgressModel() {
-                return CertMiscUtil.createCampaignWorkItemsProgressBarModel(getCampaign(), getPrincipalOid(), getPageBase());
+                return CertMiscUtil.createCampaignProgressBarModel(getCampaign(), getPrincipalOid(), getPageBase());
             }
 
             @Override

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/certification/component/DashboardCertCampaignsPanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/certification/component/DashboardCertCampaignsPanel.java
@@ -26,6 +26,7 @@ import com.evolveum.midpoint.gui.impl.page.admin.certification.helpers.CertMiscU
 import com.evolveum.midpoint.prism.PrismObject;
 import com.evolveum.midpoint.prism.query.ObjectQuery;
 import com.evolveum.midpoint.schema.result.OperationResult;
+import com.evolveum.midpoint.security.api.MidPointPrincipal;
 import com.evolveum.midpoint.schema.util.CertCampaignTypeUtil;
 import com.evolveum.midpoint.task.api.Task;
 import com.evolveum.midpoint.util.exception.CommonException;
@@ -96,20 +97,15 @@ public class DashboardCertCampaignsPanel extends ObjectListPanel<AccessCertifica
                 for (PrismObject<AccessCertificationCampaignType> campaignObj : campaigns) {
                     AccessCertificationCampaignType campaign = campaignObj.asObjectable();
 
-                    ObjectQuery workItems = CertCampaignTypeUtil.createWorkItemsForCampaignQuery(campaign.getOid());
+                    // Use method that respects collectDecisionsFromAllReviewers setting
+                    MidPointPrincipal principal = page.getPrincipal();
+                    long openNotDecided = CertMiscUtil.countOpenCertItems(
+                            campaign.getOid(), principal, true, page);
+                    long allOpen = CertMiscUtil.countOpenCertItems(
+                            campaign.getOid(), principal, false, page);
+                    long openDecided = allOpen - openNotDecided;
 
-                    try {
-                        int openNotDecided = page.getCertificationService().countOpenWorkItems(workItems, true,
-                                false, null, task, task.getResult());
-                        int allOpen = page.getCertificationService().countOpenWorkItems(workItems, false,
-                                false, null, task, task.getResult());
-                        int openDecided = allOpen - openNotDecided;
-
-                        summary.add(new CampaignSummary(campaign, openDecided, openNotDecided));
-                    } catch (CommonException ex) {
-                        LOGGER.error("Couldn't load certification campaign work items count for campaign {}: {}",
-                                campaign.getName(), ex.getMessage(), ex);
-                    }
+                    summary.add(new CampaignSummary(campaign, openDecided, openNotDecided));
                 }
 
                 LOGGER.debug("Loaded {} active campaigns summary", summary.size());

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/certification/component/ReviewersStatisticsPanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/certification/component/ReviewersStatisticsPanel.java
@@ -295,6 +295,7 @@ public class ReviewersStatisticsPanel extends BasePanel {
         if (isInReviewStage()) {
             String campaignOid = model.getObjectType().getOid();
             MidPointPrincipal principal = MidPointPrincipal.create(reviewer.asObjectable());
+            // Use method that respects collectDecisionsFromAllReviewers setting
             return CertMiscUtil.countOpenCertItems(Collections.singletonList(campaignOid), principal,
                     true, getPageBase());
         } else if (isReviewStageDone()) {
@@ -310,6 +311,7 @@ public class ReviewersStatisticsPanel extends BasePanel {
         if (isInReviewStage()) {
             String campaignOid = model.getObjectType().getOid();
             MidPointPrincipal principal = MidPointPrincipal.create(reviewer.asObjectable());
+            // Use method that respects collectDecisionsFromAllReviewers setting
             return CertMiscUtil.countOpenCertItems(Collections.singletonList(campaignOid), principal,
                     false, getPageBase());
         } else if (isReviewStageDone()) {

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/certification/helpers/CertMiscUtil.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/certification/helpers/CertMiscUtil.java
@@ -37,6 +37,7 @@ import com.evolveum.midpoint.gui.impl.page.admin.certification.column.AbstractGu
 import com.evolveum.midpoint.model.api.authentication.CompiledObjectCollectionView;
 import com.evolveum.midpoint.prism.Item;
 import com.evolveum.midpoint.prism.PrismContainerValue;
+import com.evolveum.midpoint.prism.PrismConstants;
 import com.evolveum.midpoint.prism.PrismContext;
 import com.evolveum.midpoint.prism.PrismObject;
 import com.evolveum.midpoint.prism.impl.PrismReferenceValueImpl;
@@ -50,6 +51,7 @@ import com.evolveum.midpoint.schema.SearchResultList;
 import com.evolveum.midpoint.schema.result.OperationResult;
 import com.evolveum.midpoint.schema.util.CertCampaignTypeUtil;
 import com.evolveum.midpoint.security.api.MidPointPrincipal;
+import com.evolveum.midpoint.security.api.OtherPrivilegesLimitations;
 import com.evolveum.midpoint.task.api.Task;
 import com.evolveum.midpoint.util.logging.Trace;
 import com.evolveum.midpoint.util.logging.TraceManager;
@@ -318,7 +320,7 @@ public class CertMiscUtil {
         return dataset;
     }
 
-    public static long countOpenCertItems(List<String> campaignOids, MidPointPrincipal principal, boolean notDecidedOnly,
+    private static long countOpenWorkItemsForCampaigns(List<String> campaignOids, MidPointPrincipal principal, boolean notDecidedOnly,
             PageBase pageBase) {
         long count = 0;
 
@@ -901,5 +903,213 @@ public class CertMiscUtil {
         }
         AccessCertificationDefinitionType definition = definitionObj.asObjectable();
         return definition.getView();
+    }
+
+    /**
+     * Returns whether decisions should be collected from all reviewers.
+     * If true (default), progress is calculated based on WorkItems.
+     * If false, progress is calculated based on Cases.
+     */
+    public static boolean isCollectDecisionsFromAllReviewers(PageBase pageBase) {
+        AccessCertificationConfigurationType config = getCertificationConfiguration(pageBase);
+        if (config == null || config.isCollectDecisionsFromAllReviewers() == null) {
+            return true;  // default: true
+        }
+        return config.isCollectDecisionsFromAllReviewers();
+    }
+
+    /**
+     * Returns the certification configuration from system configuration.
+     */
+    public static AccessCertificationConfigurationType getCertificationConfiguration(PageBase pageBase) {
+        try {
+            OperationResult result = new OperationResult(OPERATION_LOAD_CERTIFICATION_CONFIG);
+            return pageBase.getModelInteractionService().getCertificationConfiguration(result);
+        } catch (Exception e) {
+            LOGGER.error("Couldn't load certification configuration from system configuration", e);
+            return null;
+        }
+    }
+
+    /**
+     * Counts open certification items based on the collectDecisionsFromAllReviewers setting.
+     * When true, counts work items. When false, counts cases.
+     *
+     * @param campaignOid the campaign OID (can be null for all campaigns)
+     * @param principal the principal (can be null for all reviewers; includes deputy support)
+     * @param notDecidedOnly if true, count only not-decided items
+     * @param pageBase the page base
+     * @return the count of open items
+     */
+    public static long countOpenCertItems(String campaignOid, MidPointPrincipal principal, boolean notDecidedOnly, PageBase pageBase) {
+        if (isCollectDecisionsFromAllReviewers(pageBase)) {
+            return countOpenWorkItemsInternal(campaignOid, principal, notDecidedOnly, pageBase);
+        } else {
+            return countOpenCasesInternal(campaignOid, principal, notDecidedOnly, pageBase);
+        }
+    }
+
+    /**
+     * Counts open certification items for multiple campaigns based on the collectDecisionsFromAllReviewers setting.
+     */
+    public static long countOpenCertItems(List<String> campaignOids, MidPointPrincipal principal, boolean notDecidedOnly, PageBase pageBase) {
+        if (isCollectDecisionsFromAllReviewers(pageBase)) {
+            return countOpenWorkItemsForCampaigns(campaignOids, principal, notDecidedOnly, pageBase);
+        } else {
+            return countOpenCasesForCampaigns(campaignOids, principal, notDecidedOnly, pageBase);
+        }
+    }
+
+    /**
+     * Internal method to count open work items for a single campaign.
+     */
+    private static long countOpenWorkItemsInternal(String campaignOid, MidPointPrincipal principal, boolean notDecidedOnly, PageBase pageBase) {
+        Task task = pageBase.createSimpleTask("countCertificationWorkItems");
+        OperationResult result = task.getResult();
+        try {
+            ObjectQuery baseQuery;
+            if (campaignOid != null) {
+                baseQuery = PrismContext.get().queryFor(AccessCertificationWorkItemType.class)
+                        .exists(PrismConstants.T_PARENT)
+                        .ownerId(campaignOid)
+                        .build();
+            } else {
+                baseQuery = PrismContext.get().queryFor(AccessCertificationWorkItemType.class)
+                        .build();
+            }
+            boolean collectAll = isCollectDecisionsFromAllReviewers(pageBase);
+            ObjectQuery query = QueryUtils.createQueryForOpenWorkItems(baseQuery, principal, notDecidedOnly, collectAll);
+            if (query == null) {
+                return 0;
+            }
+            return pageBase.getModelService()
+                    .countContainers(AccessCertificationWorkItemType.class, query, null, task, result);
+        } catch (Exception ex) {
+            LOGGER.error("Couldn't count certification work items", ex);
+            pageBase.showResult(result);
+        }
+        return 0;
+    }
+
+    /**
+     * Counts open cases for a single campaign (or all campaigns if campaignOid is null).
+     * When notDecidedOnly is true, counts only cases with currentStageOutcome = NO_RESPONSE.
+     * Supports deputy/delegation via principal-based filtering.
+     *
+     * @param campaignOid the campaign OID, or null to count across all campaigns
+     */
+    private static long countOpenCasesInternal(String campaignOid, MidPointPrincipal principal, boolean notDecidedOnly, PageBase pageBase) {
+        Task task = pageBase.createSimpleTask("countCertificationCases");
+        OperationResult result = task.getResult();
+        try {
+            var q = PrismContext.get().queryFor(AccessCertificationCaseType.class);
+
+            S_FilterExit baseFilter;
+            if (campaignOid != null) {
+                baseFilter = q.ownerId(campaignOid);
+            } else {
+                baseFilter = q.all();
+            }
+
+            if (notDecidedOnly) {
+                baseFilter = baseFilter.and()
+                        .item(AccessCertificationCaseType.F_CURRENT_STAGE_OUTCOME)
+                        .eq(OutcomeUtils.toUri(NO_RESPONSE));
+            }
+
+            if (principal != null) {
+                baseFilter = baseFilter.and()
+                        .exists(AccessCertificationCaseType.F_WORK_ITEM)
+                        .block()
+                            .item(AccessCertificationWorkItemType.F_CLOSE_TIMESTAMP).isNull()
+                            .and()
+                            .item(AbstractWorkItemType.F_ASSIGNEE_REF)
+                            .ref(QueryUtils.getPotentialAssigneesForUser(principal, // includes deputies
+                                    OtherPrivilegesLimitations.Type.ACCESS_CERTIFICATION))
+                        .endBlock();
+            } else {
+                baseFilter = baseFilter.and()
+                        .exists(AccessCertificationCaseType.F_WORK_ITEM)
+                        .block()
+                            .item(AccessCertificationWorkItemType.F_CLOSE_TIMESTAMP).isNull()
+                        .endBlock();
+            }
+
+            ObjectQuery query = baseFilter.build();
+
+            return pageBase.getModelService()
+                    .countContainers(AccessCertificationCaseType.class, query, null, task, result);
+        } catch (Exception ex) {
+            LOGGER.error("Couldn't count certification cases", ex);
+            pageBase.showResult(result);
+        }
+        return 0;
+    }
+
+    /**
+     * Counts open cases for the specified campaigns. Returns 0 if campaignOids is null or empty.
+     * Supports deputy/delegation via principal-based filtering.
+     *
+     * @param campaignOids the campaign OIDs; returns 0 if null or empty
+     */
+    private static long countOpenCasesForCampaigns(List<String> campaignOids, MidPointPrincipal principal, boolean notDecidedOnly, PageBase pageBase) {
+        if (campaignOids == null || campaignOids.isEmpty()) {
+            return 0;
+        }
+
+        Task task = pageBase.createSimpleTask("countCertificationCases");
+        OperationResult result = task.getResult();
+        try {
+            String[] oids = campaignOids.toArray(new String[0]);
+
+            S_FilterExit baseFilter = PrismContext.get().queryFor(AccessCertificationCaseType.class)
+                    .ownerId(oids);
+
+            if (notDecidedOnly) {
+                baseFilter = baseFilter.and()
+                        .item(AccessCertificationCaseType.F_CURRENT_STAGE_OUTCOME)
+                        .eq(OutcomeUtils.toUri(NO_RESPONSE));
+            }
+
+            if (principal != null) {
+                baseFilter = baseFilter.and()
+                        .exists(AccessCertificationCaseType.F_WORK_ITEM)
+                        .block()
+                            .item(AccessCertificationWorkItemType.F_CLOSE_TIMESTAMP).isNull()
+                            .and()
+                            .item(AbstractWorkItemType.F_ASSIGNEE_REF)
+                            .ref(QueryUtils.getPotentialAssigneesForUser(principal, // includes deputies
+                                    OtherPrivilegesLimitations.Type.ACCESS_CERTIFICATION))
+                        .endBlock();
+            } else {
+                baseFilter = baseFilter.and()
+                        .exists(AccessCertificationCaseType.F_WORK_ITEM)
+                        .block()
+                            .item(AccessCertificationWorkItemType.F_CLOSE_TIMESTAMP).isNull()
+                        .endBlock();
+            }
+
+            ObjectQuery query = baseFilter.build();
+
+            return pageBase.getModelService()
+                    .countContainers(AccessCertificationCaseType.class, query, null, task, result);
+        } catch (Exception ex) {
+            LOGGER.error("Couldn't count certification cases for campaigns", ex);
+            pageBase.showResult(result);
+        }
+        return 0;
+    }
+
+    /**
+     * Creates a progress bar model based on the collectDecisionsFromAllReviewers setting.
+     * When true, uses work item-based progress. When false, uses case-based progress.
+     */
+    public static LoadableDetachableModel<List<ProgressBar>> createCampaignProgressBarModel(
+            AccessCertificationCampaignType campaign, String principalOid, PageBase pageBase) {
+        if (isCollectDecisionsFromAllReviewers(pageBase)) {
+            return createCampaignWorkItemsProgressBarModel(campaign, principalOid, pageBase);
+        } else {
+            return createCampaignCasesProgressBarModel(campaign, principalOid, pageBase);
+        }
     }
 }

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/data/column/ColumnUtils.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/data/column/ColumnUtils.java
@@ -47,6 +47,7 @@ import com.evolveum.midpoint.util.exception.SchemaException;
 import com.evolveum.midpoint.web.component.form.multivalue.MultiValueChoosePanel;
 import com.evolveum.midpoint.web.component.util.VisibleBehaviour;
 import com.evolveum.midpoint.gui.impl.page.admin.certification.helpers.CertMiscUtil;
+import com.evolveum.midpoint.security.api.MidPointPrincipal;
 import com.evolveum.midpoint.gui.impl.page.admin.certification.component.DeadlinePanel;
 import com.evolveum.midpoint.gui.impl.page.admin.certification.helpers.CampaignProcessingHelper;
 import com.evolveum.midpoint.gui.impl.page.admin.certification.helpers.CertificationItemResponseHelper;
@@ -1095,13 +1096,13 @@ public class ColumnUtils {
 
                         decidedPercent = all != 0 ? (decidedItems * 100) / all : 0;
                     } else {
-                        ObjectQuery query = CertCampaignTypeUtil.createWorkItemsForCampaignQuery(campaign.getOid());
-                        Task task = pageBase.createSimpleTask("countWorkItems");
-                        openNotDecidedItems = pageBase.getCertificationService().countOpenWorkItems(query, true,
-                                false, null, task, task.getResult());
+                        // Use method that respects collectDecisionsFromAllReviewers setting
+                        MidPointPrincipal principal = pageBase.getPrincipal();
+                        openNotDecidedItems = CertMiscUtil.countOpenCertItems(
+                                campaign.getOid(), principal, true, pageBase);
 
-                        int allOpenItems = pageBase.getCertificationService().countOpenWorkItems(query, false,
-                                false, null, task, task.getResult());
+                        long allOpenItems = CertMiscUtil.countOpenCertItems(
+                                campaign.getOid(), principal, false, pageBase);
                         decidedItems = allOpenItems - openNotDecidedItems;
                         decidedPercent = allOpenItems != 0 ? (decidedItems * 100) / allOpenItems : 0;
                     }

--- a/infra/schema/src/main/resources/xml/ns/public/common/common-certification-3.xsd
+++ b/infra/schema/src/main/resources/xml/ns/public/common/common-certification-3.xsd
@@ -1569,6 +1569,18 @@
                     </xsd:appinfo>
                 </xsd:annotation>
             </xsd:element>
+            <xsd:element name="collectDecisionsFromAllReviewers" type="xsd:boolean" minOccurs="0" default="true">
+                <xsd:annotation>
+                    <xsd:documentation>
+                        Specifies whether decisions should be collected from all reviewers.
+                        If true (default), progress is calculated based on work items and all reviewers are expected to provide their decisions.
+                        If false, progress is calculated based on cases. Once any reviewer answers a case, it is hidden from other reviewers' work item lists by default. Reviewers can still see and respond to answered cases by changing the response filter.
+                    </xsd:documentation>
+                    <xsd:appinfo>
+                        <a:since>4.11</a:since>
+                    </xsd:appinfo>
+                </xsd:annotation>
+            </xsd:element>
         </xsd:sequence>
         <xsd:attribute name="id" type="xsd:long"/>
     </xsd:complexType>

--- a/model/cases-api/src/main/java/com/evolveum/midpoint/cases/api/util/QueryUtils.java
+++ b/model/cases-api/src/main/java/com/evolveum/midpoint/cases/api/util/QueryUtils.java
@@ -221,6 +221,22 @@ public class QueryUtils {
 
    public static ObjectQuery createQueryForOpenWorkItems(
             ObjectQuery baseWorkItemsQuery, MidPointPrincipal principal, boolean notDecidedOnly) {
+        return createQueryForOpenWorkItems(baseWorkItemsQuery, principal, notDecidedOnly, true);
+    }
+
+    /**
+     * Creates a query for open work items with an option to filter by case outcome.
+     *
+     * @param baseWorkItemsQuery the base query
+     * @param principal the principal (can be null for all reviewers)
+     * @param notDecidedOnly if true, only return work items without a decision
+     * @param collectDecisionsFromAllReviewers if false, only return work items where the parent case
+     *        has no response yet (currentStageOutcome is NO_RESPONSE)
+     * @return the query
+     */
+    public static ObjectQuery createQueryForOpenWorkItems(
+            ObjectQuery baseWorkItemsQuery, MidPointPrincipal principal, boolean notDecidedOnly,
+            boolean collectDecisionsFromAllReviewers) {
         ObjectFilter reviewerAndEnabledFilter = getReviewerAndEnabledFilterForWI(principal);
 
         ObjectFilter filter;
@@ -232,6 +248,20 @@ public class QueryUtils {
         } else {
             filter = reviewerAndEnabledFilter;
         }
+
+        // If collectDecisionsFromAllReviewers is false and showing only not-decided items,
+        // hide work items where the parent case has already been decided by another reviewer
+        if (!collectDecisionsFromAllReviewers && notDecidedOnly) {
+            ObjectFilter caseNotDecidedFilter = PrismContext.get().queryFor(AccessCertificationWorkItemType.class)
+                    .exists(PrismConstants.T_PARENT)
+                    .block()
+                        .item(AccessCertificationCaseType.F_CURRENT_STAGE_OUTCOME)
+                        .eq(SchemaConstants.MODEL_CERTIFICATION_OUTCOME_NO_RESPONSE)
+                    .endBlock()
+                    .buildFilter();
+            filter = PrismContext.get().queryFactory().createAnd(filter, caseNotDecidedFilter);
+        }
+
         return addFilter(baseWorkItemsQuery, filter);
     }
 
@@ -266,5 +296,55 @@ public class QueryUtils {
 
     private static @NotNull ItemPath createResourceObjectPath(ItemName subPath) {
         return ItemPath.create(F_AFFECTED_OBJECTS, F_ACTIVITY, F_RESOURCE_OBJECTS, subPath);
+    }
+
+    /**
+     * Creates a query for open work items for a single campaign.
+     *
+     * @param campaignOid the campaign OID
+     * @param reviewerRef the reviewer reference (can be null for all reviewers)
+     * @param notDecidedOnly if true, only return work items without a decision
+     * @return the query
+     */
+    public static ObjectQuery createQueryForOpenWorkItems(
+            String campaignOid, ObjectReferenceType reviewerRef, boolean notDecidedOnly) {
+        S_FilterEntry queryBuilder = PrismContext.get().queryFor(AccessCertificationWorkItemType.class);
+
+        S_FilterExit baseQuery;
+        if (campaignOid != null) {
+            baseQuery = queryBuilder.ownerId(campaignOid);
+        } else {
+            baseQuery = queryBuilder.all();
+        }
+
+        ObjectQuery query = baseQuery.build();
+
+        // Add reviewer filter if specified
+        if (reviewerRef != null && reviewerRef.getOid() != null) {
+            ObjectFilter reviewerFilter = PrismContext.get().queryFor(AccessCertificationWorkItemType.class)
+                    .item(AbstractWorkItemType.F_ASSIGNEE_REF)
+                    .ref(reviewerRef.getOid())
+                    .and()
+                    .item(F_CLOSE_TIMESTAMP)
+                    .isNull()
+                    .buildFilter();
+            query = addFilter(query, reviewerFilter);
+        } else {
+            ObjectFilter openFilter = PrismContext.get().queryFor(AccessCertificationWorkItemType.class)
+                    .item(F_CLOSE_TIMESTAMP)
+                    .isNull()
+                    .buildFilter();
+            query = addFilter(query, openFilter);
+        }
+
+        // Add not decided filter if specified
+        if (notDecidedOnly) {
+            ObjectFilter noResponseFilter = PrismContext.get().queryFor(AccessCertificationWorkItemType.class)
+                    .item(F_OUTPUT, F_OUTCOME).isNull()
+                    .buildFilter();
+            query = addFilter(query, noResponseFilter);
+        }
+
+        return query;
     }
 }

--- a/model/certification-impl/src/test/java/com/evolveum/midpoint/certification/test/TestCollectDecisionsFromAllReviewers.java
+++ b/model/certification-impl/src/test/java/com/evolveum/midpoint/certification/test/TestCollectDecisionsFromAllReviewers.java
@@ -1,0 +1,312 @@
+/*
+ * Copyright (C) 2026 Evolveum and contributors
+ *
+ * Licensed under the EUPL-1.2 or later.
+ */
+
+package com.evolveum.midpoint.certification.test;
+
+import static org.testng.AssertJUnit.*;
+
+import static com.evolveum.midpoint.xml.ns._public.common.common_3.AccessCertificationResponseType.*;
+
+import java.io.File;
+import java.util.Collection;
+import java.util.List;
+import javax.xml.datatype.XMLGregorianCalendar;
+
+import com.evolveum.midpoint.cases.api.util.QueryUtils;
+import com.evolveum.midpoint.notifications.impl.SimpleObjectRefImpl;
+import com.evolveum.midpoint.notifications.impl.events.CertReviewEventImpl;
+import com.evolveum.midpoint.prism.PrismConstants;
+import com.evolveum.midpoint.prism.query.ObjectQuery;
+import com.evolveum.midpoint.schema.util.cases.WorkItemTypeUtil;
+import com.evolveum.midpoint.security.api.MidPointPrincipal;
+import com.evolveum.midpoint.task.api.LightweightIdentifierGenerator;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.testng.annotations.Test;
+
+import com.evolveum.midpoint.prism.PrismObject;
+import com.evolveum.midpoint.schema.result.OperationResult;
+import com.evolveum.midpoint.task.api.Task;
+import com.evolveum.midpoint.test.util.TestUtil;
+import com.evolveum.midpoint.xml.ns._public.common.common_3.*;
+
+/**
+ * Tests for the collectDecisionsFromAllReviewers query parameter.
+ *
+ * Verifies that QueryUtils.createQueryForOpenWorkItems and CertReviewEventImpl
+ * correctly filter work items and notification cases based on the
+ * collectDecisionsFromAllReviewers parameter (true and false).
+ *
+ * Uses a single campaign with 2 reviewers per case (administrator + jack)
+ * and oneAcceptAccepts strategy. After jack accepts one case, verifies
+ * the different behavior when the parameter is true or false.
+ */
+@ContextConfiguration(locations = { "classpath:ctx-certification-test-main.xml" })
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+public class TestCollectDecisionsFromAllReviewers extends AbstractCertificationTest {
+
+    private static final File CERT_DEF_FILE =
+            new File(COMMON_DIR, "certification-collect-decisions-test.xml");
+
+    @Autowired
+    private LightweightIdentifierGenerator idGenerator;
+
+    private AccessCertificationDefinitionType certDefinition;
+
+    private String campaignOid;
+    private int caseCount;
+
+    @Override
+    public void initSystem(Task initTask, OperationResult initResult) throws Exception {
+        super.initSystem(initTask, initResult);
+        certDefinition = repoAddObjectFromFile(CERT_DEF_FILE,
+                AccessCertificationDefinitionType.class, initResult).asObjectable();
+    }
+
+    /**
+     * Verify test environment is properly initialized.
+     */
+    @Test
+    public void test000Sanity() throws Exception {
+        assertNotNull("Certification definition not loaded", certDefinition);
+        display("Certification definition", certDefinition);
+    }
+
+    /**
+     * Create a campaign and open first stage.
+     * Verify each case has 2 work items (administrator + jack).
+     */
+    @Test
+    public void test010CreateCampaignAndOpenStage() throws Exception {
+        given();
+        Task task = getTestTask();
+        OperationResult result = task.getResult();
+
+        when();
+        AccessCertificationCampaignType campaign =
+                certificationService.createCampaign(certDefinition.getOid(), task, result);
+
+        then();
+        result.computeStatus();
+        TestUtil.assertSuccess(result);
+        assertNotNull("Created campaign is null", campaign);
+
+        campaignOid = campaign.getOid();
+        campaign = getCampaignWithCases(campaignOid);
+        display("Campaign", campaign);
+        assertSanityAfterCampaignCreate(campaign, certDefinition);
+
+        // Open first stage
+        clock.resetOverride();
+        XMLGregorianCalendar startTime = clock.currentTimeXMLGregorianCalendar();
+        task.setOwner(userAdministrator.asPrismObject());
+        certificationService.openNextStage(campaignOid, task, result);
+
+        result.computeStatus();
+        TestUtil.assertInProgressOrSuccess(result);
+
+        List<PrismObject<TaskType>> tasks = getFirstStageTasks(campaignOid, startTime, result);
+        assertEquals("Unexpected number of related tasks", 1, tasks.size());
+        waitForTaskFinish(tasks.get(0).getOid());
+
+        campaign = getCampaignWithCases(campaignOid);
+        display("Campaign after opening stage 1", campaign);
+
+        List<AccessCertificationCaseType> caseList = queryHelper.searchCases(campaignOid, null, result);
+        caseCount = caseList.size();
+        assertTrue("No cases generated", caseCount > 0);
+        displayValue("Number of cases", caseCount);
+
+        for (AccessCertificationCaseType aCase : caseList) {
+            List<AccessCertificationWorkItemType> workItems = aCase.getWorkItem();
+            assertEquals("Wrong number of work items for case " + aCase, 2, workItems.size());
+
+            assertNotNull("No work item for administrator in case " + aCase,
+                    findWorkItem(aCase, 1, 1, USER_ADMINISTRATOR_OID));
+            assertNotNull("No work item for jack in case " + aCase,
+                    findWorkItem(aCase, 1, 1, USER_JACK_OID));
+        }
+    }
+
+    /**
+     * Jack accepts one case. Then verify behavior with collectTrue and collectFalse.
+     * With collectTrue: admin's work item for the decided case is still visible.
+     * With collectFalse: admin's work item for the decided case is excluded.
+     */
+    @Test
+    public void test100RecordDecisionAndVerifyFiltering() throws Exception {
+        given();
+        Task task = getTestTask();
+        OperationResult result = task.getResult();
+
+        List<AccessCertificationCaseType> caseList = queryHelper.searchCases(campaignOid, null, result);
+        AccessCertificationCaseType targetCase = caseList.get(0);
+        long targetCaseId = targetCase.asPrismContainerValue().getId();
+
+        when();
+        recordDecision(campaignOid, targetCase, ACCEPT, "test accept", USER_JACK_OID, task, result);
+
+        then();
+        caseList = queryHelper.searchCases(campaignOid, null, result);
+        targetCase = caseList.stream()
+                .filter(c -> c.asPrismContainerValue().getId().equals(targetCaseId))
+                .findFirst().orElseThrow();
+        display("Target case after decision", targetCase);
+
+        assertCaseOutcome(caseList, targetCase.getObjectRef().getOid(), targetCase.getTargetRef().getOid(),
+                ACCEPT, ACCEPT, null);
+
+        AccessCertificationWorkItemType adminWi = findWorkItem(targetCase, 1, 1, USER_ADMINISTRATOR_OID);
+        assertNotNull("Admin work item not found", adminWi);
+        assertNull("Admin work item should have no outcome", WorkItemTypeUtil.getOutcome(adminWi));
+
+        MidPointPrincipal adminPrincipal = MidPointPrincipal.create(
+                getUser(USER_ADMINISTRATOR_OID).asObjectable());
+        ObjectQuery wiQuery = prismContext.queryFor(AccessCertificationWorkItemType.class)
+                .exists(PrismConstants.T_PARENT)
+                .ownerId(campaignOid)
+                .build();
+
+        // collectTrue: decided case's work items should still be visible
+        ObjectQuery queryTrue = QueryUtils.createQueryForOpenWorkItems(wiQuery.clone(), adminPrincipal, true, true);
+        List<AccessCertificationWorkItemType> workItemsTrue = repositoryService.searchContainers(
+                AccessCertificationWorkItemType.class, queryTrue, null, result);
+        assertEquals("With collectTrue parameter, all admin's undecided work items should be visible",
+                caseCount, workItemsTrue.size());
+
+        // collectFalse: decided case should be excluded
+        ObjectQuery queryFalse = QueryUtils.createQueryForOpenWorkItems(wiQuery.clone(), adminPrincipal, true, false);
+        List<AccessCertificationWorkItemType> workItemsFalse = repositoryService.searchContainers(
+                AccessCertificationWorkItemType.class, queryFalse, null, result);
+        assertEquals("With collectFalse parameter, decided case should be excluded",
+                caseCount - 1, workItemsFalse.size());
+
+        // principal=null with collectFalse: decided case excluded for all reviewers
+        ObjectQuery wiQueryNoPrincipal = prismContext.queryFor(AccessCertificationWorkItemType.class)
+                .exists(PrismConstants.T_PARENT)
+                .ownerId(campaignOid)
+                .build();
+        ObjectQuery queryNoPrincipalFalse = QueryUtils.createQueryForOpenWorkItems(
+                wiQueryNoPrincipal, null, true, false);
+        int wiCountNoPrincipal = modelService.countContainers(
+                AccessCertificationWorkItemType.class, queryNoPrincipalFalse, null, task, result);
+        assertEquals("With principal=null and collectFalse, decided case work items should be excluded",
+                (caseCount - 1) * 2, wiCountNoPrincipal);
+    }
+
+    /**
+     * Verify that a deputy of administrator can see work items via QueryUtils.
+     * With collectTrue: all admin's undecided work items visible.
+     * With collectFalse: decided case excluded.
+     */
+    @Test
+    public void test110QueryWithDeputy() throws Exception {
+        given();
+        Task task = getTestTask();
+        OperationResult result = task.getResult();
+
+        login(getUserFromRepo(USER_ADMINISTRATOR_DEPUTY_NO_ASSIGNMENTS_OID));
+        MidPointPrincipal deputyPrincipal = securityContextManager.getPrincipal();
+
+        when();
+        ObjectQuery wiQuery = prismContext.queryFor(AccessCertificationWorkItemType.class)
+                .exists(PrismConstants.T_PARENT)
+                .ownerId(campaignOid)
+                .build();
+
+        // collectTrue: deputy sees all admin's undecided work items
+        ObjectQuery queryTrue = QueryUtils.createQueryForOpenWorkItems(wiQuery.clone(), deputyPrincipal, true, true);
+        List<AccessCertificationWorkItemType> workItemsTrue = repositoryService.searchContainers(
+                AccessCertificationWorkItemType.class, queryTrue, null, result);
+
+        // collectFalse: deputy also has decided case excluded
+        ObjectQuery queryFalse = QueryUtils.createQueryForOpenWorkItems(wiQuery.clone(), deputyPrincipal, true, false);
+        List<AccessCertificationWorkItemType> workItemsFalse = repositoryService.searchContainers(
+                AccessCertificationWorkItemType.class, queryFalse, null, result);
+
+        then();
+        display("Work items visible to deputy with collectTrue", workItemsTrue);
+        assertEquals("Deputy with collectTrue: all admin's undecided work items",
+                caseCount, workItemsTrue.size());
+
+        display("Work items visible to deputy with collectFalse", workItemsFalse);
+        assertEquals("Deputy with collectFalse: decided case should be excluded",
+                caseCount - 1, workItemsFalse.size());
+
+        login(userAdministrator.asPrismObject());
+    }
+
+    /**
+     * Verify that with notDecidedOnly=false, all work items are returned
+     * regardless of collectDecisionsFromAllReviewers parameter.
+     * The case-level filter (hiding decided cases) requires both
+     * collectDecisionsFromAllReviewers=false AND notDecidedOnly=true.
+     */
+    @Test
+    public void test120QueryWithNotDecidedOnlyFalse() throws Exception {
+        given();
+        Task task = getTestTask();
+        OperationResult result = task.getResult();
+
+        MidPointPrincipal adminPrincipal = MidPointPrincipal.create(
+                getUser(USER_ADMINISTRATOR_OID).asObjectable());
+        ObjectQuery wiQuery = prismContext.queryFor(AccessCertificationWorkItemType.class)
+                .exists(PrismConstants.T_PARENT)
+                .ownerId(campaignOid)
+                .build();
+
+        when();
+        ObjectQuery queryAllCollectFalse = QueryUtils.createQueryForOpenWorkItems(
+                wiQuery.clone(), adminPrincipal, false, false);
+        List<AccessCertificationWorkItemType> allItemsCollectFalse = repositoryService.searchContainers(
+                AccessCertificationWorkItemType.class, queryAllCollectFalse, null, result);
+
+        ObjectQuery queryAllCollectTrue = QueryUtils.createQueryForOpenWorkItems(
+                wiQuery.clone(), adminPrincipal, false, true);
+        List<AccessCertificationWorkItemType> allItemsCollectTrue = repositoryService.searchContainers(
+                AccessCertificationWorkItemType.class, queryAllCollectTrue, null, result);
+
+        then();
+        assertEquals("notDecidedOnly=false, collectFalse: all admin work items should be visible",
+                caseCount, allItemsCollectFalse.size());
+        assertEquals("notDecidedOnly=false, collectTrue: all admin work items should be visible",
+                caseCount, allItemsCollectTrue.size());
+    }
+
+    /**
+     * Verify notification filtering via CertReviewEventImpl.
+     * With collectTrue: all cases await admin response (decided case included).
+     * With collectFalse: decided case excluded from awaiting list.
+     */
+    @Test
+    public void test130NotificationFiltering() throws Exception {
+        given();
+        Task task = getTestTask();
+        OperationResult result = task.getResult();
+        AccessCertificationCampaignType campaign = getCampaignWithCases(campaignOid);
+        SimpleObjectRefImpl adminRef = new SimpleObjectRefImpl(
+                getUser(USER_ADMINISTRATOR_OID).asObjectable());
+
+        when();
+        CertReviewEventImpl eventTrue = new CertReviewEventImpl(
+                idGenerator, campaign.getCase(), campaign, EventOperationType.MODIFY, true);
+        eventTrue.setActualReviewer(adminRef);
+        Collection<AccessCertificationCaseType> awaitingTrue = eventTrue.getCasesAwaitingResponseFromActualReviewer();
+
+        CertReviewEventImpl eventFalse = new CertReviewEventImpl(
+                idGenerator, campaign.getCase(), campaign, EventOperationType.MODIFY, false);
+        eventFalse.setActualReviewer(adminRef);
+        Collection<AccessCertificationCaseType> awaitingFalse = eventFalse.getCasesAwaitingResponseFromActualReviewer();
+
+        then();
+        assertEquals("With collectTrue, all cases should await admin response",
+                caseCount, awaitingTrue.size());
+        assertEquals("With collectFalse, decided case should be excluded from notifications",
+                caseCount - 1, awaitingFalse.size());
+    }
+}

--- a/model/certification-impl/src/test/resources/common/certification-collect-decisions-test.xml
+++ b/model/certification-impl/src/test/resources/common/certification-collect-decisions-test.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0"?>
+<!--
+  ~ Copyright (C) 2026 Evolveum and contributors
+  ~
+  ~ Licensed under the EUPL-1.2 or later.
+  -->
+
+<!-- Certification definition for testing collectDecisionsFromAllReviewers feature.
+     Uses two reviewers (administrator + jack) with oneAcceptAccepts strategy,
+     so one ACCEPT decision changes the case outcome immediately. -->
+<accessCertificationDefinition
+        xmlns='http://midpoint.evolveum.com/xml/ns/public/common/common-3'
+        xmlns:q="http://prism.evolveum.com/xml/ns/public/query-3"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        oid="33333333-0000-0000-0000-000000000004">
+    <name>Collect Decisions Test Certification</name>
+    <description>Certification for testing collectDecisionsFromAllReviewers setting.</description>
+    <handlerUri>http://midpoint.evolveum.com/xml/ns/public/certification/handlers-3#direct-assignment</handlerUri>
+    <scopeDefinition xsi:type="AccessCertificationAssignmentReviewScopeType">
+        <objectType>UserType</objectType>
+        <searchFilter>
+            <q:org>
+                <q:orgRef>
+                    <q:oid>00000000-8888-6666-0000-300000000000</q:oid> <!-- ERoot -->
+                    <q:scope>SUBTREE</q:scope>
+                </q:orgRef>
+            </q:org>
+        </searchFilter>
+        <relation>default</relation>
+    </scopeDefinition>
+    <ownerRef oid="00000000-0000-0000-0000-000000000002" type="UserType"/> <!-- administrator -->
+    <remediationDefinition>
+        <style>automated</style>
+    </remediationDefinition>
+    <stageDefinition>
+        <number>1</number>
+        <duration>P14D</duration>
+        <reviewerSpecification>
+            <defaultReviewerRef oid="00000000-0000-0000-0000-000000000002" type="UserType" /> <!-- administrator -->
+            <additionalReviewerRef oid="c0c010c0-d34d-b33f-f00d-111111111111" type="UserType" /> <!-- jack -->
+        </reviewerSpecification>
+        <outcomeStrategy>oneAcceptAccepts</outcomeStrategy>
+    </stageDefinition>
+</accessCertificationDefinition>

--- a/model/certification-impl/testng-integration.xml
+++ b/model/certification-impl/testng-integration.xml
@@ -14,6 +14,7 @@
             <class name="com.evolveum.midpoint.certification.test.TestCriticalRolesCertification"/>
             <class name="com.evolveum.midpoint.certification.test.TestSoDCertification"/>
             <class name="com.evolveum.midpoint.certification.test.TestEscalation"/>
+            <class name="com.evolveum.midpoint.certification.test.TestCollectDecisionsFromAllReviewers"/>
         </classes>
     </test>
     <test name="Complex" preserve-order="true" parallel="none" verbose="10" enabled="true">

--- a/model/notifications-impl/src/main/java/com/evolveum/midpoint/notifications/impl/events/CertReviewEventImpl.java
+++ b/model/notifications-impl/src/main/java/com/evolveum/midpoint/notifications/impl/events/CertReviewEventImpl.java
@@ -6,6 +6,7 @@
 
 package com.evolveum.midpoint.notifications.impl.events;
 
+import com.evolveum.midpoint.certification.api.OutcomeUtils;
 import com.evolveum.midpoint.notifications.api.events.CertReviewEvent;
 import com.evolveum.midpoint.notifications.api.events.SimpleObjectRef;
 import com.evolveum.midpoint.schema.util.ObjectTypeUtil;
@@ -37,10 +38,22 @@ public class CertReviewEventImpl extends AccessCertificationEventImpl implements
      */
     private SimpleObjectRef actualReviewer;
 
+    /**
+     * If true, awaiting response is determined by WorkItem.outcome.
+     * If false, awaiting response is determined by Case.currentStageOutcome.
+     */
+    private final boolean collectDecisionsFromAllReviewers;
+
     public CertReviewEventImpl(LightweightIdentifierGenerator idGenerator, List<AccessCertificationCaseType> cases,
             AccessCertificationCampaignType campaign, EventOperationType opType) {
+        this(idGenerator, cases, campaign, opType, true);
+    }
+
+    public CertReviewEventImpl(LightweightIdentifierGenerator idGenerator, List<AccessCertificationCaseType> cases,
+            AccessCertificationCampaignType campaign, EventOperationType opType, boolean collectDecisionsFromAllReviewers) {
         super(idGenerator, campaign, opType);
         this.cases = cases;
+        this.collectDecisionsFromAllReviewers = collectDecisionsFromAllReviewers;
     }
 
     @Override
@@ -71,6 +84,17 @@ public class CertReviewEventImpl extends AccessCertificationEventImpl implements
     }
 
     private boolean awaitsResponseFrom(AccessCertificationCaseType aCase, String reviewerOid, int currentStageNumber) {
+        if (!collectDecisionsFromAllReviewers) {
+            // Case-based: check if the case itself has no response yet
+            String currentStageOutcome = aCase.getCurrentStageOutcome();
+            if (currentStageOutcome != null
+                    && !OutcomeUtils.toUri(AccessCertificationResponseType.NO_RESPONSE).equals(currentStageOutcome)) {
+                // Case already has a response from another reviewer
+                return false;
+            }
+        }
+
+        // Check if there's an open work item for this reviewer
         for (AccessCertificationWorkItemType workItem : aCase.getWorkItem()) {
             if (workItem.getStageNumber() == currentStageNumber
                     && WorkItemTypeUtil.getOutcome(workItem) == null

--- a/model/notifications-impl/src/main/java/com/evolveum/midpoint/notifications/impl/events/factory/CertEventFactory.java
+++ b/model/notifications-impl/src/main/java/com/evolveum/midpoint/notifications/impl/events/factory/CertEventFactory.java
@@ -8,9 +8,12 @@ package com.evolveum.midpoint.notifications.impl.events.factory;
 
 import java.util.List;
 
+import com.evolveum.midpoint.model.api.ModelInteractionService;
 import com.evolveum.midpoint.prism.PrismObject;
 import com.evolveum.midpoint.schema.result.OperationResult;
 import com.evolveum.midpoint.security.api.SecurityUtil;
+import com.evolveum.midpoint.util.logging.Trace;
+import com.evolveum.midpoint.util.logging.TraceManager;
 import com.evolveum.midpoint.xml.ns._public.common.common_3.*;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -35,8 +38,13 @@ import com.evolveum.midpoint.task.api.Task;
 @Component
 public class CertEventFactory {
 
+    private static final Trace LOGGER = TraceManager.getTrace(CertEventFactory.class);
+
     @Autowired
     private LightweightIdentifierGenerator idGenerator;
+
+    @Autowired
+    private ModelInteractionService modelInteractionService;
 
     public CertCampaignEvent createOnCampaignStartEvent(AccessCertificationCampaignType campaign, Task task, OperationResult result) {
         CertCampaignEventImpl event = new CertCampaignEventImpl(idGenerator, campaign, EventOperationType.ADD);
@@ -87,15 +95,35 @@ public class CertEventFactory {
 
     public CertReviewEvent createReviewRequestedEvent(ObjectReferenceType reviewerOrDeputyRef, ObjectReferenceType actualReviewerRef,
             List<AccessCertificationCaseType> cases, AccessCertificationCampaignType campaign, Task task, OperationResult result) {
-        CertReviewEventImpl event = new CertReviewEventImpl(idGenerator, cases, campaign, EventOperationType.ADD);
+        CertReviewEventImpl event = new CertReviewEventImpl(idGenerator, cases, campaign, EventOperationType.ADD,
+                isCollectDecisionsFromAllReviewers(result));
         fillInReviewerRelatedEvent(reviewerOrDeputyRef, actualReviewerRef, task, event, result);
         return event;
     }
 
     public CertReviewEvent createReviewDeadlineApproachingEvent(ObjectReferenceType reviewerOrDeputyRef, ObjectReferenceType actualReviewerRef,
             List<AccessCertificationCaseType> cases, AccessCertificationCampaignType campaign, Task task, OperationResult result) {
-        CertReviewEventImpl event = new CertReviewEventImpl(idGenerator, cases, campaign, EventOperationType.MODIFY);
+        CertReviewEventImpl event = new CertReviewEventImpl(idGenerator, cases, campaign, EventOperationType.MODIFY,
+                isCollectDecisionsFromAllReviewers(result));
         fillInReviewerRelatedEvent(reviewerOrDeputyRef, actualReviewerRef, task, event, result);
         return event;
+    }
+
+    /**
+     * Returns whether decisions should be collected from all reviewers.
+     * If true (default), awaiting response is determined by WorkItem.outcome.
+     * If false, awaiting response is determined by Case.currentStageOutcome.
+     */
+    private boolean isCollectDecisionsFromAllReviewers(OperationResult result) {
+        try {
+            AccessCertificationConfigurationType config = modelInteractionService.getCertificationConfiguration(result);
+            if (config == null || config.isCollectDecisionsFromAllReviewers() == null) {
+                return true;  // default: true
+            }
+            return config.isCollectDecisionsFromAllReviewers();
+        } catch (Exception e) {
+            LOGGER.warn("Couldn't load certification configuration, using default value (true)", e);
+            return true;
+        }
     }
 }


### PR DESCRIPTION
Add a new global configuration option `collectDecisionsFromAllReviewers` (boolean, default `true`) to `AccessCertificationConfigurationType`.

- **`true` (default)**: Original behavior. Progress is calculated based on work items. All reviewers are expected to respond.
- **`false`**: Progress is calculated based on cases. Once any reviewer answers a case, it is hidden from other reviewers' work item lists and notifications.

See [MID-11152](https://support.evolveum.com/projects/midpoint/work_packages/11152/activity) for details.
