### PR TITLE
Fix stale form after resource save in connector wizard step panels

### DIFF
--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/component/wizard/scimrest/connection/BaseUrlConnectorStepPanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/component/wizard/scimrest/connection/BaseUrlConnectorStepPanel.java
@@ -34,11 +34,12 @@ import com.evolveum.midpoint.web.model.PrismContainerWrapperModel;
 import com.evolveum.midpoint.xml.ns._public.common.common_3.*;
 
 import org.apache.commons.lang3.StringUtils;
-import java.util.List;
 import org.apache.wicket.ajax.AjaxRequestTarget;
 import org.apache.wicket.behavior.AttributeAppender;
 import org.apache.wicket.markup.html.WebMarkupContainer;
 import org.apache.wicket.model.IModel;
+
+import java.util.List;
 
 /**
  * @author lskublik
@@ -57,6 +58,8 @@ public class BaseUrlConnectorStepPanel extends AbstractFormWizardStepPanel<Conne
     public static final ItemName SCIM_BASE_URL_ITEM_NAME = ItemName.from("", "scimBaseUrl");
 
     private static final String ID_AI_ALERT = "aiAlert";
+
+    private PrismContainerWrapper<? extends Containerable> containerWrapper;
 
     public BaseUrlConnectorStepPanel(WizardPanelHelper<? extends Containerable, ConnectorDevelopmentDetailsModel> helper) {
         super(helper);
@@ -103,6 +106,13 @@ public class BaseUrlConnectorStepPanel extends AbstractFormWizardStepPanel<Conne
 
     @Override
     protected void onBeforeRender() {
+        PrismContainerWrapper<?> wrapper = getContainerFormModel().getObject();
+
+        if (containerWrapper != null && containerWrapper != wrapper) {
+            initLayout();
+        }
+        containerWrapper = wrapper;
+
         super.onBeforeRender();
         ((VerticalFormPrismContainerPanel) getVerticalForm().getSingleContainerPanel().getContainer().get("1"))
                 .getContainer().add(AttributeAppender.remove("class"));
@@ -118,7 +128,7 @@ public class BaseUrlConnectorStepPanel extends AbstractFormWizardStepPanel<Conne
 
         WebMarkupContainer aiAlert = new WebMarkupContainer(ID_AI_ALERT);
         aiAlert.setOutputMarkupId(true);
-        add(aiAlert);
+        addOrReplace(aiAlert);
         aiAlert.add(new VisibleBehaviour(this::isAiAlertVisible));
 
         ItemPanelSettings settings = new ItemPanelSettingsBuilder()
@@ -158,7 +168,7 @@ public class BaseUrlConnectorStepPanel extends AbstractFormWizardStepPanel<Conne
         };
         panel.setOutputMarkupId(true);
         panel.add(AttributeAppender.replace("class", "col-12"));
-        add(panel);
+        addOrReplace(panel);
     }
 
     private boolean isAiAlertVisible() {

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/component/wizard/scimrest/connection/EndpointConnectorStepPanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/component/wizard/scimrest/connection/EndpointConnectorStepPanel.java
@@ -6,11 +6,21 @@
  */
 package com.evolveum.midpoint.gui.impl.page.admin.connector.development.component.wizard.scimrest.connection;
 
+import com.evolveum.midpoint.gui.api.factory.wrapper.WrapperContext;
+import com.evolveum.midpoint.gui.api.prism.wrapper.ItemVisibilityHandler;
+import com.evolveum.midpoint.gui.api.prism.wrapper.ItemWrapper;
+import com.evolveum.midpoint.gui.api.prism.wrapper.PrismContainerWrapper;
 import com.evolveum.midpoint.gui.api.prism.wrapper.PrismReferenceWrapper;
 import com.evolveum.midpoint.gui.api.util.WebComponentUtil;
+import com.evolveum.midpoint.gui.impl.component.wizard.AbstractFormWizardStepPanel;
 import com.evolveum.midpoint.gui.impl.component.wizard.WizardPanelHelper;
+import com.evolveum.midpoint.gui.impl.page.admin.ObjectDetailsModels;
 import com.evolveum.midpoint.gui.impl.page.admin.connector.development.ConnectorDevelopmentDetailsModel;
 import com.evolveum.midpoint.gui.impl.page.admin.connector.development.component.wizard.ConnectorDevelopmentWizardUtil;
+import com.evolveum.midpoint.gui.impl.prism.panel.ItemPanelSettings;
+import com.evolveum.midpoint.gui.impl.prism.panel.ItemPanelSettingsBuilder;
+import com.evolveum.midpoint.gui.impl.prism.panel.vertical.form.VerticalFormPanel;
+import com.evolveum.midpoint.gui.impl.prism.panel.vertical.form.VerticalFormPrismContainerPanel;
 import com.evolveum.midpoint.prism.Containerable;
 import com.evolveum.midpoint.prism.Referencable;
 import com.evolveum.midpoint.prism.path.ItemName;
@@ -19,34 +29,21 @@ import com.evolveum.midpoint.schema.constants.SchemaConstants;
 import com.evolveum.midpoint.schema.result.OperationResult;
 import com.evolveum.midpoint.util.QNameUtil;
 import com.evolveum.midpoint.util.exception.SchemaException;
