### PR TITLE
MID-10911 Fix generic "Fatal error" message in object tables

### DIFF
--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/component/data/provider/SelectableBeanDataProvider.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/component/data/provider/SelectableBeanDataProvider.java
@@ -10,6 +10,8 @@ import java.io.Serializable;
 import java.util.*;
 import java.util.stream.Collectors;
 
+import org.apache.commons.lang3.StringUtils;
+
 import com.evolveum.midpoint.gui.api.component.data.provider.ISelectableDataProvider;
 import com.evolveum.midpoint.gui.api.util.WebComponentUtil;
 import com.evolveum.midpoint.model.api.authentication.CompiledObjectCollectionView;
@@ -127,7 +129,7 @@ public abstract class SelectableBeanDataProvider<T extends Serializable> extends
 
         } catch (Exception ex) {
             setupUserFriendlyMessage(result, ex);
-            result.recordFatalError(getPageBase().createStringResource("ObjectDataProvider.message.listObjects.fatalError").getString(), ex);
+            result.recordFatalError(createListObjectsErrorMessage(ex), ex);
             LoggingUtils.logUnexpectedException(LOGGER, "Couldn't list objects", ex);
             return handleNotSuccessOrHandledErrorInIterator(result);
         } finally {
@@ -177,6 +179,14 @@ public abstract class SelectableBeanDataProvider<T extends Serializable> extends
 
     protected SelectableBean<T> createDataObjectWrapperForError() {
         return new SelectableBeanImpl<>();
+    }
+
+    private String createListObjectsErrorMessage(Exception ex) {
+        String message = getPageBase().createStringResource("ObjectDataProvider.message.listObjects.fatalError").getString();
+        if (StringUtils.isBlank(ex.getMessage())) {
+            return message;
+        }
+        return message + ": " + ex.getMessage();
     }
 
     protected abstract List<T> searchObjects(Class<T> type,

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/data/column/ContainerableNameColumn.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/component/data/column/ContainerableNameColumn.java
@@ -8,6 +8,7 @@ package com.evolveum.midpoint.web.component.data.column;
 
 import java.io.Serial;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.wicket.Component;
 import org.apache.wicket.RestartResponseException;
 import org.apache.wicket.ajax.AjaxRequestTarget;
@@ -89,7 +90,8 @@ public abstract class ContainerableNameColumn<SR extends SelectableRow<C>, C ext
         if (selectableBean instanceof SelectableBean) {
             OperationResult result = ((SelectableBean<?>) selectableBean).getResult();
             OperationResultStatusPresentationProperties props = OperationResultStatusPresentationProperties.parseOperationalResultStatus(result.getStatus());
-            return getPageBase().getString(props.getStatusLabelKey());
+            String status = getPageBase().getString(props.getStatusLabelKey());
+            return StringUtils.isBlank(result.getMessage()) ? status : status + ": " + result.getMessage();
         }
         return "";
     }

--- a/release-notes.adoc
+++ b/release-notes.adoc
@@ -102,6 +102,7 @@ Overall, midPoint 4.10 opens up the world of identity management and governance 
 * Delineation suggestions: filter parsing broken after recent GUI change. See bug:MID-11175[]
 * Fixed work item search by name causing repository mapping error. See bug:MID-8834[]
 * Fixed translation of archetype display labels in assignment picker and summary panel. See bug:MID-11177[]
+* Fixed generic "Fatal error" message in object tables to show available list/search error details. See bug:MID-10911[]
 
 === Releases Of Other Components
 


### PR DESCRIPTION
## Summary

Improves error reporting in object tables.

When a table search/list operation failed, the UI displayed only a generic synthetic row:

```text
Fatal error
```

even when the underlying `OperationResult` already contained a useful diagnostic message. This made users check server logs to understand what actually failed.

This change keeps the existing synthetic error row behavior, but includes the available `OperationResult` message in the row label.

## Example

Before:

```text
Fatal error
```

After:

```text
Fatal error: Couldn't list objects: CSV validation failed. Required unique attribute 'empnum' is empty at record 2. Each record must contain a non-empty value for 'empnum'.
```

## Related work

Related CSV connector fix: https://github.com/Evolveum/connector-csv/pull/8

The connector PR improves the connector-side validation message. This PR makes such list/search failure details visible in object tables.

## Testing

Tested with a CSV resource where the configured unique attribute contains an empty value.