### PR TITLE
MID-11096 Fix missing zip suffix on tracing reports

### DIFF
--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/reports/ReportDownloadHelper.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/reports/ReportDownloadHelper.java
@@ -59,16 +59,17 @@ public class ReportDownloadHelper implements Serializable {
 
     public static String getReportFileName(ReportDataType currentReport) {
         String name = WebComponentUtil.getName(currentReport);
-        if (StringUtils.isNotEmpty(name)) {
-            // Sanitize to remove any path components for defense in depth
-            // (browsers also ignore path components, but better to be safe)
-            String sanitizedName = FilenameUtils.getName(name);
-            if (isZipReport(currentReport) && !hasZipExtension(sanitizedName)) {
-                return sanitizedName + "." + ZIP_EXTENSION;
-            }
-            return sanitizedName;
+        if (StringUtils.isEmpty(name)) {
+            name = "report"; // A fallback - this should not really occur
         }
-        return "report"; // A fallback - this should not really occur
+
+        // Sanitize to remove any path components for defense in depth
+        // (browsers also ignore path components, but better to be safe)
+        String sanitizedName = FilenameUtils.getName(name);
+        if (isZipReport(currentReport) && !hasZipExtension(sanitizedName)) {
+            return sanitizedName + "." + ZIP_EXTENSION;
+        }
+        return sanitizedName;
     }
 
     private static boolean isZipReport(ReportDataType report) {

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/reports/ReportDownloadHelper.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/page/admin/reports/ReportDownloadHelper.java
@@ -30,6 +30,7 @@ public class ReportDownloadHelper implements Serializable {
     private static final Trace LOGGER = TraceManager.getTrace(ReportDownloadHelper.class);
     private static final String DOT_CLASS = ReportDownloadHelper.class.getName() + ".";
     private static final String OPERATION_DOWNLOAD_REPORT = DOT_CLASS + ".downloadReport";
+    private static final String ZIP_EXTENSION = "zip";
 
     private static final Map<FileFormatTypeType, String> REPORT_EXPORT_TYPE_MAP = new HashMap<>();
     static {
@@ -61,9 +62,24 @@ public class ReportDownloadHelper implements Serializable {
         if (StringUtils.isNotEmpty(name)) {
             // Sanitize to remove any path components for defense in depth
             // (browsers also ignore path components, but better to be safe)
-            return FilenameUtils.getName(name);
+            String sanitizedName = FilenameUtils.getName(name);
+            if (isZipReport(currentReport) && !hasZipExtension(sanitizedName)) {
+                return sanitizedName + "." + ZIP_EXTENSION;
+            }
+            return sanitizedName;
         }
         return "report"; // A fallback - this should not really occur
+    }
+
+    private static boolean isZipReport(ReportDataType report) {
+        // ReportDataType has no ZIP file-format enum value, tracing stores ZIP outputs as files with .zip suffix.
+        return report != null
+                && report.getFilePath() != null
+                && hasZipExtension(report.getFilePath());
+    }
+
+    private static boolean hasZipExtension(String fileName) {
+        return ZIP_EXTENSION.equalsIgnoreCase(FilenameUtils.getExtension(fileName));
     }
 
     public static InputStream createReport(ReportDataType report,

--- a/gui/admin-gui/src/test/java/com/evolveum/midpoint/web/ReportDownloadHelperTest.java
+++ b/gui/admin-gui/src/test/java/com/evolveum/midpoint/web/ReportDownloadHelperTest.java
@@ -20,6 +20,13 @@ import com.evolveum.midpoint.gui.test.TestMidPointSpringApplication;
 import com.evolveum.midpoint.xml.ns._public.common.common_3.ReportDataType;
 import com.evolveum.prism.xml.ns._public.types_3.PolyStringType;
 
+/**
+ * Tests download filename handling for report outputs.
+ *
+ * In particular, verifies that ZIP-backed tracing report files are downloaded
+ * with the {@code .zip} suffix while preserving existing names and filename
+ * sanitization behavior.
+ */
 @ActiveProfiles("test")
 @SpringBootTest(classes = TestMidPointSpringApplication.class)
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
@@ -58,6 +65,13 @@ public class ReportDownloadHelperTest extends AbstractGuiIntegrationTest {
         ReportDataType report = report("trace-2026", null);
 
         assertEquals(ReportDownloadHelper.getReportFileName(report), "trace-2026");
+    }
+
+    @Test
+    public void emptyZipReportFileNameUsesFallbackWithZipExtension() {
+        ReportDataType report = report(null, "C:\\midpoint\\trace\\trace-2026.zip");
+
+        assertEquals(ReportDownloadHelper.getReportFileName(report), "report.zip");
     }
 
     private static ReportDataType report(String name, String filePath) {

--- a/gui/admin-gui/src/test/java/com/evolveum/midpoint/web/ReportDownloadHelperTest.java
+++ b/gui/admin-gui/src/test/java/com/evolveum/midpoint/web/ReportDownloadHelperTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2026 Evolveum and contributors
+ *
+ * This work is dual-licensed under the Apache License 2.0
+ * and European Union Public License. See LICENSE file for details.
+ */
+
+package com.evolveum.midpoint.web;
+
+import static org.testng.Assert.assertEquals;
+
+import com.evolveum.midpoint.web.page.admin.reports.ReportDownloadHelper;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ActiveProfiles;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import com.evolveum.midpoint.gui.test.TestMidPointSpringApplication;
+import com.evolveum.midpoint.xml.ns._public.common.common_3.ReportDataType;
+import com.evolveum.prism.xml.ns._public.types_3.PolyStringType;
+
+@ActiveProfiles("test")
+@SpringBootTest(classes = TestMidPointSpringApplication.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+public class ReportDownloadHelperTest extends AbstractGuiIntegrationTest {
+
+    @Test
+    public void zipReportFileNameHasZipExtension() {
+        ReportDataType report = report("trace-2026", "C:\\midpoint\\trace\\trace-2026.zip");
+
+        Assert.assertEquals(ReportDownloadHelper.getReportFileName(report), "trace-2026.zip");
+    }
+
+    @Test
+    public void zipReportFileNameDoesNotDuplicateZipExtension() {
+        ReportDataType report = report("trace-2026.zip", "C:\\midpoint\\trace\\trace-2026.zip");
+
+        assertEquals(ReportDownloadHelper.getReportFileName(report), "trace-2026.zip");
+    }
+
+    @Test
+    public void nonZipReportFileNameIsNotChanged() {
+        ReportDataType report = report("report-output", "C:\\midpoint\\export\\report-output.csv");
+
+        assertEquals(ReportDownloadHelper.getReportFileName(report), "report-output");
+    }
+
+    @Test
+    public void pathComponentsAreRemovedBeforeAppendingZipExtension() {
+        ReportDataType report = report("C:\\tmp\\trace-2026", "C:\\midpoint\\trace\\trace-2026.zip");
+
+        assertEquals(ReportDownloadHelper.getReportFileName(report), "trace-2026.zip");
+    }
+
+    @Test
+    public void reportWithoutFilePathDoesNotGetZipExtension() {
+        ReportDataType report = report("trace-2026", null);
+
+        assertEquals(ReportDownloadHelper.getReportFileName(report), "trace-2026");
+    }
+
+    private static ReportDataType report(String name, String filePath) {
+        ReportDataType report = new ReportDataType()
+                .filePath(filePath);
+        if (name != null) {
+            report.name(new PolyStringType(name));
+        }
+        return report;
+    }
+}

--- a/gui/admin-gui/testng-integration.xml
+++ b/gui/admin-gui/testng-integration.xml
@@ -35,6 +35,7 @@
             <class name="com.evolveum.midpoint.web.TestDisplayLabelLocalization"/>
             <class name="com.evolveum.midpoint.web.component.FileValidatorTest"/>
             <class name="com.evolveum.midpoint.web.component.ImageSanitizationTest"/>
+            <class name="com.evolveum.midpoint.web.ReportDownloadHelperTest"/>
         </classes>
     </test>
 </suite>

--- a/release-notes.adoc
+++ b/release-notes.adoc
@@ -137,6 +137,7 @@ Overall, midPoint 4.10 opens up the world of identity management and governance 
 * Fixed skipped approval processing for role ADD operations that could leave empty ADD deltas. See bug:MID-11101[]
 * Fixed loss of unsaved resource detail changes after running Test connection. See bug:MID-10966[]
 * Fixed dashboard widget collections with inline filters by allowing explicit object type specification. See bug:MID-9879[]
+* Fixed missing .zip extension when downloading tracing report files. See bug:MID-11096[]
 
 === Releases Of Other Components
 


### PR DESCRIPTION
## Summary

Fixes MID-11096: downloaded tracing report files were missing the `.zip` filename extension even though the stored report output was a ZIP archive.

The change updates `ReportDownloadHelper.getReportFileName(...)` so that ZIP-backed report outputs are downloaded with a `.zip` suffix when the display name does not already include one.

## Changes

- Added ZIP filename extension handling for report downloads.
- Detects ZIP report outputs based on the stored report file path extension.
- Preserves existing `.zip` suffixes and avoids duplicating them.
- Keeps filename sanitization via `FilenameUtils.getName(...)`.
- Adds regression tests for:
  - appending `.zip` to ZIP report downloads
  - avoiding duplicate `.zip`
  - leaving non-ZIP reports unchanged
  - stripping path components before appending `.zip`
  - handling reports without a file path
- Registered the new test class in `testing-integration.xml`.
- Added release note entry for MID-11096.

## Testing

Added regression coverage in `ReportDownloadHelperTest` for ZIP suffix handling in downloaded report filenames.