### PR TITLE
MID-10905 Add input variable to existence mappings

### DIFF
--- a/docs/resources/resource-configuration/schema-handling/activation.adoc
+++ b/docs/resources/resource-configuration/schema-handling/activation.adoc
@@ -67,6 +67,11 @@ E.g. in RELATIVE mode, a resource object may be legal even if it is not assigned
 See xref:/midpoint/reference/roles-policies/roles/assignment/[Assignment]
 
 
+| `legal`
+| boolean
+| Same as `input`: set to `true` if the object is legal, based on assignment evaluation and enforcement mode.
+This variable is kept for compatibility with existing mappings.
+
 | `assigned`
 | boolean
 | True if there is a valid assignment for this object.

--- a/model/model-impl/src/main/java/com/evolveum/midpoint/model/impl/lens/projector/ActivationProcessor.java
+++ b/model/model-impl/src/main/java/com/evolveum/midpoint/model/impl/lens/projector/ActivationProcessor.java
@@ -732,7 +732,9 @@ public class ActivationProcessor implements ProjectorProcessor {
                     .implicitSourcePath(LEGAL_PROPERTY_NAME)
                     .implicitTargetPath(SHADOW_EXISTS_PROPERTY_NAME);
 
-            builder.defaultSource(new Source<>(getLegalIdi(projCtx), ExpressionConstants.VAR_LEGAL_QNAME));
+            ItemDeltaItem<PrismPropertyValue<Boolean>, PrismPropertyDefinition<Boolean>> legalIdi = getLegalIdi(projCtx);
+            builder.defaultSource(new Source<>(legalIdi, ExpressionConstants.VAR_LEGAL_QNAME));
+            builder.additionalSource(new Source<>(legalIdi, ExpressionConstants.VAR_INPUT_QNAME));
             builder.additionalSource(new Source<>(getAssignedIdi(projCtx), ExpressionConstants.VAR_ASSIGNED_QNAME));
             builder.additionalSource(new Source<>(getFocusExistsIdi(context.getFocusContext()), ExpressionConstants.VAR_FOCUS_EXISTS_QNAME));
 

--- a/model/model-intest/src/test/java/com/evolveum/midpoint/model/intest/TestActivation.java
+++ b/model/model-intest/src/test/java/com/evolveum/midpoint/model/intest/TestActivation.java
@@ -95,6 +95,8 @@ public class TestActivation extends AbstractInitializedModelIntegrationTest {
             c -> c.extendSchemaPirate());
     private static final DummyTestResource RESOURCE_DUMMY_FIXED_EXISTENCE = new DummyTestResource(TEST_DIR,
             "resource-dummy-fixed-existence.xml", "8ba303ee-3f07-4163-aa46-508cbc496ff4", "fixed-existence");
+    private static final DummyTestResource RESOURCE_DUMMY_EXISTENCE_INPUT = new DummyTestResource(TEST_DIR,
+            "resource-dummy-existence-input.xml", "8ba303ee-3f07-4163-aa46-508cbc496ff5", "existence-input");
 
     private static final String ACCOUNT_MANCOMB_DUMMY_USERNAME = "mancomb";
     private static final Date ACCOUNT_MANCOMB_VALID_FROM_DATE = MiscUtil.asDate(2011, 2, 3, 4, 5, 6);
@@ -133,7 +135,8 @@ public class TestActivation extends AbstractInitializedModelIntegrationTest {
                 RESOURCE_DUMMY_KHAKI,
                 RESOURCE_DUMMY_PRECREATE,
                 RESOURCE_DUMMY_FULL_VALIDITY,
-                RESOURCE_DUMMY_FIXED_EXISTENCE);
+                RESOURCE_DUMMY_FIXED_EXISTENCE,
+                RESOURCE_DUMMY_EXISTENCE_INPUT);
 
         resourceDummyKhaki = modelService
                 .getObject(ResourceType.class, RESOURCE_DUMMY_KHAKI.oid, null, initTask, initResult)