+import com.evolveum.midpoint.web.application.PanelDisplay;
+import com.evolveum.midpoint.web.application.PanelInstance;
+import com.evolveum.midpoint.web.application.PanelType;
 import com.evolveum.midpoint.web.component.AjaxIconButton;
-import com.evolveum.midpoint.web.component.AjaxSubmitButton;
-
+import com.evolveum.midpoint.web.component.prism.ItemVisibility;
 import com.evolveum.midpoint.web.component.util.VisibleEnableBehaviour;
+import com.evolveum.midpoint.web.model.PrismContainerWrapperModel;
 import com.evolveum.midpoint.xml.ns._public.common.common_3.*;
 
 import org.apache.wicket.ajax.AjaxRequestTarget;
 import org.apache.wicket.behavior.AttributeAppender;
 import org.apache.wicket.markup.repeater.RepeatingView;
 import org.apache.wicket.model.IModel;
-
-import com.evolveum.midpoint.gui.api.factory.wrapper.WrapperContext;
-import com.evolveum.midpoint.gui.api.prism.wrapper.ItemVisibilityHandler;
-import com.evolveum.midpoint.gui.api.prism.wrapper.ItemWrapper;
-import com.evolveum.midpoint.gui.api.prism.wrapper.PrismContainerWrapper;
-import com.evolveum.midpoint.gui.impl.component.wizard.AbstractFormWizardStepPanel;
-import com.evolveum.midpoint.gui.impl.page.admin.ObjectDetailsModels;
-import com.evolveum.midpoint.gui.impl.prism.panel.ItemPanelSettings;
-import com.evolveum.midpoint.gui.impl.prism.panel.ItemPanelSettingsBuilder;
-import com.evolveum.midpoint.gui.impl.prism.panel.vertical.form.VerticalFormPanel;
-import com.evolveum.midpoint.gui.impl.prism.panel.vertical.form.VerticalFormPrismContainerPanel;
-import com.evolveum.midpoint.web.application.PanelDisplay;
-import com.evolveum.midpoint.web.application.PanelInstance;
-import com.evolveum.midpoint.web.application.PanelType;
-import com.evolveum.midpoint.web.component.prism.ItemVisibility;
-import com.evolveum.midpoint.web.model.PrismContainerWrapperModel;
-
 import org.apache.wicket.model.Model;
+
 
 /**
  * @author lskublik
@@ -62,6 +59,8 @@ public class EndpointConnectorStepPanel extends AbstractFormWizardStepPanel<Conn
     private static final String PANEL_TYPE = "cdw-endpoint-path";
 
     public static final ItemName PROPERTY_ITEM_NAME = ItemName.from("", "restTestEndpoint");
+
+    private PrismContainerWrapper<? extends Containerable> containerWrapper;
 
     public EndpointConnectorStepPanel(WizardPanelHelper<? extends Containerable, ConnectorDevelopmentDetailsModel> helper) {
         super(helper);
@@ -90,6 +89,12 @@ public class EndpointConnectorStepPanel extends AbstractFormWizardStepPanel<Conn
 
     @Override
     protected void onBeforeRender() {
+        PrismContainerWrapper<?> wrapper = getContainerFormModel().getObject();
+        if (containerWrapper != null && containerWrapper != wrapper) {
+            initLayout();
+        }
+        containerWrapper = wrapper;
+
         super.onBeforeRender();
         ((VerticalFormPrismContainerPanel)getVerticalForm().getSingleContainerPanel().getContainer().get("1"))
                 .getContainer().add(AttributeAppender.remove("class"));
@@ -104,7 +109,7 @@ public class EndpointConnectorStepPanel extends AbstractFormWizardStepPanel<Conn
         getFeedback().add(AttributeAppender.replace("class", "col-12 feedbackContainer"));
 
 
-                ItemPanelSettings settings = new ItemPanelSettingsBuilder()
+        ItemPanelSettings settings = new ItemPanelSettingsBuilder()
                 .visibilityHandler(getVisibilityHandler())
                 .mandatoryHandler(this::checkMandatory)
                 .build();
@@ -141,7 +146,7 @@ public class EndpointConnectorStepPanel extends AbstractFormWizardStepPanel<Conn
         };
         panel.setOutputMarkupId(true);
         panel.add(AttributeAppender.replace("class", "col-12"));
-        add(panel);
+        addOrReplace(panel);
     }
 
     protected String getPanelType() {


### PR DESCRIPTION
After saving the testing resource, ReferenceExecutedDeltaProcessor calls resetNewObjectModel() to clear the cached ObjectDetailsModels so fresh data is loaded from the repository. The next call to getContainerFormModel() therefore returns a brand-new PrismContainerWrapper instance, but the Wicket form components are still wired to the old one, causing stale display and broken data binding.

Fix: in onBeforeRender(), compare the current wrapper instance with the last known one using identity (!=). If changed, call initLayout() to rebuild the form against the new wrapper.

initLayout() can now be called multiple times, so add() is replaced with addOrReplace() to avoid "component with id 'form' already exists" errors.