### PR TITLE
MID-8834 Fix work item search by name mapping

### DIFF
--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/component/search/SearchableItemsDefinitions.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/component/search/SearchableItemsDefinitions.java
@@ -157,7 +157,7 @@ public class SearchableItemsDefinitions {
         ));
 
         SEARCHABLE_OBJECTS.put(CaseWorkItemType.class, Arrays.asList(
-                ItemPath.create(AbstractWorkItemType.F_NAME),
+                ItemPath.create(PrismConstants.T_PARENT, CaseType.F_NAME),
                 ItemPath.create(CaseWorkItemType.F_ASSIGNEE_REF),
                 ItemPath.create(CaseWorkItemType.F_ORIGINAL_ASSIGNEE_REF),
                 ItemPath.create(PrismConstants.T_PARENT, CaseType.F_STATE),

--- a/release-notes.adoc
+++ b/release-notes.adoc
@@ -99,6 +99,7 @@ Overall, midPoint 4.10 opens up the world of identity management and governance 
 * Improved login and self-dashboard performance. See bug:MID-10972[]
 * Fixed hide export button in the popup. See bug:MID-11160[]
 * Delineation suggestions: filter parsing broken after recent GUI change. See bug:MID-11175[]
+* Fixed work item search by name causing repository mapping error. See bug:MID-8834[]
 
 
 === Releases Of Other Components

--- a/repo/repo-sqale/src/test/java/com/evolveum/midpoint/repo/sqale/func/SqaleRepoSearchTest.java
+++ b/repo/repo-sqale/src/test/java/com/evolveum/midpoint/repo/sqale/func/SqaleRepoSearchTest.java
@@ -2507,6 +2507,16 @@ public class SqaleRepoSearchTest extends SqaleRepoBaseTest {
     }
 
     @Test
+    public void test611SearchCaseWIContainerByParentCaseName() throws SchemaException {
+        SearchResultList<CaseWorkItemType> result = searchContainerTest(
+                "by parent case name", CaseWorkItemType.class,
+                f -> f.item(T_PARENT, CaseType.F_NAME).eq(new PolyString("case-1")));
+        assertThat(result)
+                .extracting(CaseWorkItemType::getStageNumber)
+                .containsExactlyInAnyOrder(1, 2);
+    }
+
+    @Test
     public void test615SearchAssignmentByApproverNameWithOrder() throws SchemaException {
         SearchResultList<AssignmentType> result = searchContainerTest(
                 "by approver name", AssignmentType.class,


### PR DESCRIPTION
Filtering work items by **Name** failed due to missing mapping.

The Name column in the UI is derived from the parent case (stored in m_case), not in m_case_wi. Therefore, the search must target the parent case.

This change updates the searchable path to:
`PrismConstants.T_PARENT, CaseType.F_NAME`

aligning the query with the data model and fixing the error.