### PR TITLE
MID-11179 Improve user list performance for large orgRelation authorization

### DIFF
--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/component/data/provider/SelectableBeanContainerDataProvider.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/component/data/provider/SelectableBeanContainerDataProvider.java
@@ -54,7 +54,8 @@ public class SelectableBeanContainerDataProvider<C extends Containerable> extend
     protected Integer countObjects(Class<C> type, ObjectQuery query,
             Collection<SelectorOptions<GetOperationOptions>> currentOptions, Task task, OperationResult result)
             throws CommonException {
-        return getModelService().countContainers(type, getQuery(), currentOptions, task, result);
+        // Use the query passed from internalSize(); it is also used for the count cache key.
+        return getModelService().countContainers(type, query, currentOptions, task, result);
     }
 
     @Override

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/component/data/provider/SelectableBeanDataProvider.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/component/data/provider/SelectableBeanDataProvider.java
@@ -71,6 +71,12 @@ public abstract class SelectableBeanDataProvider<T extends Serializable> extends
 
     private OperationResult result;
 
+    // Short-lived count cache for repeated Wicket size/page-count calls in one render.
+    // Cleared on detach and provider state changes; independent of row/object caching.
+    private CountCacheKey cachedCountKey;
+    private Integer cachedCount;
+    private boolean cachedCountAvailable;
+
     public Set<T> getSelected() {
         return selected;
     }
@@ -261,11 +267,20 @@ public abstract class SelectableBeanDataProvider<T extends Serializable> extends
             return Integer.MAX_VALUE;
         }
         int count = 0;
-        Task task = getPageBase().createSimpleTask(OPERATION_COUNT_OBJECTS);
-        OperationResult result = task.getResult();
+        Task task = createCountTask();
+        OperationResult result = createCountResult(task);
         try {
             Collection<SelectorOptions<GetOperationOptions>> currentOptions = GetOperationOptions.merge( getSearchOptions(), null);
-            Integer counted = countObjects(getType(), getQuery(), currentOptions, task, result);
+            Class<T> type = getType();
+            ObjectQuery query = getQuery();
+            CountCacheKey countKey = new CountCacheKey(type, query, currentOptions);
+            Integer counted;
+            if (isCountCached(countKey)) {
+                counted = cachedCount;
+            } else {
+                counted = countObjects(type, query, currentOptions, task, result);
+                cacheCount(countKey, counted);
+            }
             count = defaultIfNull(counted, defaultCountIfNull);
         } catch (Exception ex) {
             setupUserFriendlyMessage(result, ex);
@@ -285,10 +300,34 @@ public abstract class SelectableBeanDataProvider<T extends Serializable> extends
         return count;
     }
 
+    private boolean isCountCached(CountCacheKey countKey) {
+        return cachedCountAvailable && Objects.equals(cachedCountKey, countKey);
+    }
+
+    private void cacheCount(CountCacheKey countKey, Integer count) {
+        cachedCountKey = countKey;
+        cachedCount = count;
+        cachedCountAvailable = true;
+    }
+
+    private void clearCountCache() {
+        cachedCountKey = null;
+        cachedCount = null;
+        cachedCountAvailable = false;
+    }
+
     protected abstract Integer countObjects(Class<T> type, ObjectQuery query,
             Collection<SelectorOptions<GetOperationOptions>> currentOptions,
             Task task, OperationResult result)
             throws CommonException;
+
+    protected Task createCountTask() {
+        return getPageBase().createSimpleTask(OPERATION_COUNT_OBJECTS);
+    }
+
+    protected OperationResult createCountResult(Task task) {
+        return task.getResult();
+    }
 
     public boolean isUseObjectCounting() {
         CompiledObjectCollectionView guiObjectListViewType = getCompiledObjectCollectionView();
@@ -300,6 +339,7 @@ public abstract class SelectableBeanDataProvider<T extends Serializable> extends
 
 
     public void setOptions(Collection<SelectorOptions<GetOperationOptions>> options) {
+        clearCountCache();
         this.options = options;
     }
 
@@ -316,6 +356,7 @@ public abstract class SelectableBeanDataProvider<T extends Serializable> extends
     }
 
     public void setForPreview(boolean forPreview) {
+        clearCountCache();
         isForPreview = forPreview;
     }
 
