### PR TITLE
MID-11177 Fix archetype display label translation

### DIFF
--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/api/util/GuiDisplayTypeUtil.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/api/util/GuiDisplayTypeUtil.java
@@ -130,11 +130,9 @@ public class GuiDisplayTypeUtil {
                         null, null, pageBase.createSimpleTask(result.getOperation()), result);
                 if (archetype != null) {
                     DisplayType archetypeDisplayType = archetype.getArchetypePolicy() != null ? archetype.getArchetypePolicy().getDisplay() : null;
-                    String archetypeTooltip = archetypeDisplayType != null && archetypeDisplayType.getLabel() != null &&
-                            StringUtils.isNotEmpty(archetypeDisplayType.getLabel().getOrig()) ?
-                            archetypeDisplayType.getLabel().getOrig() :
-                            (archetype.getName() != null && StringUtils.isNotEmpty(archetype.getName().getOrig()) ?
-                                    archetype.getName().getOrig() : null);
+                    String archetypeTooltip = StringUtils.defaultIfEmpty(
+                            getTranslatedLabel(archetypeDisplayType),
+                            archetype.getName() != null ? LocalizationUtil.translatePolyString(archetype.getName()) : null);
                     typeValue = archetypeTooltip;
                     typeTitle = StringUtils.isNotEmpty(archetypeTooltip) ?
                             pageBase.createStringResource("abstractRoleMemberPanel.withType", archetypeTooltip).getString() : "";

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/AbstractSummaryPanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/AbstractSummaryPanel.java
@@ -12,6 +12,7 @@ import java.util.Objects;
 import java.util.stream.Collectors;
 import javax.xml.namespace.QName;
 
+import com.evolveum.midpoint.gui.api.util.LocalizationUtil;
 import com.evolveum.midpoint.util.logging.Trace;
 
 import com.evolveum.midpoint.util.logging.TraceManager;
@@ -451,13 +452,13 @@ public abstract class AbstractSummaryPanel<C extends Containerable> extends Base
         return sb.toString();
     }
 
