### PR TITLE
Selecting nodeIdentifiers by RegEx

### DIFF
--- a/repo/repo-common/src/main/java/com/evolveum/midpoint/repo/common/activity/run/distribution/ExpectedSetup.java
+++ b/repo/repo-common/src/main/java/com/evolveum/midpoint/repo/common/activity/run/distribution/ExpectedSetup.java
@@ -21,6 +21,9 @@ import com.evolveum.midpoint.xml.ns._public.common.common_3.*;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.*;
+import java.util.function.Predicate;
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
 
 import static org.apache.commons.lang3.ObjectUtils.defaultIfNull;
 

--- a/repo/repo-common/src/main/java/com/evolveum/midpoint/repo/common/activity/run/distribution/ExpectedSetup.java
+++ b/repo/repo-common/src/main/java/com/evolveum/midpoint/repo/common/activity/run/distribution/ExpectedSetup.java
@@ -136,7 +136,16 @@ class ExpectedSetup {
 
     private Collection<String> getNodeIdentifiers(WorkersPerNodeDefinitionType perNodeDefinition) {
         if (!perNodeDefinition.getNodeIdentifier().isEmpty()) {
-            return perNodeDefinition.getNodeIdentifier();
+            Set<String> nodeIds = new HashSet<>();
+            for (String nodeIdentifier : perNodeDefinition.getNodeIdentifier()) {
+                try {
+                    Predicate<String> pattern = Pattern.compile(nodeIdentifier).asMatchPredicate();
+                    nodeIds.addAll(nodesUp.stream().filter(pattern).toList());
+                } catch (PatternSyntaxException e) {
+                    nodeIds.addAll(nodesUp.stream().filter(nodeIdentifier::equals).toList());
+                }
+            }
+            return nodeIds;
         } else {
             return nodesUp;
         }


### PR DESCRIPTION
Uses the nodeIdentifier as a regular expression to select matching nodes dynamically (e.g. `<nodeIdentifier>worker-.*</nodeIdentifier>`).
Classic nodeIdentifiers without RegEx (like 'worker-1') are still possible.

This enables a dynamic node selection in cluster environments where nodes can be dynamically started or stopped. Previously all nodes had to be specified individually and produced an error if one was missing.