### PR TITLE
MID-11015 Summarize operation results before task and trace storage

### DIFF
--- a/infra/schema/src/main/java/com/evolveum/midpoint/schema/util/OperationResultUtil.java
+++ b/infra/schema/src/main/java/com/evolveum/midpoint/schema/util/OperationResultUtil.java
@@ -7,6 +7,7 @@
 package com.evolveum.midpoint.schema.util;
 
 import com.evolveum.midpoint.prism.util.CloneUtil;
+import com.evolveum.midpoint.schema.result.OperationResult;
 import com.evolveum.midpoint.schema.result.OperationResultStatus;
 import com.evolveum.midpoint.xml.ns._public.common.common_3.OperationResultStatusType;
 import com.evolveum.midpoint.xml.ns._public.common.common_3.OperationResultType;
@@ -81,5 +82,33 @@ public class OperationResultUtil {
         } else {
             return SUCCESS;
         }
+    }
+
+    /**
+     * Creates a storage-friendly bean representation of the given operation result.
+     *
+     * The returned bean is based on a cloned and summarized copy of the original result. Successful
+     * subresults are marked for summarization recursively, and then {@link OperationResult#summarize(boolean)}
+     * is applied to collapse repeated successful branches. The original result object is left untouched.
+     *
+     * @param result live operation result to serialize for storage
+     * @return summarized bean suitable for task result or trace storage
+     */
+    public static OperationResultType createStoredResultBean(OperationResult result) {
+        OperationResult resultClone = result.clone();
+        setSummarizeSuccessesRecursively(resultClone);
+        resultClone.summarize(true);
+        return resultClone.createOperationResultType();
+    }
+
+    /**
+     * Enables successful-result summarization on the whole result tree.
+     *
+     * {@link OperationResult#summarize(boolean)} respects per-result summarization flags, so all
+     * existing subresults have to be marked before summarization is invoked.
+     */
+    private static void setSummarizeSuccessesRecursively(OperationResult result) {
+        result.setSummarizeSuccesses(true);
+        result.getSubresults().forEach(OperationResultUtil::setSummarizeSuccessesRecursively);
     }
 }

--- a/infra/schema/src/test/java/com/evolveum/midpoint/schema/TestOperationResult.java
+++ b/infra/schema/src/test/java/com/evolveum/midpoint/schema/TestOperationResult.java
@@ -7,6 +7,8 @@
 package com.evolveum.midpoint.schema;
 
 import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.AssertJUnit.assertNotNull;
+import static org.testng.AssertJUnit.assertTrue;
 
 import static com.evolveum.midpoint.prism.util.PrismTestUtil.getPrismContext;
 import static com.evolveum.midpoint.xml.ns._public.common.common_3.OperationResultImportanceType.MAJOR;
@@ -20,6 +22,7 @@ import com.evolveum.midpoint.prism.PrismContext;
 import com.evolveum.midpoint.schema.constants.SchemaConstants;
 import com.evolveum.midpoint.schema.result.OperationResult;
 import com.evolveum.midpoint.schema.result.OperationResultStatus;
+import com.evolveum.midpoint.schema.util.OperationResultUtil;
 import com.evolveum.midpoint.util.exception.SchemaException;
 import com.evolveum.midpoint.xml.ns._public.common.common_3.OperationResultHandlingStrategyType;
 import com.evolveum.midpoint.xml.ns._public.common.common_3.OperationResultType;
