### PR TITLE
MID-9998 Fix stale page recovery after view-source

### DIFF
--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/security/LoggingRequestCycleListener.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/security/LoggingRequestCycleListener.java
@@ -9,6 +9,8 @@ package com.evolveum.midpoint.web.security;
 import org.apache.wicket.Application;
 import org.apache.wicket.core.request.handler.PageProvider;
 import org.apache.wicket.core.request.handler.RenderPageRequestHandler;
+import org.apache.wicket.core.request.handler.RenderPageRequestHandler.RedirectPolicy;
+import org.apache.wicket.core.request.mapper.StalePageException;
 import org.apache.wicket.request.IRequestHandler;
 import org.apache.wicket.request.Url;
 import org.apache.wicket.request.component.IRequestablePage;
@@ -48,6 +50,14 @@ public class LoggingRequestCycleListener implements IRequestCycleListener {
         if (REQUEST_LOGGER.isTraceEnabled()) {
             REQUEST_LOGGER.trace("REQUEST CYCLE: Exception: {}, handler {}", ex,
                     WebComponentUtil.debugHandler(cycle.getActiveRequestHandler()), ex);
+        }
+        if (ex instanceof StalePageException stalePageException) {
+            // Wicket uses this exception for stale render-count recovery, e.g. after browser view-source.
+            // Do not convert it to PageError/500, recover by re-rendering the stale page.
+            LOGGER.debug("Recovering stale Wicket page request by re-rendering page {}", stalePageException.getPage());
+            return new RenderPageRequestHandler(
+                    new PageProvider(stalePageException.getPage()),
+                    RedirectPolicy.ALWAYS_REDIRECT);
         }
         LoggingUtils.logUnexpectedException(LOGGER, "Error occurred during page rendering", ex);
         return new RenderPageRequestHandler(new PageProvider(new PageError(ex)));
@@ -136,4 +146,3 @@ public class LoggingRequestCycleListener implements IRequestCycleListener {
         }
     }
 }
-

--- a/gui/admin-gui/src/test/java/com/evolveum/midpoint/web/LoggingRequestCycleListenerTest.java
+++ b/gui/admin-gui/src/test/java/com/evolveum/midpoint/web/LoggingRequestCycleListenerTest.java
@@ -17,8 +17,16 @@ import org.apache.wicket.util.tester.WicketTester;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
+/**
+ * Tests exception handling behavior in {@link LoggingRequestCycleListener}.
+ */
 public class LoggingRequestCycleListenerTest {
 
+    /**
+     * MID-9998: Verifies that Wicket stale page recovery, e.g. after browser
+     * view-source, is handled by re-rendering the stale page instead of being
+     * converted to the error page / HTTP 500.
+     */
     @Test
     public void testStalePageExceptionIsRecoveredInsteadOfConvertedToPageError() {
         WicketTester tester = new WicketTester();

--- a/gui/admin-gui/src/test/java/com/evolveum/midpoint/web/LoggingRequestCycleListenerTest.java
+++ b/gui/admin-gui/src/test/java/com/evolveum/midpoint/web/LoggingRequestCycleListenerTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2010-2026 Evolveum and contributors
+ *
+ * This work is dual-licensed under the Apache License 2.0
+ * and European Union Public License. See LICENSE file for details.
+ */
+
+package com.evolveum.midpoint.web;
+
+import com.evolveum.midpoint.web.security.LoggingRequestCycleListener;
+import org.apache.wicket.core.request.handler.RenderPageRequestHandler;
+import org.apache.wicket.core.request.handler.RenderPageRequestHandler.RedirectPolicy;
+import org.apache.wicket.core.request.mapper.StalePageException;
+import org.apache.wicket.markup.html.WebPage;
+import org.apache.wicket.request.IRequestHandler;
+import org.apache.wicket.util.tester.WicketTester;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class LoggingRequestCycleListenerTest {
+
+    @Test
+    public void testStalePageExceptionIsRecoveredInsteadOfConvertedToPageError() {
+        WicketTester tester = new WicketTester();
+        try {
+            LoggingRequestCycleListener listener = new LoggingRequestCycleListener(tester.getApplication());
+            TestPage page = new TestPage();
+
+            IRequestHandler handler = listener.onException(null, new StalePageException(page));
+
+            Assert.assertTrue(handler instanceof RenderPageRequestHandler);
+
+            RenderPageRequestHandler renderHandler = (RenderPageRequestHandler) handler;
+            Assert.assertSame(renderHandler.getPage(), page);
+            Assert.assertSame(renderHandler.getRedirectPolicy(), RedirectPolicy.ALWAYS_REDIRECT);
+        } finally {
+            tester.destroy();
+        }
+    }
+
+    private static class TestPage extends WebPage {
+    }
+}

--- a/gui/admin-gui/testng-unit.xml
+++ b/gui/admin-gui/testng-unit.xml
@@ -13,6 +13,7 @@
             <class name="com.evolveum.midpoint.web.TestPageMounter"/>
             <class name="com.evolveum.midpoint.web.TestXmlGregorianCalendarModel"/>
             <class name="com.evolveum.midpoint.gui.SelectableBeanDataProviderCountCacheTest"/>
+            <class name="com.evolveum.midpoint.web.LoggingRequestCycleListenerTest"/>
         </classes>
     </test>
 </suite>

--- a/release-notes.adoc
+++ b/release-notes.adoc
@@ -137,6 +137,7 @@ Overall, midPoint 4.10 opens up the world of identity management and governance 
 * Fixed skipped approval processing for role ADD operations that could leave empty ADD deltas. See bug:MID-11101[]
 * Fixed loss of unsaved resource detail changes after running Test connection. See bug:MID-10966[]
 * Fixed dashboard widget collections with inline filters by allowing explicit object type specification. See bug:MID-9879[]
+* Fixed stale page recovery after viewing page source causing internal server error. See bug:MID-9998[]
 
 === Releases Of Other Components
 


### PR DESCRIPTION
## Summary

Fixed `MID-9998`: internal server error after viewing page source and returning to midPoint.

The issue was caused by `StalePageException` being handled by `LoggingRequestCycleListener` as an unexpected rendering error and converted to `PageError`, which produced a user-facing HTTP 500.

`StalePageException` is a Wicket stale page/render-count recovery case, for example after browser `view-source`, back/forward navigation, duplicate tabs, or similar stale page requests. It should be recovered by re-rendering the stale page instead of being converted to the generic error page.

## Changes

- Added special handling for `StalePageException` in `LoggingRequestCycleListener`.
- Re-render the stale page using `RenderPageRequestHandler` with `RedirectPolicy.ALWAYS_REDIRECT`.
- Keep the stale page recovery log at debug level instead of treating it as an unexpected error.
- Added `LoggingRequestCycleListenerTest` to verify that `StalePageException` is recovered with `RenderPageRequestHandler` and is not converted to `PageError`.
- Added release notes entry for `MID-9998`.

## Testing

- Added unit test:
  - `LoggingRequestCycleListenerTest.testStalePageExceptionIsRecoveredInsteadOfConvertedToPageError`

- Manually verified original reproduction scenario:
  1. Open midPoint locally.
  2. Go to **Users → All users**.
  3. Press `Ctrl+U` to display page source.
  4. Return to the midPoint UI.
  5. Click logo/Home or another navigation target.

Expected result: no HTTP 500 is shown. The stale page is recovered/re-rendered. A second click may be needed to perform the original navigation after recovery.