@@ -3113,6 +3116,36 @@ public class TestActivation extends AbstractInitializedModelIntegrationTest {
         assertNoObject(UserType.class, user.getOid());
         assertDummyAccountByUsername(RESOURCE_DUMMY_FIXED_EXISTENCE.name, userName)
                 .assertFullName(fullName);
+    }
+
+    /** Existence mapping should expose "input" as the same legality value as "legal". MID-10905. */
+    @Test
+    public void test830ExistenceInput() throws Exception {
+        var task = getTestTask();
+        var result = task.getResult();
+        assumeAssignmentPolicy(AssignmentPolicyEnforcementType.FULL);
+        var userName = getTestNameShort();
+        var fullName = "Mr. " + userName;
+
+        given("a user with a single account exists");
+        var user = new UserType()
+                .name(userName)
+                .fullName(fullName)
+                .assignment(
+                        RESOURCE_DUMMY_EXISTENCE_INPUT.assignmentWithConstructionOf(ACCOUNT, INTENT_DEFAULT));
+        addObject(user, task, result);
+
+        then("the existence mapping used input=true to create the account");
+        assertSuccess(result);
+        assertDummyAccountByUsername(RESOURCE_DUMMY_EXISTENCE_INPUT.name, userName)
+                .assertFullName(fullName);
+
+        when("the account is unassigned");
+        unassignAccountFromUser(user.getOid(), RESOURCE_DUMMY_EXISTENCE_INPUT.oid, INTENT_DEFAULT, task, result);
+
+        then("the existence mapping used input=false to delete the account");
+        assertSuccess(result);
+        assertNoDummyAccount(RESOURCE_DUMMY_EXISTENCE_INPUT.name, userName);
     }
 
     private void assertDummyActivationEnabledState(String userId, Boolean expectedEnabled) throws SchemaViolationException, ConflictException, InterruptedException {

--- a/model/model-intest/src/test/resources/activation/resource-dummy-existence-input.xml
+++ b/model/model-intest/src/test/resources/activation/resource-dummy-existence-input.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2026 Evolveum and contributors
+  ~
+  ~ Licensed under the EUPL-1.2 or later.
+  -->
+
+<resource oid="8ba303ee-3f07-4163-aa46-508cbc496ff5"
+          xmlns="http://midpoint.evolveum.com/xml/ns/public/common/common-3"
+          xmlns:c="http://midpoint.evolveum.com/xml/ns/public/common/common-3"
+          xmlns:q="http://prism.evolveum.com/xml/ns/public/query-3"
+          xmlns:icfs="http://midpoint.evolveum.com/xml/ns/public/connector/icf-1/resource-schema-3"
+          xmlns:ri="http://midpoint.evolveum.com/xml/ns/public/resource/instance-3">
+
+    <name>resource-dummy-existence-input</name>
+    <connectorRef type="c:ConnectorType">
+        <filter>
+            <q:and>
+                <q:equal>
+                    <q:path>connectorType</q:path>
+                    <q:value>com.evolveum.icf.dummy.connector.DummyConnector</q:value>
+                </q:equal>
+                <q:equal>
+                    <q:path>connectorVersion</q:path>
+                    <q:value>2.0</q:value>
+                </q:equal>
+            </q:and>
+        </filter>
+    </connectorRef>
+    <connectorConfiguration xmlns:icfi="http://midpoint.evolveum.com/xml/ns/public/connector/icf-1/bundle/com.evolveum.icf.dummy/com.evolveum.icf.dummy.connector.DummyConnector"
+                            xmlns:icfc="http://midpoint.evolveum.com/xml/ns/public/connector/icf-1/connector-schema-3">
+        <icfc:configurationProperties>
+            <icfi:instanceId>existence-input</icfi:instanceId>
+        </icfc:configurationProperties>
+    </connectorConfiguration>
+    <schemaHandling>
+        <objectType>
+            <kind>account</kind>
+            <intent>default</intent>
+            <displayName>Default Account</displayName>
+            <default>true</default>
+            <objectClass>ri:AccountObjectClass</objectClass>
+            <attribute>
+                <ref>icfs:name</ref>
+                <outbound>
+                    <strength>strong</strength>
+                    <source>
+                        <path>name</path>
+                    </source>
+                </outbound>
+            </attribute>
+            <attribute>
+                <ref>ri:fullname</ref>
+                <outbound>
+                    <strength>strong</strength>
+                    <source>
+                        <path>fullName</path>
+                    </source>
+                </outbound>
+            </attribute>
+            <activation>
+                <existence>
+                    <outbound>
+                        <expression>
+                            <script>
+                                <code>
+                                    if (input != legal) {
+                                        throw new IllegalStateException('input and legal differ')
+                                    }
+                                    input
+                                </code>
+                            </script>
+                        </expression>
+                    </outbound>
+                </existence>
+            </activation>
+        </objectType>
+    </schemaHandling>
+</resource>

--- a/release-notes.adoc
+++ b/release-notes.adoc
@@ -139,6 +139,7 @@ Overall, midPoint 4.10 opens up the world of identity management and governance 
 * Fixed dashboard widget collections with inline filters by allowing explicit object type specification. See bug:MID-9879[]
 * Fixed missing .zip extension when downloading tracing report files. See bug:MID-11096[]
 * Fixed resource wizard mapping property autocomplete to find partial matches regardless of letter case. See bug:MID-10415[]
+* Fixed missing input variable in resource activation existence mappings. See bug:MID-10905[]
 
 === Releases Of Other Components
 


### PR DESCRIPTION
## Summary

Fixes MID-10905 by exposing the documented `input` variable in resource activation existence mappings.

Existence mappings already used the computed projection legality value as the default source named `legal`. However, the documentation says that the same legality value is available as `input`. Expressions explicitly referencing `input` failed with `No such property: input`.

This change keeps `legal` as the default source to preserve existing behavior, including `<asIs/>`, and adds `input` as an additional source backed by the same legality IDI.

## Changes

- Added `input` as an additional source in `ActivationProcessor.evaluateExistenceMapping`.
- Kept `legal` as the default source for backward compatibility.
- Added a regression resource with an existence mapping that checks `input == legal` and returns `input`.
- Added `test830ExistenceInput` covering both:
  - assigned/legal projection creates the account
  - unassigned/illegal projection deletes the account
- Added release note entry.

## Manual verification

Verified manually in GUI using a resource existence mapping script that throws debug output.

On the fixed branch, the existence mapping saw:

- assigned case: `input=true`, `legal=true`, `assigned=true`, `focusExists=true`
- unassigned case: `input=false`, `legal=false`, `assigned=false`, `focusExists=true`

On current master, the same mapping failed with:

`Groovy Evaluation Failed: No such property: input`

The master error context contained `legal`, `assigned`, and `focusExists`, but not `input`.