@@ -27,6 +30,8 @@ import com.evolveum.midpoint.xml.ns._public.common.common_3.OperationResultType;
 public class TestOperationResult extends AbstractSchemaTest {
 
     private static final String LOCAL_1 = "local1";
+
+    private static final int SUCCESSFUL_RESULTS = 1000;
 
     @Test
     public void testCleanup() throws Exception {
@@ -206,6 +211,86 @@ public class TestOperationResult extends AbstractSchemaTest {
         }
 
         checkResultConversion(root, true);
+    }
+
+    @Test
+    public void testCreateStoredResultBeanSummarizesWithoutMutatingSource() throws Exception {
+        given();
+        OperationResult result = createLargeResult();
+        OperationResult firstOriginalSuccess = result.getSubresults().get(0);
+        OperationResultType fullBean = result.createOperationResultType();
+        String fullXml = serializeResult(fullBean);
+
+        when();
+        OperationResultType storedBean = OperationResultUtil.createStoredResultBean(result);
+        String storedXml = serializeResult(storedBean);
+
+        then();
+        assertTrue("Stored result should be much smaller than the original",
+                storedXml.length() < fullXml.length() / 5);
+        assertTrue("Repeated successful results should be summarized",
+                countPartialResults(storedBean) < countPartialResults(fullBean));
+        assertEquals("Root operation must be preserved", "run", storedBean.getOperation());
+        assertEquals("Root status must be preserved", fullBean.getStatus(), storedBean.getStatus());
+        assertTrue("Warning result must be preserved",
+                containsOperation(storedBean, "warning.operation"));
+        assertTrue("Partial error result must be preserved",
+                containsOperation(storedBean, "partial.error.operation"));
+        assertTrue("Fatal error result must be preserved",
+                containsOperation(storedBean, "fatal.error.operation"));
+        assertNotNull("Stored result bean must be convertible back to OperationResult",
+                OperationResult.createOperationResult(storedBean));
+        assertEquals("Live OperationResult must not be mutated",
+                SUCCESSFUL_RESULTS + 3, result.getSubresults().size());
+        assertEquals("First original success result parameter must be preserved",
+                "0", firstOriginalSuccess.getParamSingle("iteration"));
+        assertEquals("First original success result detail must be preserved",
+                "detail-0", firstOriginalSuccess.getDetail().get(0));
+    }
+
+    private OperationResult createLargeResult() {
+        OperationResult result = new OperationResult("run");
+
+        for (int i = 0; i < SUCCESSFUL_RESULTS; i++) {
+            OperationResult subresult = result.createSubresult("repository.modifyObject");
+            subresult.addParam("iteration", i);
+            subresult.appendDetail("detail-" + i);
+            subresult.recordStatus(OperationResultStatus.SUCCESS, "success");
+        }
+
+        result.createSubresult("warning.operation")
+                .recordWarning("warning");
+        result.createSubresult("partial.error.operation")
+                .recordPartialError("partial error");
+        result.createSubresult("fatal.error.operation")
+                .recordFatalError("fatal error");
+
+        result.computeStatus();
+        return result;
+    }
+
+    private int countPartialResults(OperationResultType result) {
+        int count = result.getPartialResults().size();
+        for (OperationResultType partialResult : result.getPartialResults()) {
+            count += countPartialResults(partialResult);
+        }
+        return count;
+    }
+
+    private boolean containsOperation(OperationResultType result, String operation) {
+        if (operation.equals(result.getOperation())) {
+            return true;
+        }
+        for (OperationResultType partialResult : result.getPartialResults()) {
+            if (containsOperation(partialResult, operation)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private String serializeResult(OperationResultType bean) throws SchemaException {
+        return getPrismContext().xmlSerializer().serializeAnyData(bean, SchemaConstants.C_RESULT);
     }
 
     private void checkResultConversion(OperationResult result, boolean assertEquals) throws SchemaException {

--- a/release-notes.adoc
+++ b/release-notes.adoc
@@ -102,6 +102,7 @@ Overall, midPoint 4.10 opens up the world of identity management and governance 
 * Delineation suggestions: filter parsing broken after recent GUI change. See bug:MID-11175[]
 * Fixed work item search by name causing repository mapping error. See bug:MID-8834[]
 * Fixed translation of archetype display labels in assignment picker and summary panel. See bug:MID-11177[]
+* Reduced functional trace and task result size by summarizing repetitive successful OperationResult subresults. See bug:MID-11015[]
 * Fixed generic "Fatal error" message in object tables to show available list/search error details. See bug:MID-10911[]
 
 === Releases Of Other Components

--- a/repo/task-quartz-impl/src/main/java/com/evolveum/midpoint/task/quartzimpl/TaskQuartzImpl.java
+++ b/repo/task-quartz-impl/src/main/java/com/evolveum/midpoint/task/quartzimpl/TaskQuartzImpl.java
@@ -41,6 +41,7 @@ import com.evolveum.midpoint.repo.api.ModificationPrecondition;
 import com.evolveum.midpoint.repo.api.PreconditionViolationException;
 import com.evolveum.midpoint.schema.result.OperationResult;
 import com.evolveum.midpoint.schema.util.ObjectTypeUtil;
+import com.evolveum.midpoint.schema.util.OperationResultUtil;
 import com.evolveum.midpoint.task.api.*;
 import com.evolveum.midpoint.task.quartzimpl.statistics.Statistics;
 import com.evolveum.midpoint.util.DebugUtil;
@@ -272,7 +273,7 @@ public class TaskQuartzImpl implements Task {
         synchronized (prismAccess) {
             if (taskResult != null) {
                 clearPrismResultIncompleteFlag();
-                taskPrism.asObjectable().setResult(taskResult.createOperationResultType());
+                taskPrism.asObjectable().setResult(createStoredResultBean(taskResult));
                 taskPrism.asObjectable().setResultStatus(taskResult.getStatus().createStatusType());
             } else {
                 taskPrism.asObjectable().setResult(null);
@@ -800,7 +801,7 @@ public class TaskQuartzImpl implements Task {
             if (result != null) {
                 clearPrismResultIncompleteFlag();
             }
-            taskPrism.asObjectable().setResult(result != null ? result.createOperationResultType() : null);
+            taskPrism.asObjectable().setResult(createStoredResultBean(result));
             taskPrism.asObjectable().setResultStatus(result != null ? result.getStatus().createStatusType() : null);
         }
     }
@@ -816,10 +817,14 @@ public class TaskQuartzImpl implements Task {
     private PropertyDelta<?> setResultAndPrepareDelta(OperationResult result) {
         setResultTransient(result);
         if (isPersistent()) {
-            return createPropertyDeltaIfPersistent(TaskType.F_RESULT, result != null ? result.createOperationResultType() : null);
+            return createPropertyDeltaIfPersistent(TaskType.F_RESULT, createStoredResultBean(result));
         } else {
             return null;
         }
+    }
+
+    static OperationResultType createStoredResultBean(OperationResult result) {
+        return result != null ? OperationResultUtil.createStoredResultBean(result) : null;
     }
 
     /*

--- a/repo/task-quartz-impl/src/main/java/com/evolveum/midpoint/task/quartzimpl/tracing/TracingOutputCreator.java
+++ b/repo/task-quartz-impl/src/main/java/com/evolveum/midpoint/task/quartzimpl/tracing/TracingOutputCreator.java
@@ -13,6 +13,7 @@ import com.evolveum.midpoint.prism.xml.XmlTypeConverter;
 import com.evolveum.midpoint.schema.constants.SchemaConstants;
 import com.evolveum.midpoint.schema.result.OperationResult;
 import com.evolveum.midpoint.schema.util.ObjectTypeUtil;
+import com.evolveum.midpoint.schema.util.OperationResultUtil;
 import com.evolveum.midpoint.task.api.Task;
 import com.evolveum.midpoint.task.api.TaskManager;
 import com.evolveum.midpoint.util.DebugUtil;
@@ -50,7 +51,7 @@ public class TracingOutputCreator {
 
         result.checkLogRecorderFlushed();
 
-        OperationResultType resultBean = result.createOperationResultType();
+        OperationResultType resultBean = OperationResultUtil.createStoredResultBean(result);
         new LogCompressor().compressResult(resultBean);
 
         List<TraceDictionaryType> embeddedDictionaries = extractDictionaries(result);


### PR DESCRIPTION
## Summary

This change reduces oversized functional trace and task result content by storing summarized `OperationResult` beans instead of full repetitive successful subresult trees.

A new `OperationResultUtil.createStoredResultBean(...)` helper clones the live result, enables successful-result summarization recursively, calls the existing `OperationResult.summarize(true)`, and returns a storage-friendly `OperationResultType`. The live `OperationResult` is not mutated.

The helper is used in:
- functional trace output creation,
- task result storage in `TaskQuartzImpl`.

This keeps important root status and warning/error/fatal branches, while collapsing repeated successful low-level operations.

Related Prism PR:
- https://github.com/Evolveum/prism/pull/12

That Prism change avoids large intermediate byte array allocation when writing ZIP entries and should be reviewed/merged together with this fix.

## Testing

Tested with CSV import scenarios:
- small successful import,
- small failed import with broken mapping,
- conflict/ObjectAlreadyExists import,
- 250-attribute heavy import.

Observed reductions included:
- small success: `245` partial results / `868k` XML → `20` partial results / `91k` XML,
- 250-attribute conflict: `1113` partial results / `3.6MB` XML → `80` partial results / `1.0MB` XML,
- 250-attribute success: `1294` partial results / `5.3MB` XML → `28` partial results / `1.2MB` XML.

Added test coverage for `OperationResultUtil.createStoredResultBean(...)` to verify summarization, preservation of warning/error/fatal results, round-trip conversion, and no mutation of the source result.