@@ -336,5 +377,32 @@ public abstract class SelectableBeanDataProvider<T extends Serializable> extends
     public void detach() {
         super.detach();
         result = null;
+        clearCountCache();
+    }
+
+    @Override
+    public void clearCache() {
+        super.clearCache();
+        clearCountCache();
+    }
+
+    @Override
+    public void setCompiledObjectCollectionView(CompiledObjectCollectionView objectCollectionView) {
+        clearCountCache();
+        super.setCompiledObjectCollectionView(objectCollectionView);
+    }
+
+    private record CountCacheKey(Class<?> type, ObjectQuery query,
+                                 Collection<SelectorOptions<GetOperationOptions>> options) implements Serializable {
+
+            private CountCacheKey(
+                    Class<?> type,
+                    ObjectQuery query,
+                    Collection<SelectorOptions<GetOperationOptions>> options) {
+                this.type = type;
+                this.query = query != null ? query.clone() : null;
+                this.options = options != null ? List.copyOf(options) : null;
+            }
+
     }
 }

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/component/data/provider/SelectableBeanObjectDataProvider.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/component/data/provider/SelectableBeanObjectDataProvider.java
@@ -94,8 +94,9 @@ public class SelectableBeanObjectDataProvider<O extends ObjectType> extends Sele
     protected Integer countObjects(Class<O> type, ObjectQuery query,
             Collection<SelectorOptions<GetOperationOptions>> currentOptions,
             Task task, OperationResult result) throws CommonException {
+        // Use the query passed from internalSize(); it is also used for the count cache key.
         return getModelService().countObjects(
-                type, getQuery(), currentOptions, task, result);
+                type, query, currentOptions, task, result);
     }
 
     protected boolean isMemberPanel() {

--- a/gui/admin-gui/src/test/java/com/evolveum/midpoint/gui/SelectableBeanDataProviderCountCacheTest.java
+++ b/gui/admin-gui/src/test/java/com/evolveum/midpoint/gui/SelectableBeanDataProviderCountCacheTest.java
@@ -1,0 +1,219 @@
+/*
+ * Copyright (C) 2026 Evolveum and contributors
+ *
+ * Licensed under the EUPL-1.2 or later.
+ */
+
+package com.evolveum.midpoint.gui;
+
+import static org.testng.AssertJUnit.*;
+
+import java.lang.reflect.Proxy;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+import org.apache.wicket.markup.html.basic.Label;
+import org.apache.wicket.model.Model;
+import org.apache.wicket.util.tester.WicketTester;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import com.evolveum.midpoint.gui.impl.component.data.provider.SelectableBeanDataProvider;
+import com.evolveum.midpoint.gui.impl.component.search.Search;
+import com.evolveum.midpoint.model.api.ModelInteractionService;
+import com.evolveum.midpoint.model.api.authentication.CompiledGuiProfile;
+import com.evolveum.midpoint.model.api.authentication.CompiledObjectCollectionView;
+import com.evolveum.midpoint.prism.query.ObjectQuery;
+import com.evolveum.midpoint.schema.GetOperationOptions;
+import com.evolveum.midpoint.schema.SelectorOptions;
+import com.evolveum.midpoint.schema.result.OperationResult;
+import com.evolveum.midpoint.task.api.Task;
+import com.evolveum.midpoint.task.api.test.NullTaskImpl;
+import com.evolveum.midpoint.web.AbstractGuiUnitTest;
+import com.evolveum.midpoint.web.component.util.SelectableBean;
+import com.evolveum.midpoint.xml.ns._public.common.common_3.UserType;
+
+/**
+ * Tests short-lived count caching in {@link SelectableBeanDataProvider}.
+ */
+public class SelectableBeanDataProviderCountCacheTest extends AbstractGuiUnitTest {
+
+    private static final ModelInteractionService MODEL_INTERACTION_SERVICE = (ModelInteractionService)
+            Proxy.newProxyInstance(
+                    ModelInteractionService.class.getClassLoader(),
+                    new Class<?>[] { ModelInteractionService.class },
+                    (proxy, method, args) -> "getCompiledGuiProfile".equals(method.getName())
+                            ? new CompiledGuiProfile()
+                            : null);
+
+    private WicketTester wicketTester;
+
+    @BeforeClass
+    public void initWicket() {
+        wicketTester = new WicketTester();
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void destroyWicket() {
+        if (wicketTester != null) {
+            wicketTester.destroy();
+            wicketTester = null;
+        }
+    }
+
+    /**
+     * Simulates Wicket asking for provider size repeatedly during one render.
+     * The second request should reuse cached count instead of calling model/repository count again.
+     */
+    @Test
+    public void testRepeatedSizeCallsUseCachedCount() {
+        TestProvider provider = new TestProvider();
+        provider.returnCount = 42;
+
+        assertEquals(42, provider.size());
+        assertEquals(42, provider.size());
+
+        assertEquals(1, provider.countCalls);
+    }
+
+    /**
+     * Verifies invalidation paths for provider state that can affect count semantics.
+     * After each state change, the next size request must execute a fresh count.
+     */
+    @Test
+    public void testStateChangesInvalidateCountCache() {
+        assertInvalidatesCountCache(provider -> provider.setOptions(GetOperationOptions.createRawCollection()));
+        assertInvalidatesCountCache(TestProvider::clearCache);
+        assertInvalidatesCountCache(TestProvider::detach);
+        assertInvalidatesCountCache(provider -> provider.setCompiledObjectCollectionView(new CompiledObjectCollectionView()));
+    }
+
+    /**
+     * Preview panels intentionally bypass object counting.
+     * Leaving preview mode must not reuse a count captured before preview mode was enabled.
+     */
+    @Test
+    public void testPreviewBypassesCountingAndDoesNotReuseStaleCount() {
+        TestProvider provider = new TestProvider();
+        provider.returnCount = 42;
+
+        assertEquals(42, provider.size());
+        provider.returnCount = 43;
+        provider.setForPreview(true);
+
+        assertEquals(Integer.MAX_VALUE, provider.size());
+        assertEquals(1, provider.countCalls);
+
+        provider.setForPreview(false);
+        assertEquals(43, provider.size());
+        assertEquals(2, provider.countCalls);
+    }
+
+    /**
+     * Guards against recomputing the query inside concrete count implementations.
+     * The count operation must use the query instance captured by internalSize(), because it is also the cache key.
+     */
+    @Test
+    public void testCountReceivesQueryBuiltForCurrentInternalSizeCall() {
+        TestProvider provider = new TestProvider();
+        provider.querySupplier = () -> queryForOid(UUID.randomUUID().toString());
+
+        assertEquals(42, provider.size());
+
+        assertSame(provider.builtQueries.get(0), provider.lastCountQuery);
+        assertEquals(1, provider.builtQueries.size());
+        assertEquals(1, provider.countCalls);
+    }
+
+    private ObjectQuery queryForOid(String oid) {
+        return getPrismContext().queryFor(UserType.class)
+                .id(oid)
+                .build();
+    }
+
+    private void assertInvalidatesCountCache(Consumer<TestProvider> invalidator) {
+        TestProvider provider = new TestProvider();
+        provider.returnCount = 42;
+
+        assertEquals(42, provider.size());
+        provider.returnCount = 43;
+        invalidator.accept(provider);
+
+        assertEquals(43, provider.size());
+        assertEquals(2, provider.countCalls);
+    }
+
+    private class TestProvider extends SelectableBeanDataProvider<UserType> {
+
+        private final Class<UserType> type = UserType.class;
+        private Supplier<ObjectQuery> querySupplier = () -> queryForOid("00000000-0000-0000-0000-000000000001");
+        private int returnCount = 42;
+        private int countCalls;
+        private ObjectQuery lastCountQuery;
+        private final List<ObjectQuery> builtQueries = new ArrayList<>();
+
+        private TestProvider() {
+            super(new Label("test"), Model.of((Search<UserType>) null), Set.of(), false);
+        }
+
+        @Override
+        protected ModelInteractionService getModelInteractionService() {
+            return MODEL_INTERACTION_SERVICE;
+        }
+
+        @Override
+        public ObjectQuery getQuery() {
+            ObjectQuery query = querySupplier.get();
+            builtQueries.add(query);
+            return query;
+        }
+
+        @Override
+        public Class<UserType> getType() {
+            return type;
+        }
+
+        @Override
+        protected Task createCountTask() {
+            return new NullTaskImpl();
+        }
+
+        @Override
+        protected OperationResult createCountResult(Task task) {
+            return new OperationResult("test");
+        }
+
+        @Override
+        public Iterator<SelectableBean<UserType>> internalIterator(long offset, long pageSize) {
+            return List.<SelectableBean<UserType>>of().iterator();
+        }
+
+        @Override
+        protected List<UserType> searchObjects(Class<UserType> type, ObjectQuery query,
+                Collection<SelectorOptions<GetOperationOptions>> options, Task task, OperationResult result) {
+            return List.of();
+        }
+
+        @Override
+        protected boolean match(UserType selectedValue, UserType foundValue) {
+            return false;
+        }
+
+        @Override
+        protected Integer countObjects(Class<UserType> type, ObjectQuery query,
+                Collection<SelectorOptions<GetOperationOptions>> currentOptions,
+                Task task, OperationResult result) {
+            assertSame(this.type, type);
+            countCalls++;
+            lastCountQuery = query;
+            return returnCount;
+        }
+    }
+}

--- a/gui/admin-gui/testng-unit.xml
+++ b/gui/admin-gui/testng-unit.xml
@@ -12,6 +12,7 @@
             <class name="com.evolveum.midpoint.web.TestUnitObjectWrapperFactory"/>
             <class name="com.evolveum.midpoint.web.TestPageMounter"/>
             <class name="com.evolveum.midpoint.web.TestXmlGregorianCalendarModel"/>
+            <class name="com.evolveum.midpoint.gui.SelectableBeanDataProviderCountCacheTest"/>
         </classes>
     </test>
 </suite>

--- a/infra/schema/src/main/java/com/evolveum/midpoint/schema/selector/eval/OrgTreeEvaluator.java
+++ b/infra/schema/src/main/java/com/evolveum/midpoint/schema/selector/eval/OrgTreeEvaluator.java
@@ -6,6 +6,8 @@
 
 package com.evolveum.midpoint.schema.selector.eval;
 
+import java.util.Collection;
+
 import com.evolveum.midpoint.prism.PrismObject;
 import com.evolveum.midpoint.util.exception.*;
 import com.evolveum.midpoint.xml.ns._public.common.common_3.ObjectType;
@@ -53,6 +55,19 @@ public interface OrgTreeEvaluator {
      * @param ancestorOrgOid identifier of ancestor organization
      */
     <O extends ObjectType> boolean isDescendant(PrismObject<O> object, String ancestorOrgOid)
+            throws SchemaException;
+
+    /**
+     * Returns `true` if the `object` is under the organization identified with `ancestorOrgOids`.
+     *
+     * The `object` can be an Org or any other object; all targets of its
+     * `parentOrgRef`s are tested. The object is not considered to be its own
+     * descendant. An empty or null ancestor collection returns `false`.
+     *
+     * @param object object of any type tested to belong under one of the ancestor orgs
+     * @param ancestorOrgOids identifiers of ancestor organizations
+     */
+     <O extends ObjectType> boolean isDescendantOfAny(PrismObject<O> object, Collection<String> ancestorOrgOids)
             throws SchemaException;
 
 }

--- a/infra/schema/src/main/java/com/evolveum/midpoint/schema/selector/spec/OrgRelationClause.java
+++ b/infra/schema/src/main/java/com/evolveum/midpoint/schema/selector/spec/OrgRelationClause.java
@@ -25,8 +25,10 @@ import org.apache.commons.lang3.BooleanUtils;
 import org.jetbrains.annotations.NotNull;
 
 import javax.xml.namespace.QName;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 
 import static com.evolveum.midpoint.schema.util.ObjectTypeUtil.asObjectTypeIfPossible;
 
@@ -66,6 +68,11 @@ public class OrgRelationClause extends SelectorClause {
         }
         var principalFocus = ctx.getPrincipalFocus();
         if (principalFocus != null) {
+            // ALL_DESCENDANTS is the default used by the existing org-relation matching logic.
+            OrgScopeType scope = Objects.requireNonNullElse(bean.getScope(), OrgScopeType.ALL_DESCENDANTS);
+            if (scope == OrgScopeType.ALL_DESCENDANTS) {
+                return matchesAllDescendants(object, principalFocus, ctx);
+            }
             for (ObjectReferenceType subjectParentOrgRef : principalFocus.getParentOrgRef()) {
                 if (matchesOrgRelation(object, subjectParentOrgRef, ctx)) {
                     traceApplicable(ctx, "subject org matches: %s", subjectParentOrgRef.getOid());
@@ -73,6 +80,36 @@ public class OrgRelationClause extends SelectorClause {
                 }
             }
         }
+        traceNotApplicable(ctx, "none of the subject orgs match");
+        return false;
+    }
+
+    private boolean matchesAllDescendants(
+            ObjectType object, FocusType principalFocus, @NotNull SelectorProcessingContext ctx)
+            throws SchemaException {
+        Set<String> ancestorOrgOids = new LinkedHashSet<>();
+        for (ObjectReferenceType subjectParentOrgRef : principalFocus.getParentOrgRef()) {
+            if (PrismContext.get().relationMatches(bean.getSubjectRelation(), subjectParentOrgRef.getRelation())) {
+                String subjectOrgOid = subjectParentOrgRef.getOid();
+                if (BooleanUtils.isTrue(bean.isIncludeReferenceOrg())
+                        && subjectOrgOid.equals(object.getOid())) {
+                    traceApplicable(ctx, "subject org matches by includeReferenceOrg: %s", subjectOrgOid);
+                    return true;
+                }
+                ancestorOrgOids.add(subjectOrgOid);
+            }
+        }
+
+        if (ancestorOrgOids.isEmpty()) {
+            traceNotApplicable(ctx, "none of the subject orgs match subject relation");
+            return false;
+        }
+
+        if (ctx.orgTreeEvaluator.isDescendantOfAny(object.asPrismObject(), ancestorOrgOids)) {
+            traceApplicable(ctx, "subject org matches one of: %s", ancestorOrgOids);
+            return true;
+        }
+
         traceNotApplicable(ctx, "none of the subject orgs match");
         return false;
     }

--- a/infra/schema/src/test/java/com/evolveum/midpoint/schema/selector/spec/OrgRelationClauseBatchingTest.java
+++ b/infra/schema/src/test/java/com/evolveum/midpoint/schema/selector/spec/OrgRelationClauseBatchingTest.java
@@ -1,0 +1,261 @@
+/*
+ * Copyright (C) 2026 Evolveum and contributors
+ *
+ * Licensed under the EUPL-1.2 or later.
+ */
+
+package com.evolveum.midpoint.schema.selector.spec;
+
+import static com.evolveum.midpoint.schema.selector.eval.SubjectedEvaluationContext.DelegatorSelection.NO_DELEGATOR;
+import static org.testng.AssertJUnit.*;
+
+import java.util.Collection;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import javax.xml.namespace.QName;
+
+import org.jetbrains.annotations.NotNull;
+import org.testng.annotations.Test;
+
+import com.evolveum.midpoint.prism.PrismObject;
+import com.evolveum.midpoint.schema.AbstractSchemaTest;
+import com.evolveum.midpoint.schema.constants.SchemaConstants;
+import com.evolveum.midpoint.schema.selector.eval.ClauseProcessingContextDescription;
+import com.evolveum.midpoint.schema.selector.eval.MatchingContext;
+import com.evolveum.midpoint.schema.selector.eval.OrgTreeEvaluator;
+import com.evolveum.midpoint.schema.selector.eval.SelectorTraceEvent;
+import com.evolveum.midpoint.schema.selector.eval.SubjectedEvaluationContext;
+import com.evolveum.midpoint.schema.traces.details.ProcessingTracer;
+import com.evolveum.midpoint.xml.ns._public.common.common_3.FocusType;
+import com.evolveum.midpoint.xml.ns._public.common.common_3.ObjectReferenceType;
+import com.evolveum.midpoint.xml.ns._public.common.common_3.ObjectType;
+import com.evolveum.midpoint.xml.ns._public.common.common_3.OrgRelationObjectSpecificationType;
+import com.evolveum.midpoint.xml.ns._public.common.common_3.OrgScopeType;
+import com.evolveum.midpoint.xml.ns._public.common.common_3.OrgType;
+import com.evolveum.midpoint.xml.ns._public.common.common_3.UserType;
+
+/**
+ * Tests post-filter matching for orgRelation selectors.
+ *
+ * Regression focus: ALL_DESCENDANTS should batch descendant checks for all matching
+ * subject org refs, while preserving includeReferenceOrg and subjectRelation semantics.
+ */
+public class OrgRelationClauseBatchingTest extends AbstractSchemaTest {
+
+    private static final String ORG_A = "00000000-0000-0000-0000-0000000000a1";
+    private static final String ORG_B = "00000000-0000-0000-0000-0000000000b1";
+    private static final String ORG_C = "00000000-0000-0000-0000-0000000000c1";
+    private static final String TARGET = "00000000-0000-0000-0000-000000000010";
+    private static final QName CUSTOM_TARGET_RELATION = QName.valueOf("{https://example.com/relations}custom");
+
+    /**
+     * Principal has multiple parentOrgRefs, but only manager refs are selected by subjectRelation.
+     * The selected ancestor OIDs should be passed to one batched isDescendantOfAny call, not checked one by one.
+     */
+    @Test
+    public void testAllDescendantsUsesOneBatchedDescendantLookup() throws Exception {
+        TrackingOrgTreeEvaluator evaluator = new TrackingOrgTreeEvaluator();
+        UserType principal = principal(
+                parentOrgRef(ORG_A, SchemaConstants.ORG_MANAGER),
+                parentOrgRef(ORG_B, SchemaConstants.ORG_DEFAULT),
+                parentOrgRef(ORG_C, SchemaConstants.ORG_MANAGER));
+        UserType target = targetUser(TARGET, parentOrgRef("00000000-0000-0000-0000-000000000111", CUSTOM_TARGET_RELATION));
+
+        boolean matches = clause(SchemaConstants.ORG_MANAGER, false)
+                .matches(target.asPrismObject().getValue(), context(principal, evaluator));
+
+        assertTrue(matches);
+        assertEquals(1, evaluator.isDescendantOfAnyCalls);
+        assertEquals(0, evaluator.isDescendantCalls);
+        assertEquals(Set.of(ORG_A, ORG_C), evaluator.lastAncestorOrgOids);
+    }
+
+    /**
+     * When the target object is one of the matching subject orgs, includeReferenceOrg=true is sufficient to match.
+     * This self branch is separate from descendant membership and should avoid any org-closure lookup.
+     */
+    @Test
+    public void testIncludeReferenceOrgSelfMatchAvoidsDescendantLookup() throws Exception {
+        TrackingOrgTreeEvaluator evaluator = new TrackingOrgTreeEvaluator();
+        UserType principal = principal(parentOrgRef(ORG_A, SchemaConstants.ORG_MANAGER));
+        OrgType target = new OrgType().oid(ORG_A).name("org-a");
+
+        boolean matches = clause(SchemaConstants.ORG_MANAGER, true)
+                .matches(target.asPrismObject().getValue(), context(principal, evaluator));
+
+        assertTrue(matches);
+        assertEquals(0, evaluator.isDescendantOfAnyCalls);
+        assertEquals(0, evaluator.isDescendantCalls);
+    }
+
+    /**
+     * The same target/self setup must not match just because the OIDs are equal when includeReferenceOrg=false.
+     * In that case the clause should continue to descendant evaluation and return what the evaluator returns.
+     */
+    @Test
+    public void testIncludeReferenceOrgFalseDoesNotSelfMatch() throws Exception {
+        TrackingOrgTreeEvaluator evaluator = new TrackingOrgTreeEvaluator();
+        evaluator.isDescendantOfAnyReturnValue = false;
+        UserType principal = principal(parentOrgRef(ORG_A, SchemaConstants.ORG_MANAGER));
+        OrgType target = new OrgType().oid(ORG_A).name("org-a");
+
+        boolean matches = clause(SchemaConstants.ORG_MANAGER, false)
+                .matches(target.asPrismObject().getValue(), context(principal, evaluator));
+
+        assertFalse(matches);
+        assertEquals(1, evaluator.isDescendantOfAnyCalls);
+        assertEquals(Set.of(ORG_A), evaluator.lastAncestorOrgOids);
+    }
+
+    /**
+     * subjectRelation=manager selects manager refs from the principal only.
+     * The target object is passed to descendant evaluation with its original non-manager parentOrgRef relation intact,
+     * proving that target-side relation is not accidentally constrained by subjectRelation.
+     */
+    @Test
+    public void testSubjectRelationFiltersPrincipalRefsOnly() throws Exception {
+        TrackingOrgTreeEvaluator evaluator = new TrackingOrgTreeEvaluator();
+        UserType principal = principal(
+                parentOrgRef(ORG_A, SchemaConstants.ORG_MANAGER),
+                parentOrgRef(ORG_B, SchemaConstants.ORG_DEFAULT));
+        UserType target = targetUser(
+                TARGET,
+                parentOrgRef("00000000-0000-0000-0000-000000000222", CUSTOM_TARGET_RELATION));
+
+        boolean matches = clause(SchemaConstants.ORG_MANAGER, false)
+                .matches(target.asPrismObject().getValue(), context(principal, evaluator));
+
+        assertTrue(matches);
+        assertEquals(Set.of(ORG_A), evaluator.lastAncestorOrgOids);
+        assertEquals(TARGET, evaluator.lastObject.getOid());
+        assertEquals(
+                CUSTOM_TARGET_RELATION,
+                ((UserType) evaluator.lastObject.asObjectable()).getParentOrgRef().get(0).getRelation());
+    }
+
+    /**
+     * Principal has parentOrgRefs, but none match subjectRelation=manager.
+     * With no selected ancestor orgs there is nothing to batch, so the clause should return false immediately.
+     */
+    @Test
+    public void testNoMatchingSubjectRelationsReturnsFalseWithoutLookup() throws Exception {
+        TrackingOrgTreeEvaluator evaluator = new TrackingOrgTreeEvaluator();
+        UserType principal = principal(parentOrgRef(ORG_B, SchemaConstants.ORG_DEFAULT));
+        UserType target = targetUser(TARGET);
+
+        boolean matches = clause(SchemaConstants.ORG_MANAGER, false)
+                .matches(target.asPrismObject().getValue(), context(principal, evaluator));
+
+        assertFalse(matches);
+        assertEquals(0, evaluator.isDescendantOfAnyCalls);
+        assertEquals(0, evaluator.isDescendantCalls);
+    }
+
+    private OrgRelationClause clause(QName subjectRelation, boolean includeReferenceOrg) {
+        OrgRelationObjectSpecificationType bean = new OrgRelationObjectSpecificationType();
+        bean.setScope(OrgScopeType.ALL_DESCENDANTS);
+        bean.setSubjectRelation(subjectRelation);
+        bean.setIncludeReferenceOrg(includeReferenceOrg);
+        return OrgRelationClause.of(bean);
+    }
+
+    private MatchingContext context(FocusType principal, OrgTreeEvaluator evaluator) {
+        return new MatchingContext(
+                null,
+                new NoOpTracer(),
+                evaluator,
+                new TestSubjectedEvaluationContext(principal),
+                null,
+                null,
+                ClauseProcessingContextDescription.defaultOne(),
+                NO_DELEGATOR,
+                true);
+    }
+
+    private UserType principal(ObjectReferenceType... parentOrgRefs) {
+        UserType principal = new UserType().oid("00000000-0000-0000-0000-000000000001").name("principal");
+        for (ObjectReferenceType parentOrgRef : parentOrgRefs) {
+            principal.getParentOrgRef().add(parentOrgRef);
+        }
+        return principal;
+    }
+
+    private UserType targetUser(String oid, ObjectReferenceType... parentOrgRefs) {
+        UserType target = new UserType().oid(oid).name("target");
+        for (ObjectReferenceType parentOrgRef : parentOrgRefs) {
+            target.getParentOrgRef().add(parentOrgRef);
+        }
+        return target;
+    }
+
+    private ObjectReferenceType parentOrgRef(String oid, QName relation) {
+        return new ObjectReferenceType()
+                .oid(oid)
+                .type(OrgType.COMPLEX_TYPE)
+                .relation(relation);
+    }
+
+    private static class TrackingOrgTreeEvaluator implements OrgTreeEvaluator {
+
+        private boolean isDescendantOfAnyReturnValue = true;
+        private int isDescendantCalls;
+        private int isDescendantOfAnyCalls;
+        private PrismObject<?> lastObject;
+        private Set<String> lastAncestorOrgOids;
+
+        @Override
+        public <O extends ObjectType> boolean isDescendant(PrismObject<O> object, String ancestorOrgOid) {
+            isDescendantCalls++;
+            return false;
+        }
+
+        @Override
+        public <O extends ObjectType> boolean isDescendantOfAny(
+                PrismObject<O> object, Collection<String> ancestorOrgOids) {
+            isDescendantOfAnyCalls++;
+            lastObject = object;
+            lastAncestorOrgOids = new LinkedHashSet<>(ancestorOrgOids);
+            return isDescendantOfAnyReturnValue;
+        }
+
+        @Override
+        public <O extends ObjectType> boolean isAncestor(PrismObject<O> object, String descendantOrgOid) {
+            return false;
+        }
+    }
+
+    private record TestSubjectedEvaluationContext(FocusType principal) implements SubjectedEvaluationContext {
+
+        @Override
+        public String getPrincipalOid() {
+            return principal.getOid();
+        }
+
+        @Override
+        public FocusType getPrincipalFocus() {
+            return principal;
+        }
+
+        @Override
+        public @NotNull Set<String> getSelfOids(@NotNull DelegatorSelection delegatorSelection) {
+            return Set.of(principal.getOid());
+        }
+
+        @Override
+        public @NotNull Set<String> getSelfPlusRolesOids(@NotNull DelegatorSelection delegatorSelection) {
+            return Set.of(principal.getOid());
+        }
+    }
+
+    private static class NoOpTracer implements ProcessingTracer<SelectorTraceEvent> {
+
+        @Override
+        public boolean isEnabled() {
+            return false;
+        }
+
+        @Override
+        public void trace(@NotNull SelectorTraceEvent event) {
+        }
+    }
+}

--- a/infra/schema/testng-unit.xml
+++ b/infra/schema/testng-unit.xml
@@ -143,6 +143,7 @@
             <class name="com.evolveum.midpoint.schema.TestSchemaImmutability"/>
             <class name="com.evolveum.midpoint.schema.TestParseFilter"/>
             <class name="com.evolveum.midpoint.schema.TestFilterSimplifier"/>
+            <class name="com.evolveum.midpoint.schema.selector.spec.OrgRelationClauseBatchingTest"/>
             <class name="com.evolveum.midpoint.schema.simulations.TestSimulationMetricComputations"/>
             <class name="com.evolveum.midpoint.schema.TestConfigErrorReporter"/>
             <class name="com.evolveum.midpoint.schema.validator.processor.TestUpgradeProcessors"/>

--- a/model/model-impl/src/test/java/com/evolveum/midpoint/model/impl/util/mock/RepositoryServiceMock.java
+++ b/model/model-impl/src/test/java/com/evolveum/midpoint/model/impl/util/mock/RepositoryServiceMock.java
@@ -131,6 +131,11 @@ public class RepositoryServiceMock implements RepositoryService {
     }
 
     @Override
+    public <O extends ObjectType> boolean isDescendantOfAny(PrismObject<O> object, Collection<String> ancestorOrgOids) throws SchemaException {
+        return false;
+    }
+
+    @Override
     public <O extends ObjectType> boolean isAncestor(
             PrismObject<O> object, String descendantOrgOid) {
         return false;

--- a/release-notes.adoc
+++ b/release-notes.adoc
@@ -104,6 +104,7 @@ Overall, midPoint 4.10 opens up the world of identity management and governance 
 * Fixed translation of archetype display labels in assignment picker and summary panel. See bug:MID-11177[]
 * Fix 10k limit in certification queries using iterative search. See bug:MID-11043[]
 * Fixed generic "Fatal error" message in object tables to show available list/search error details. See bug:MID-10911[]
+* Improved user list performance with orgRelation authorization for users managing many organizations. See bug:MID-11179[]
 
 === Releases Of Other Components
 

--- a/repo/repo-api/src/main/java/com/evolveum/midpoint/repo/api/RepositoryService.java
+++ b/repo/repo-api/src/main/java/com/evolveum/midpoint/repo/api/RepositoryService.java
@@ -127,6 +127,7 @@ public interface RepositoryService extends OrgTreeEvaluator, CaseSupportMixin, A
     String OP_MODIFY_OBJECT_DYNAMICALLY = "modifyObjectDynamically";
     String OP_GET_VERSION = "getVersion";
     String OP_IS_DESCENDANT = "isDescendant";
+    String OP_IS_DESCENDANT_OF_ANY = "isDescendantOfAny";
     String OP_IS_ANCESTOR = "isAncestor";
     String OP_ADVANCE_SEQUENCE = "advanceSequence";
     String OP_RETURN_UNUSED_VALUES_TO_SEQUENCE = "returnUnusedValuesToSequence";

--- a/repo/repo-cache/src/main/java/com/evolveum/midpoint/repo/cache/RepositoryCache.java
+++ b/repo/repo-cache/src/main/java/com/evolveum/midpoint/repo/cache/RepositoryCache.java
@@ -352,6 +352,18 @@ public class RepositoryCache implements RepositoryService, Cache {
     }
 
     @Override
+    public <O extends ObjectType> boolean isDescendantOfAny(
+            PrismObject<O> object, Collection<String> ancestorOrgOids)
+            throws SchemaException {
+        Long startTime = repoOpStart();
+        try {
+            return repositoryService.isDescendantOfAny(object, ancestorOrgOids);
+        } finally {
+            repoOpEnd(startTime);
+        }
+    }
+
+    @Override
     public <O extends ObjectType> boolean isAncestor(PrismObject<O> object, String descendantOrgOid)
             throws SchemaException {
         Long startTime = repoOpStart();

--- a/repo/repo-sqale/src/main/java/com/evolveum/midpoint/repo/sqale/SqaleQueryContext.java
+++ b/repo/repo-sqale/src/main/java/com/evolveum/midpoint/repo/sqale/SqaleQueryContext.java
@@ -10,14 +10,12 @@ import java.util.Collection;
 import java.util.UUID;
 import javax.xml.namespace.QName;
 
-import com.evolveum.midpoint.xml.ns._public.common.common_3.RepositoryConfigurationType;
-import com.evolveum.midpoint.xml.ns._public.common.common_3.ShadowType;
-
 import com.querydsl.core.types.Expression;
 import com.querydsl.core.types.Predicate;
 import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.sql.SQLQuery;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import com.evolveum.midpoint.prism.PrismObject;
 import com.evolveum.midpoint.prism.query.*;
@@ -41,8 +39,6 @@ import com.evolveum.midpoint.util.exception.ObjectNotFoundException;
 import com.evolveum.midpoint.util.exception.SchemaException;
 import com.evolveum.midpoint.util.exception.SystemException;
 import com.evolveum.midpoint.xml.ns._public.common.common_3.ObjectType;
-
-import org.jetbrains.annotations.Nullable;
 
 public class SqaleQueryContext<S, Q extends FlexibleRelationalPathBase<R>, R>
         extends SqlQueryContext<S, Q, R> {
@@ -139,6 +135,9 @@ public class SqaleQueryContext<S, Q extends FlexibleRelationalPathBase<R>, R>
             return new InOidFilterProcessor(this).process((InOidFilter) filter);
         } else if (filter instanceof OrgFilter) {
             return new OrgFilterProcessor(this).process((OrgFilter) filter);
+        } else if (filter instanceof OrFilter) {
+            @Nullable Predicate predicate = new OrgFilterOrOptimizer(this).process((OrFilter) filter);
+            return predicate != null ? predicate : super.process(filter);
         } else if (filter instanceof FullTextFilter) {
             return new FullTextFilterProcessor(this).process((FullTextFilter) filter);
         } else if (filter instanceof ExistsFilter) {

--- a/repo/repo-sqale/src/main/java/com/evolveum/midpoint/repo/sqale/SqaleRepositoryService.java
+++ b/repo/repo-sqale/src/main/java/com/evolveum/midpoint/repo/sqale/SqaleRepositoryService.java
@@ -1975,28 +1975,68 @@ public class SqaleRepositoryService extends SqaleServiceBase implements Reposito
         Validate.notNull(ancestorOrgOid, "ancestorOrgOid must not be null");
 
         logger.trace("Querying if object {} is descendant of {}", object.getOid(), ancestorOrgOid);
+        return isDescendantOfAnyInternal(object, List.of(ancestorOrgOid), OP_IS_DESCENDANT);
+    }
+
+    /**
+     * Batched variant of {@link #isDescendant(PrismObject, String)} used by selector post-filtering.
+     * It checks all supplied ancestors against all parentOrgRefs of the object with a single closure query.
+     */
+    @Override
+    public <O extends ObjectType> boolean isDescendantOfAny(
+            PrismObject<O> object, Collection<String> ancestorOrgOids) {
+        Validate.notNull(object, "object must not be null");
+
+        logger.trace("Querying if object {} is descendant of any of {}", object.getOid(), ancestorOrgOids);
+        if (ancestorOrgOids == null || ancestorOrgOids.isEmpty()) {
+            return false;
+        }
+
+        return isDescendantOfAnyInternal(object, ancestorOrgOids, OP_IS_DESCENDANT_OF_ANY);
+    }
+
+    private <O extends ObjectType> boolean isDescendantOfAnyInternal(
+            PrismObject<O> object, Collection<String> ancestorOrgOids, String operationName) {
         List<ObjectReferenceType> objParentOrgRefs = object.asObjectable().getParentOrgRef();
         if (objParentOrgRefs == null || objParentOrgRefs.isEmpty()) {
             return false;
         }
 
-        List<UUID> objParentOrgOids = objParentOrgRefs.stream()
-                .map(ref -> UUID.fromString(ref.getOid()))
-                .collect(Collectors.toList());
-
-        long opHandle = registerOperationStart(OP_IS_DESCENDANT, OrgType.class);
+        Set<UUID> objParentOrgOids = new LinkedHashSet<>();
+        Set<UUID> ancestorUuids = new LinkedHashSet<>();
         try {
-            return executeRetriable(OP_IS_DESCENDANT, SqaleUtils.oidToUuid(object.getOid()), opHandle, () -> {
+            for (ObjectReferenceType ref : objParentOrgRefs) {
+                String parentOrgOid = ref.getOid();
+                if (parentOrgOid == null) {
+                    throw new SystemException("Object parentOrgRef without OID cannot be used for descendant check");
+                }
+                objParentOrgOids.add(UUID.fromString(parentOrgOid));
+            }
+            for (String ancestorOrgOid : ancestorOrgOids) {
+                if (ancestorOrgOid == null) {
+                    throw new SystemException("Null ancestor org OID cannot be used for descendant check");
+                }
+                ancestorUuids.add(UUID.fromString(ancestorOrgOid));
+            }
+        } catch (IllegalArgumentException e) {
+            throw new SystemException("Cannot convert org OID to UUID for descendant check", e);
+        }
+
+        long opHandle = registerOperationStart(operationName, OrgType.class);
+        try {
+            return executeRetriable(operationName, SqaleUtils.oidToUuid(object.getOid()), opHandle, () -> {
                 try (JdbcSession jdbcSession = sqlRepoContext.newJdbcSession().startTransaction()) {
                     jdbcSession.executeStatement("CALL m_refresh_org_closure()");
 
                     QOrgClosure oc = new QOrgClosure();
-                    long count = jdbcSession.newQuery()
+                    Integer one = jdbcSession.newQuery()
+                            .select(Expressions.ONE)
                             .from(oc)
-                            .where(oc.ancestorOid.eq(UUID.fromString(ancestorOrgOid))
+                            .where(oc.ancestorOid.in(ancestorUuids)
                                     .and(oc.descendantOid.in(objParentOrgOids)))
-                            .fetchCount();
-                    return count != 0L;
+                            .limit(1)
+                            .fetchFirst();
+                    return one != null;
                 }
             });
         } catch (ObjectAlreadyExistsException | ObjectNotFoundException | SchemaException | RepositoryException e) {

--- a/repo/repo-sqale/src/main/java/com/evolveum/midpoint/repo/sqale/filtering/OrgFilterOrOptimizer.java
+++ b/repo/repo-sqale/src/main/java/com/evolveum/midpoint/repo/sqale/filtering/OrgFilterOrOptimizer.java
@@ -44,6 +44,12 @@ import com.evolveum.midpoint.repo.sqlbase.querydsl.QuerydslUtils;
  * EXISTS. This optimizer groups compatible subtree org branches by target relation and replaces
  * multi-org groups with one semijoin-style EXISTS using {@code ancestor_oid in (...)}. Branches
  * outside the optimized groups are preserved and processed through the normal sqale path.
+ *
+ * Example: an OR like
+ * {@code isChildOf(orgA) OR id(orgA) OR isChildOf(orgB) OR id(orgB)}
+ * is rewritten to one subtree check using {@code ancestor_oid IN (orgA, orgB)}
+ * plus one object OID check using {@code oid IN (orgA, orgB)}. Non-compatible
+ * branches remain in the OR and are processed normally.
  */
 public class OrgFilterOrOptimizer implements FilterProcessor<OrFilter> {
 
@@ -144,6 +150,15 @@ public class OrgFilterOrOptimizer implements FilterProcessor<OrFilter> {
                 context.uniqueAliasName(QOrgClosure.DEFAULT_ALIAS_NAME));
     }
 
+    /**
+     * Parsed representation of an OR filter split into parts that can be optimized
+     * and parts that must keep the standard processing path.
+     *
+     * Compatible subtree org filters are grouped by target parent-org relation.
+     * Simple object OID filters are split later: OIDs matching optimized org groups
+     * become self branches of those groups, while unrelated OIDs stay as normal
+     * leftover OID predicates.
+     */
     private static class Optimization {
         // null key means ANY target parentOrgRef relation
         private final Map<QName, OrgGroup> orgGroups = new LinkedHashMap<>();
@@ -245,6 +260,15 @@ public class OrgFilterOrOptimizer implements FilterProcessor<OrFilter> {
         }
     }
 
+    /**
+     * Group of subtree org filters that can share one optimized EXISTS predicate.
+     *
+     * All org filters in the group use the same target parent-org relation.
+     * The optimized predicate checks whether one of the object's parent-org refs,
+     * optionally constrained by relation, points to a descendant of any
+     * {@link #orgOids}. Optional {@link #selfOids} represent direct object OID
+     * branches such as those produced by includeReferenceOrg-style filters.
+     */
     private static class OrgGroup {
         private final QName relation;
         private final Set<String> orgOids = new LinkedHashSet<>();

--- a/repo/repo-sqale/src/main/java/com/evolveum/midpoint/repo/sqale/filtering/OrgFilterOrOptimizer.java
+++ b/repo/repo-sqale/src/main/java/com/evolveum/midpoint/repo/sqale/filtering/OrgFilterOrOptimizer.java
@@ -1,0 +1,267 @@
+/*
+ * Copyright (C) 2026 Evolveum and contributors
+ *
+ * Licensed under the EUPL-1.2 or later.
+ */
+
+package com.evolveum.midpoint.repo.sqale.filtering;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import javax.xml.namespace.QName;
+
+import com.querydsl.core.types.ExpressionUtils;
+import com.querydsl.core.types.Predicate;
+import com.querydsl.sql.SQLQuery;
+import org.jetbrains.annotations.Nullable;
+
+import com.evolveum.midpoint.prism.query.InOidFilter;
+import com.evolveum.midpoint.prism.query.ObjectFilter;
+import com.evolveum.midpoint.prism.query.OrFilter;
+import com.evolveum.midpoint.prism.query.OrgFilter;
+import com.evolveum.midpoint.repo.sqale.SqaleQueryContext;
+import com.evolveum.midpoint.repo.sqale.qmodel.object.MObject;
+import com.evolveum.midpoint.repo.sqale.qmodel.object.QObject;
+import com.evolveum.midpoint.repo.sqale.qmodel.org.QOrgClosure;
+import com.evolveum.midpoint.repo.sqale.qmodel.ref.QObjectReference;
+import com.evolveum.midpoint.repo.sqale.qmodel.ref.QObjectReferenceMapping;
+import com.evolveum.midpoint.repo.sqlbase.QueryException;
+import com.evolveum.midpoint.repo.sqlbase.RepositoryException;
+import com.evolveum.midpoint.repo.sqlbase.filtering.FilterProcessor;
+import com.evolveum.midpoint.repo.sqlbase.querydsl.FlexibleRelationalPathBase;
+import com.evolveum.midpoint.repo.sqlbase.querydsl.QuerydslUtils;
+
+/**
+ * Partially collapses ORs produced by orgRelation authorization.
+ *
+ * The generic OR processor would turn every subtree {@link OrgFilter} into its own correlated
+ * EXISTS. This optimizer groups compatible subtree org branches by target relation and replaces
+ * multi-org groups with one semijoin-style EXISTS using {@code ancestor_oid in (...)}. Branches
+ * outside the optimized groups are preserved and processed through the normal sqale path.
+ */
+public class OrgFilterOrOptimizer implements FilterProcessor<OrFilter> {
+
+    private final SqaleQueryContext<?, ?, ?> context;
+
+    public OrgFilterOrOptimizer(SqaleQueryContext<?, ?, ?> context) {
+        this.context = context;
+    }
+
+    @Override
+    public @Nullable Predicate process(OrFilter filter) throws RepositoryException {
+        FlexibleRelationalPathBase<?> path = context.root();
+        if (!(path instanceof QObject<?> objectPath)) {
+            return null;
+        }
+
+        Optimization optimization = Optimization.from(filter);
+        if (!optimization.hasUsefulOptimization()) {
+            return null;
+        }
+
+        optimization.splitInOidFiltersByOptimizedGroups();
+
+        List<Predicate> predicates = new ArrayList<>();
+        for (OrgGroup group : optimization.optimizedGroups()) {
+            predicates.add(processOptimized(group, objectPath));
+        }
+        for (Set<String> leftoverOids : optimization.leftoverOidSets) {
+            predicates.add(objectPath.oid.in(toUuids(leftoverOids)));
+        }
+        for (ObjectFilter leftover : optimization.leftoverFilters) {
+            Predicate predicate = context.process(leftover);
+            if (predicate != null) {
+                predicates.add(predicate);
+            }
+        }
+
+        return or(predicates);
+    }
+
+    private Predicate processOptimized(OrgGroup group, QObject<?> objectPath) throws QueryException {
+        context.markContainsOrgFilter();
+
+        QObjectReference<MObject> ref = getNewRefAlias();
+        QOrgClosure oc = getNewClosureAlias();
+        SQLQuery<?> subQuery = new SQLQuery<>()
+                .select(QuerydslUtils.EXPRESSION_ONE)
+                .from(ref)
+                .join(oc).on(oc.descendantOid.eq(ref.targetOid))
+                .where(ref.ownerOid.eq(objectPath.oid)
+                        .and(oc.ancestorOid.in(toUuids(group.orgOids))));
+
+        if (group.relation != null) {
+            subQuery.where(ref.relationId.eq(
+                    context.repositoryContext().searchCachedRelationId(group.relation)));
+        }
+
+        Predicate predicate = subQuery.exists();
+        if (!group.selfOids.isEmpty()) {
+            predicate = ExpressionUtils.or(
+                    predicate,
+                    objectPath.oid.in(toUuids(group.selfOids)));
+        }
+        return predicate;
+    }
+
+    private Predicate or(List<Predicate> predicates) {
+        Predicate result = null;
+        for (Predicate predicate : predicates) {
+            result = result != null
+                    ? ExpressionUtils.or(result, predicate)
+                    : predicate;
+        }
+        return result;
+    }
+
+    private UUID[] toUuids(Collection<String> oids) throws QueryException {
+        List<UUID> uuids = new ArrayList<>(oids.size());
+        for (String oid : oids) {
+            try {
+                uuids.add(UUID.fromString(oid));
+            } catch (IllegalArgumentException e) {
+                throw new QueryException("OID '" + oid + "' is not a valid UUID.", e);
+            }
+        }
+        return uuids.toArray(UUID[]::new);
+    }
+
+    private QObjectReference<MObject> getNewRefAlias() {
+        QObjectReferenceMapping<?, QObject<MObject>, MObject> refMapping =
+                QObjectReferenceMapping.getForParentOrg();
+        return refMapping.newAlias(
+                context.uniqueAliasName(refMapping.defaultAliasName()));
+    }
+
+    private QOrgClosure getNewClosureAlias() {
+        return new QOrgClosure(
+                context.uniqueAliasName(QOrgClosure.DEFAULT_ALIAS_NAME));
+    }
+
+    private static class Optimization {
+        // null key means ANY target parentOrgRef relation
+        private final Map<QName, OrgGroup> orgGroups = new LinkedHashMap<>();
+        private final List<InOidFilter> simpleInOidFilters = new ArrayList<>();
+        private final List<ObjectFilter> leftoverFilters = new ArrayList<>();
+        private final List<Set<String>> leftoverOidSets = new ArrayList<>();
+
+        private static Optimization from(OrFilter filter) {
+            Optimization optimization = new Optimization();
+            List<ObjectFilter> flattened = new ArrayList<>();
+            flattenOr(filter, flattened);
+
+            for (ObjectFilter condition : flattened) {
+                if (condition instanceof OrgFilter orgFilter && isOptimizable(orgFilter)) {
+                    optimization.groupFor(orgFilter.getOrgRef().getRelation())
+                            .add(orgFilter);
+                } else if (condition instanceof InOidFilter inOidFilter && isSimpleRootInOid(inOidFilter)) {
+                    optimization.simpleInOidFilters.add(inOidFilter);
+                } else {
+                    optimization.leftoverFilters.add(condition);
+                }
+            }
+
+            optimization.moveSingletonGroupsToLeftovers();
+            return optimization;
+        }
+
+        private boolean hasUsefulOptimization() {
+            return orgGroups.values().stream()
+                    .anyMatch(OrgGroup::isOptimized);
+        }
+
+        private List<OrgGroup> optimizedGroups() {
+            return orgGroups.values().stream()
+                    .filter(OrgGroup::isOptimized)
+                    .toList();
+        }
+
+        private void splitInOidFiltersByOptimizedGroups() {
+            for (InOidFilter filter : simpleInOidFilters) {
+                Set<String> leftoverOids = new LinkedHashSet<>();
+                for (String oid : filter.getOids()) {
+                    OrgGroup group = findOptimizedGroupContaining(oid);
+                    if (group != null) {
+                        group.selfOids.add(oid);
+                    } else {
+                        leftoverOids.add(oid);
+                    }
+                }
+                if (!leftoverOids.isEmpty()) {
+                    leftoverOidSets.add(leftoverOids);
+                }
+            }
+        }
+
+        private @Nullable OrgGroup findOptimizedGroupContaining(String oid) {
+            for (OrgGroup group : orgGroups.values()) {
+                if (group.isOptimized() && group.orgOids.contains(oid)) {
+                    return group;
+                }
+            }
+            return null;
+        }
+
+        private OrgGroup groupFor(QName relation) {
+            return orgGroups.computeIfAbsent(relation, OrgGroup::new);
+        }
+
+        private void moveSingletonGroupsToLeftovers() {
+            for (OrgGroup group : orgGroups.values()) {
+                if (!group.isOptimized()) {
+                    leftoverFilters.addAll(group.orgFilters);
+                }
+            }
+        }
+
+        private static void flattenOr(ObjectFilter filter, List<ObjectFilter> flattened) {
+            if (filter instanceof OrFilter orFilter) {
+                for (ObjectFilter condition : orFilter.getConditions()) {
+                    flattenOr(condition, flattened);
+                }
+            } else {
+                flattened.add(filter);
+            }
+        }
+
+        private static boolean isOptimizable(OrgFilter filter) {
+            return !filter.isRoot()
+                    && filter.getScope() == OrgFilter.Scope.SUBTREE
+                    && filter.getOrgRef() != null
+                    && filter.getOrgRef().getOid() != null;
+        }
+
+        private static boolean isSimpleRootInOid(InOidFilter filter) {
+            return !filter.isConsiderOwner()
+                    && filter.getExpression() == null
+                    && filter.getOids() != null
+                    && !filter.getOids().isEmpty();
+        }
+    }
+
+    private static class OrgGroup {
+        private final QName relation;
+        private final Set<String> orgOids = new LinkedHashSet<>();
+        private final Set<String> selfOids = new LinkedHashSet<>();
+        private final List<OrgFilter> orgFilters = new ArrayList<>();
+
+        private OrgGroup(QName relation) {
+            this.relation = relation;
+        }
+
+        private void add(OrgFilter filter) {
+            orgFilters.add(filter);
+            orgOids.add(filter.getOrgRef().getOid());
+        }
+
+        private boolean isOptimized() {
+            return orgOids.size() > 1;
+        }
+    }
+}

--- a/repo/repo-sqale/src/test/java/com/evolveum/midpoint/repo/sqale/func/SqaleRepoSearchTest.java
+++ b/repo/repo-sqale/src/test/java/com/evolveum/midpoint/repo/sqale/func/SqaleRepoSearchTest.java
@@ -44,6 +44,8 @@ import com.evolveum.midpoint.prism.path.ItemName;
 import com.evolveum.midpoint.prism.path.ItemPath;
 import com.evolveum.midpoint.prism.path.ObjectReferencePathSegment;
 import com.evolveum.midpoint.prism.polystring.PolyString;
+import com.evolveum.midpoint.prism.impl.query.InOidFilterImpl;
+import com.evolveum.midpoint.prism.query.ObjectFilter;
 import com.evolveum.midpoint.prism.query.ObjectQuery;
 import com.evolveum.midpoint.prism.query.builder.S_FilterEntryOrEmpty;
 import com.evolveum.midpoint.repo.api.RepositoryService;
@@ -60,6 +62,7 @@ import com.evolveum.midpoint.schema.SearchResultList;
 import com.evolveum.midpoint.schema.constants.SchemaConstants;
 import com.evolveum.midpoint.schema.result.OperationResult;
 import com.evolveum.midpoint.schema.result.OperationResultStatus;
+import com.evolveum.midpoint.schema.util.ObjectQueryUtil;
 import com.evolveum.midpoint.schema.util.ObjectTypeUtil;
 import com.evolveum.midpoint.test.util.TestUtil;
 import com.evolveum.midpoint.util.DOMUtil;
@@ -1087,6 +1090,251 @@ public class SqaleRepoSearchTest extends SqaleRepoBaseTest {
                 f -> f.isChildOf(org2Oid)
                         .and().item(FocusType.F_COST_CENTER).startsWith("5"),
                 org21Oid, user3Oid);
+    }
+
+    @Test
+    public void test240QueryForChildrenUsingOptimizedOrgOr() throws SchemaException {
+        searchObjectTest("anywhere under any of multiple orgs", ObjectType.class,
+                f -> f.block()
+                        .isChildOf(org11Oid)
+                        .or().isChildOf(org21Oid)
+                        .endBlock(),
+                org111Oid, org112Oid, orgXOid, user2Oid, user3Oid, user4Oid);
+    }
+
+    @Test
+    public void test241QueryForChildrenUsingOptimizedOrgOrWithSelfBranch() throws SchemaException {
+        searchObjectTest("anywhere under any of multiple orgs or the orgs themselves", ObjectType.class,
+                f -> f.block()
+                        .isChildOf(org11Oid)
+                        .or().id(org11Oid)
+                        .or().isChildOf(org21Oid)
+                        .or().id(org21Oid)
+                        .endBlock(),
+                org11Oid, org21Oid, org111Oid, org112Oid, orgXOid, user2Oid, user3Oid, user4Oid);
+    }
+
+    @Test
+    public void test243QueryForChildrenUsingOptimizedOrgOrWithAnyTargetParentRelation() throws SchemaException {
+        searchObjectTest("anywhere under any org with any target parent-org relation", UserType.class,
+                f -> f.block()
+                        .isChildOf(org11Oid)
+                        .or().isChildOf(org21Oid)
+                        .endBlock(),
+                user2Oid, user3Oid, user4Oid);
+    }
+
+    @Test
+    public void test244QueryForChildrenUsingOptimizedOrgOrWithExplicitTargetParentRelation() throws SchemaException {
+        searchObjectTest("anywhere under any org with explicit target parent-org relation",
+                UserType.class,
+                f -> f.block()
+                        .isChildOf(ref(org11Oid, OrgType.COMPLEX_TYPE, relation1))
+                        .or().isChildOf(ref(org21Oid, OrgType.COMPLEX_TYPE, relation1))
+                        .endBlock(),
+                user2Oid, user3Oid);
+    }
+
+    @Test
+    public void test246QueryForChildrenUsingOptimizedOrgOrDoesNotDuplicateRowsOrCount() throws SchemaException {
+        when("searching with optimized OR where users can match via multiple parent-org paths");
+        OperationResult operationResult = createOperationResult();
+        ObjectQuery query = prismContext.queryFor(UserType.class)
+                .block()
+                    .isChildOf(org11Oid)
+                    .or().isChildOf(org21Oid)
+                .endBlock()
+                .build();
+
+        SearchResultList<UserType> result = searchObjects(UserType.class, query, operationResult);
+        int count = repositoryService.countObjects(UserType.class, query, null, operationResult);
+
+        then("search and count both see each user only once");
+        assertThatOperationResult(operationResult).isSuccess();
+        assertThat(result)
+                .extracting(o -> o.getOid())
+                .containsExactlyInAnyOrder(user2Oid, user3Oid, user4Oid);
+        assertThat(count).isEqualTo(result.size());
+    }
+
+    @Test
+    public void test247QueryForChildrenUsingOptimizedOrgOrAndArchetypeConjunct() throws Exception {
+        given("a user under matching org with archetype and another user under matching org without it");
+        OperationResult operationResult = createOperationResult();
+        String matchingUserOid = null;
+        String nonMatchingUserOid = null;
+        try {
+            matchingUserOid = repositoryService.addObject(
+                    new UserType()
+                            .name("user-org-or-archetype")
+                            .parentOrgRef(org11Oid, OrgType.COMPLEX_TYPE)
+                            .archetypeRef(archetypeOid, ArchetypeType.COMPLEX_TYPE)
+                            .asPrismObject(),
+                    null, operationResult);
+            nonMatchingUserOid = repositoryService.addObject(
+                    new UserType()
+                            .name("user-org-or-no-archetype")
+                            .parentOrgRef(org11Oid, OrgType.COMPLEX_TYPE)
+                            .asPrismObject(),
+                    null, operationResult);
+
+            when("searching with archetype AND optimized org OR");
+            ObjectQuery query = prismContext.queryFor(UserType.class)
+                    .item(AssignmentHolderType.F_ARCHETYPE_REF).ref(archetypeOid)
+                    .and()
+                    .block()
+                        .isChildOf(org11Oid)
+                        .or().isChildOf(org21Oid)
+                    .endBlock()
+                    .build();
+            SearchResultList<UserType> result = searchObjects(UserType.class, query, operationResult);
+            int count = repositoryService.countObjects(UserType.class, query, null, operationResult);
+
+            then("only users satisfying both conjuncts are returned and counted");
+            assertThatOperationResult(operationResult).isSuccess();
+            assertThat(result)
+                    .extracting(o -> o.getOid())
+                    .containsExactlyInAnyOrder(matchingUserOid);
+            assertThat(count).isEqualTo(result.size());
+        } finally {
+            OperationResult cleanupResult = createOperationResult();
+            if (nonMatchingUserOid != null) {
+                repositoryService.deleteObject(UserType.class, nonMatchingUserOid, cleanupResult);
+            }
+            if (matchingUserOid != null) {
+                repositoryService.deleteObject(UserType.class, matchingUserOid, cleanupResult);
+            }
+        }
+    }
+
+    @Test
+    public void test248QueryForChildrenUsingOptimizedOrgOrPreservesLeftoverOidBranch() throws SchemaException {
+        searchObjectTest("optimized org OR preserves an unrelated OID branch", ObjectType.class,
+                f -> f.block()
+                        .isChildOf(org11Oid)
+                        .or().id(org11Oid)
+                        .or().isChildOf(org21Oid)
+                        .or().id(org21Oid)
+                        .or().id(user1Oid)
+                        .endBlock(),
+                org11Oid, org21Oid, org111Oid, org112Oid, orgXOid, user1Oid, user2Oid, user3Oid, user4Oid);
+    }
+
+    @Test
+    public void test249QueryForChildrenUsingOptimizedOrgOrSplitsMixedInOidBranch() throws SchemaException {
+        searchObjectTest("optimized org OR splits matching and unrelated OIDs from one ID branch", ObjectType.class,
+                f -> f.block()
+                        .isChildOf(org11Oid)
+                        .or().isChildOf(org21Oid)
+                        .or().id(org11Oid, org21Oid, user1Oid)
+                        .endBlock(),
+                org11Oid, org21Oid, org111Oid, org112Oid, orgXOid, user1Oid, user2Oid, user3Oid, user4Oid);
+    }
+
+    @Test
+    public void test250QueryForChildrenUsingOptimizedOrgOrWithMixedRelationGroups() throws SchemaException {
+        searchObjectTest("optimized org OR handles separate relation groups", UserType.class,
+                f -> f.block()
+                        .isChildOf(org11Oid)
+                        .or().isChildOf(org21Oid)
+                        .or().isChildOf(ref(org11Oid, OrgType.COMPLEX_TYPE, relation1))
+                        .or().isChildOf(ref(org21Oid, OrgType.COMPLEX_TYPE, relation1))
+                        .endBlock(),
+                user2Oid, user3Oid, user4Oid);
+    }
+
+    @Test
+    public void test251QueryForChildrenUsingOptimizedOrgOrDoesNotMixAnyAndDefaultRelation() throws SchemaException {
+        searchObjectTest("explicit default relation remains separate from null/any relation", UserType.class,
+                f -> f.block()
+                        .isChildOf(org11Oid)
+                        .or().isChildOf(org21Oid)
+                        .or().isChildOf(ref(org11Oid, OrgType.COMPLEX_TYPE, ORG_DEFAULT))
+                        .or().isChildOf(ref(org21Oid, OrgType.COMPLEX_TYPE, ORG_DEFAULT))
+                        .endBlock(),
+                user2Oid, user3Oid, user4Oid);
+    }
+
+    @Test
+    public void test252QueryForChildrenUsingOptimizedOrgOrPreservesOtherFilterBranch() throws SchemaException {
+        searchObjectTest("optimized org OR preserves an unrelated filter branch", UserType.class,
+                f -> f.block()
+                        .isChildOf(org11Oid)
+                        .or().isChildOf(org21Oid)
+                        .or().item(F_NAME).eq(PolyString.fromOrig("creator"))
+                        .endBlock(),
+                creatorOid, user2Oid, user3Oid, user4Oid);
+    }
+
+    @Test
+    public void test253QueryForChildrenUsingOptimizedOrgOrWithNestedOr() throws SchemaException {
+        searchObjectTest("optimized org OR flattens only nested OR branches", ObjectType.class,
+                f -> f.block()
+                        .isChildOf(org11Oid)
+                        .or()
+                        .block()
+                            .isChildOf(org21Oid)
+                            .or().id(org21Oid)
+                        .endBlock()
+                        .or().id(org11Oid)
+                        .endBlock(),
+                org11Oid, org21Oid, org111Oid, org112Oid, orgXOid, user2Oid, user3Oid, user4Oid);
+    }
+
+    @Test
+    public void test254QueryForChildrenUsingOptimizedOrgOrReportsMalformedOid() {
+        ObjectQuery query = prismContext.queryFor(ObjectType.class)
+                .block()
+                    .isChildOf(org11Oid)
+                    .or().isChildOf(org21Oid)
+                    .or().id("not-a-uuid")
+                .endBlock()
+                .build();
+
+        assertThatThrownBy(() -> searchObjects(ObjectType.class, query, createOperationResult()))
+                .isInstanceOf(SystemException.class)
+                .hasCauseInstanceOf(QueryException.class);
+    }
+
+    @Test
+    public void test255QueryForChildrenUsingOptimizedOrgOrPreservesSingletonOrgGroup() throws SchemaException {
+        searchObjectTest("singleton org group is preserved by normal OR processing", ObjectType.class,
+                f -> f.block()
+                        .isChildOf(org11Oid)
+                        .or().id(user1Oid)
+                        .endBlock(),
+                org111Oid, org112Oid, user1Oid, user2Oid, user4Oid);
+    }
+
+    @Test
+    public void test256QueryForChildrenUsingOptimizedOrgOrPreservesUnsupportedInOidBranch() throws SchemaException {
+        ObjectFilter orgOr = prismContext.queryFor(ObjectType.class)
+                .block()
+                    .isChildOf(org11Oid)
+                    .or().isChildOf(org21Oid)
+                .endBlock()
+                .buildFilter();
+        ObjectQuery query = prismContext.queryFactory().createQuery(
+                ObjectQueryUtil.filterOr(
+                        orgOr,
+                        InOidFilterImpl.createOwnerHasOidIn(user1Oid)));
+
+        SearchResultList<ObjectType> result = searchObjects(ObjectType.class, query, createOperationResult());
+
+        assertThat(result)
+                .extracting(ObjectType::getOid)
+                .containsExactlyInAnyOrder(
+                        org111Oid, org112Oid, orgXOid, user1Oid, user2Oid, user3Oid, user4Oid);
+    }
+
+    @Test
+    public void test257QueryForChildrenUsingOptimizedOrgOrWithExplicitDefaultRelation() throws SchemaException {
+        searchObjectTest("explicit default relation does not match non-default target parent-org refs", UserType.class,
+                f -> f.block()
+                        .isChildOf(ref(org11Oid, OrgType.COMPLEX_TYPE, ORG_DEFAULT))
+                        .or().isChildOf(ref(org21Oid, OrgType.COMPLEX_TYPE, ORG_DEFAULT))
+                        .endBlock(),
+                user2Oid, user4Oid);
     }
     // endregion
 
@@ -3410,6 +3658,40 @@ public class SqaleRepoSearchTest extends SqaleRepoBaseTest {
 
         expect("isDescendant returns false for reverse relationship");
         assertFalse(repositoryService.isDescendant(org11, org112Oid));
+    }
+
+    @Test
+    public void test972IsDescendantOfAny() throws Exception {
+        OperationResult operationResult = createOperationResult();
+
+        expect("isDescendantOfAny returns true when object is under one of many ancestors");
+        PrismObject<UserType> user3 =
+                repositoryService.getObject(UserType.class, user3Oid, null, operationResult);
+        assertTrue(repositoryService.isDescendantOfAny(user3, List.of(org1Oid, org11Oid, org2Oid)));
+
+        expect("isDescendantOfAny returns false when object is outside all ancestors");
+        PrismObject<UserType> user1 =
+                repositoryService.getObject(UserType.class, user1Oid, null, operationResult);
+        assertFalse(repositoryService.isDescendantOfAny(user1, List.of(org1Oid, org2Oid)));
+
+        expect("isDescendantOfAny handles multiple target parent org refs");
+        PrismObject<UserType> user2 =
+                repositoryService.getObject(UserType.class, user2Oid, null, operationResult);
+        assertTrue(repositoryService.isDescendantOfAny(user2, List.of(org2Oid)));
+        assertFalse(repositoryService.isDescendantOfAny(user2, List.of(org111Oid)));
+
+        expect("isDescendantOfAny does not treat an org as its own descendant");
+        PrismObject<OrgType> org11 =
+                repositoryService.getObject(OrgType.class, org11Oid, null, operationResult);
+        assertFalse(repositoryService.isDescendantOfAny(org11, List.of(org11Oid)));
+
+        expect("isDescendantOfAny handles a large ancestor set in one call");
+        List<String> ancestorOids = new java.util.ArrayList<>();
+        for (int i = 0; i < 99; i++) {
+            ancestorOids.add(UUID.randomUUID().toString());
+        }
+        ancestorOids.add(org2Oid);
+        assertTrue(repositoryService.isDescendantOfAny(user3, ancestorOids));
     }
 
     @Test


### PR DESCRIPTION
### Summary

Improves performance of user list/search/count operations when authorization contains large `orgRelation` / managed-org filters.

The main problem was that users managing many organizations could produce very large OR predicates and repeated org descendant checks. This PR reduces that overhead in three places:

1. Optimizes sqale OR query generation for compatible subtree `OrgFilter` branches.
2. Batches post-filter `orgRelation` descendant checks.
3. Avoids duplicate GUI `countObjects` calls during repeated Wicket size/page-count requests.

--------------------------------------------------------------------------------------------------

### Changes

#### Sqale org OR optimization

Adds an optimizer for OR filters containing multiple compatible subtree org filters.

Instead of emitting many similar org `EXISTS` branches, compatible branches are grouped and emitted as a single predicate using `ancestorOid.in(...)`.

The optimizer preserves fallback behavior for unsupported or mixed branches:
- singleton org groups are handled by normal OR processing
- unrelated OID branches are preserved
- unsupported `InOidFilter` shapes are preserved
- unrelated non-org filters remain in the OR
- null/ANY relation and explicit relations are kept separate


#### Batched orgRelation post-filter checks

Adds `OrgTreeEvaluator.isDescendantOfAny(...)` and sqale repository support for checking multiple ancestor org OIDs in one closure query.

`OrgRelationClause` now uses the batched method for `ALL_DESCENDANTS`, while preserving existing semantics:
- `subjectRelation` filters only the principal/subject parent org refs
- target-side parent org relation remains unconstrained
- `includeReferenceOrg` self-match is checked before descendant lookup
- non-`ALL_DESCENDANTS` scopes continue using the existing path


#### GUI count cache

Adds a short-lived count cache in `SelectableBeanDataProvider`.

This avoids repeated `countObjects` calls when Wicket asks for provider size/page count multiple times during the same render cycle. The cache key includes:
- object type
- query
- count options

The cache is cleared on provider detach and relevant state changes, and is independent of row/object caching.

Also updates concrete count implementations to use the query passed from `internalSize()`, so the counted query matches the cache key.

--------------------------------------------------------------------------------------------------

### Tests

Added/updated tests for:

- optimized org OR query semantics in sqale search
- ANY/null vs explicit target parent relation behavior
- self/OID branches from include-reference-org style filters
- mixed relation groups and leftover OR branches
- duplicate-safe search/count behavior
- batched repository `isDescendantOfAny(...)`
- selector-level `OrgRelationClause` batching semantics
- GUI count cache reuse and invalidation

--------------------------------------------------------------------------------------------------

### Validation

- Added regression coverage for:
  - sqale optimized org-OR query semantics
  - selector-level `orgRelation` batching
  - repository-level `isDescendantOfAny(...)`
  - GUI provider count-cache reuse and invalidation
- Manual profiling confirmed repeated page-count requests now hit the provider count cache within the same render.
- Manual profiling on the reproduced large managed-org scenario showed the affected user list count/search path dropping from several seconds to sub-second execution, with remaining samples mostly in normal Wicket rendering/security/schema processing rather than repeated org-filter query construction.