-    private String translateDisplayLabelOrDefault(DisplayType display, String defValue) {
+    protected String translateDisplayLabelOrDefault(DisplayType display, String defValue) {
         if (display == null || display.getLabel() == null) {
             return defValue;
         }
-        String label = display.getLabel().getOrig();
 
-        return getString(label, Model.of(), label);
+        String translatedLabel = LocalizationUtil.translatePolyString(display.getLabel());
+        return StringUtils.isNotEmpty(translatedLabel) ? translatedLabel : defValue;
     }
 
     private String getArchetypeIconCssClass() {

--- a/gui/admin-gui/src/test/java/com/evolveum/midpoint/web/TestDisplayLabelLocalization.java
+++ b/gui/admin-gui/src/test/java/com/evolveum/midpoint/web/TestDisplayLabelLocalization.java
@@ -1,0 +1,176 @@
+/*
+ * Copyright (c) 2026 Evolveum and contributors
+ *
+ * Licensed under the EUPL-1.2 or later.
+ */
+
+package com.evolveum.midpoint.web;
+
+import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.AssertJUnit.assertFalse;
+import static org.testng.AssertJUnit.assertTrue;
+
+import java.util.List;
+import java.util.Locale;
+
+import org.apache.wicket.model.Model;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ActiveProfiles;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import com.evolveum.midpoint.model.api.AssignmentObjectRelation;
+import com.evolveum.midpoint.repo.api.RepoAddOptions;
+import com.evolveum.midpoint.schema.constants.SchemaConstants;
+import com.evolveum.midpoint.gui.test.TestMidPointSpringApplication;
+import com.evolveum.midpoint.gui.api.util.GuiDisplayTypeUtil;
+import com.evolveum.midpoint.schema.result.OperationResult;
+import com.evolveum.midpoint.task.api.Task;
+import com.evolveum.midpoint.web.component.AbstractSummaryPanel;
+import com.evolveum.midpoint.web.security.MidPointAuthWebSession;
+import com.evolveum.midpoint.web.page.admin.users.PageUsers;
+import com.evolveum.midpoint.xml.ns._public.common.common_3.ArchetypePolicyType;
+import com.evolveum.midpoint.xml.ns._public.common.common_3.ArchetypeType;
+import com.evolveum.midpoint.xml.ns._public.common.common_3.DisplayType;
+import com.evolveum.midpoint.xml.ns._public.common.common_3.ObjectReferenceType;
+import com.evolveum.midpoint.xml.ns._public.common.common_3.SummaryPanelSpecificationType;
+import com.evolveum.midpoint.xml.ns._public.common.common_3.UserType;
+import com.evolveum.prism.xml.ns._public.types_3.PolyStringLangType;
+import com.evolveum.prism.xml.ns._public.types_3.PolyStringTranslationType;
+import com.evolveum.prism.xml.ns._public.types_3.PolyStringType;
+
+/**
+ * Regression coverage for assignment relation display labels. The archetype branch must use the localized
+ * display label value, not {@code display.label.orig}, when composing labels like {@code <archetype> (<relation>)}.
+ */
+@ActiveProfiles("test")
+@SpringBootTest(classes = TestMidPointSpringApplication.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+public class TestDisplayLabelLocalization extends AbstractGuiIntegrationTest {
+
+    private static final Locale TEST_LOCALE = Locale.forLanguageTag("sk");
+    private static final String ARCHETYPE_OID = "00000000-0000-0000-0000-00000000a111";
+
+    private Locale originalSessionLocale;
+
+    @Override
+    public void initSystem(Task initTask, OperationResult initResult) throws Exception {
+        repoAddObjectFromFile(USER_ADMINISTRATOR_FILE, RepoAddOptions.createOverwrite(), false, initResult);
+
+        super.initSystem(initTask, initResult);
+    }
+
+    @BeforeMethod
+    public void setSessionLocale() {
+        MidPointAuthWebSession session = MidPointAuthWebSession.get();
+        originalSessionLocale = session.getLocale();
+        session.setLocale(TEST_LOCALE);
+    }
+
+    @AfterMethod(alwaysRun = true)
+    public void restoreSessionLocale() {
+        MidPointAuthWebSession session = MidPointAuthWebSession.get();
+        if (session != null && originalSessionLocale != null) {
+            session.setLocale(originalSessionLocale);
+        }
+        originalSessionLocale = null;
+    }
+
+    @Test
+    public void testAssignmentObjectRelationDisplayLabelLocalization() throws Exception {
+        OperationResult result = new OperationResult("testAssignmentObjectRelationDisplayLabelLocalization");
+        repoAddObject(createArchetype().asPrismObject(), "test archetype", RepoAddOptions.createOverwrite(), result);
+
+        AssignmentObjectRelation assignmentTargetRelation = new AssignmentObjectRelation();
+        assignmentTargetRelation.setArchetypeRefs(List.of(
+                new ObjectReferenceType().oid(ARCHETYPE_OID).type(ArchetypeType.COMPLEX_TYPE)));
+        assignmentTargetRelation.setRelations(List.of(SchemaConstants.ORG_DEFAULT));
+
+        PageUsers page = tester.startPage(PageUsers.class);
+        DisplayType display = GuiDisplayTypeUtil.getAssignmentObjectRelationDisplayType(
+                page, assignmentTargetRelation, "abstractRoleMemberPanel.title");
+
+        String translatedLabel = GuiDisplayTypeUtil.getTranslatedLabel(display);
+        assertTrue("Expected assignment relation display label to contain translated archetype label, but was: "
+                        + translatedLabel,
+                translatedLabel.contains("standardKeyCustomValue"));
+        assertFalse("Assignment relation display label must not use raw archetype label: " + translatedLabel,
+                translatedLabel.contains("MyApp"));
+        assertEquals(translatedLabel, new TestSummaryPanel().callTranslateDisplayLabelOrDefault(display, "fallback"));
+    }
+
+    @Test
+    public void testOrigDisplayLabelFallback() {
+        DisplayType display = new DisplayType().label(new PolyStringType("MyApp"));
+
+        assertEquals("MyApp", GuiDisplayTypeUtil.getTranslatedLabel(display));
+        assertEquals("MyApp", new TestSummaryPanel().callTranslateDisplayLabelOrDefault(display, "fallback"));
+    }
+
+    @Test
+    public void testMissingDisplayLabelFallbackToDefault() {
+        DisplayType display = new DisplayType();
+
+        assertEquals("", GuiDisplayTypeUtil.getTranslatedLabel(display));
+        assertEquals("fallback", new TestSummaryPanel().callTranslateDisplayLabelOrDefault(display, "fallback"));
+    }
+
+    @Test
+    public void testNullDisplayFallbackToDefault() {
+        assertEquals("fallback", new TestSummaryPanel().callTranslateDisplayLabelOrDefault(null, "fallback"));
+    }
+
+    /**
+     * Creates a polystring whose raw {@code orig} value intentionally differs from the localized value so the
+     * regression is visible.
+     */
+    private static PolyStringType createPolyString(String orig, String key) {
+        PolyStringType value = new PolyStringType(orig);
+        PolyStringLangType lang = new PolyStringLangType();
+        lang.getLang().put(TEST_LOCALE.getLanguage(), "standardKeyCustomValue");
+        value.setLang(lang);
+        PolyStringTranslationType translation = new PolyStringTranslationType();
+        translation.setKey(key);
+        value.setTranslation(translation);
+        return value;
+    }
+
+    private static ArchetypeType createArchetype() {
+        DisplayType displayType = new DisplayType().label(createPolyString("MyApp", "standardKey"));
+        ArchetypePolicyType policy = new ArchetypePolicyType().display(displayType);
+
+        ArchetypeType archetype = new ArchetypeType();
+        archetype.setOid(ARCHETYPE_OID);
+        archetype.setName(new PolyStringType("test-archetype"));
+        archetype.setArchetypePolicy(policy);
+        return archetype;
+    }
+
+    private static class TestSummaryPanel extends AbstractSummaryPanel<UserType> {
+
+        private TestSummaryPanel() {
+            super("panel", Model.of(new UserType()), new SummaryPanelSpecificationType());
+        }
+
+        private String callTranslateDisplayLabelOrDefault(DisplayType display, String defaultValue) {
+            return translateDisplayLabelOrDefault(display, defaultValue);
+        }
+
+        @Override
+        protected String getDefaultIconCssClass() {
+            return "";
+        }
+
+        @Override
+        protected String getIconBoxAdditionalCssClass() {
+            return "";
+        }
+
+        @Override
+        protected String getBoxAdditionalCssClass() {
+            return "";
+        }
+    }
+}

--- a/gui/admin-gui/testng-integration.xml
+++ b/gui/admin-gui/testng-integration.xml
@@ -31,6 +31,7 @@
     <test name="Features" preserve-order="true" parallel="none" verbose="10">
         <classes>
             <class name="com.evolveum.midpoint.web.RequestAccessTest"/>
+            <class name="com.evolveum.midpoint.web.TestDisplayLabelLocalization"/>
             <class name="com.evolveum.midpoint.web.component.FileValidatorTest"/>
         </classes>
     </test>

--- a/release-notes.adoc
+++ b/release-notes.adoc
@@ -101,7 +101,7 @@ Overall, midPoint 4.10 opens up the world of identity management and governance 
 * Fixed hide export button in the popup. See bug:MID-11160[]
 * Delineation suggestions: filter parsing broken after recent GUI change. See bug:MID-11175[]
 * Fixed work item search by name causing repository mapping error. See bug:MID-8834[]
-
+* Fixed translation of archetype display labels in assignment picker and summary panel. See bug:MID-10834[]
 
 === Releases Of Other Components
 


### PR DESCRIPTION
## **Summary**
Fixes MID-10834: archetype display labels in the GUI were using the raw `display.label.orig` value instead of the localized PolyString value.

This affected two visible places:

* assignment object picker cards, for example showing `MyApp (Default)` instead of the localized label
* summary panel archetype badges, for example showing `MyApp` instead of the localized label

--------------------------------------------------------------------------------------------

## **Changes**
* Updated `GuiDisplayTypeUtil.getAssignmentObjectRelationDisplayType(...)` to resolve archetype display labels through PolyString localization before composing the relation suffix.
* Updated `AbstractSummaryPanel.translateDisplayLabelOrDefault(...)` to use localized PolyString resolution instead of treating `label.orig` as a resource key.
* Added regression coverage in `TestDisplayLabelLocalization`.

--------------------------------------------------------------------------------------------

## **Testing**
Verified manually on localhost:

* assignment picker now shows the localized archetype label, e.g. `Applications (Default)`
* summary panel archetype badge now shows the localized archetype label, e.g. `Applications`
* object/page title still correctly uses the repository object name, e.g. `MyApp`

Regression test added:

* verifies assignment relation display labels use the localized PolyString value instead of raw `orig`
* verifies plain `orig` fallback
* verifies missing label fallback
* verifies null display fallback
