### PR TITLE
MID-10908 Fix tooltip lifecycle in search popovers

### DIFF
--- a/gui/admin-gui/src/frontend/js/midpoint-theme.js
+++ b/gui/admin-gui/src/frontend/js/midpoint-theme.js
@@ -364,13 +364,21 @@ export default class MidPointTheme {
                     const tooltipId = 'tooltip-' + Math.random().toString(16).substr(2, 6);
                     $el.attr('data-tooltip-id', tooltipId);
 
-                    $el.tooltip({
+                    const tooltipOptions = {
                         html: true,
                         title: $el.attr('data-tooltip-content') || '',
                         whiteList: wl,
                         container: container,
                         trigger: 'manual'
-                    });
+                    };
+
+                    if ($el.closest('.search-popover').length !== 0) {
+                        tooltipOptions.placement = 'left';
+                        tooltipOptions.boundary = 'window';
+                        tooltipOptions.offset = '0, 2';
+                    }
+
+                    $el.tooltip(tooltipOptions);
 
                     // "tooltipShowDelayTimer" is used to prevent tooltip from showing when user quickly moves mouse
                     // over multiple icons with tooltips or quickly tabs through them. Tooltip will be shown only for

--- a/gui/admin-gui/src/frontend/js/midpoint-theme.js
+++ b/gui/admin-gui/src/frontend/js/midpoint-theme.js
@@ -302,11 +302,11 @@ export default class MidPointTheme {
                     if (parentMorePopup && parentMorePopup.length !== 0) {
                         setTimeout(function() {
                             isHovered = false;
-                            checkHide($(this));
+                            checkHide($el);
                         }, 300);
                     } else {
                         isHovered = false;
-                        checkHide($(this));
+                        checkHide($el);
                     }
                 });
 
@@ -379,13 +379,13 @@ export default class MidPointTheme {
                     $el.data("tooltipShowDelayTimer", setTimeout(() => {
                         $el.tooltip("show");
                         $el.removeAttr("aria-describedby");
-                    }, 1000));
-
-                    setTimeout(() => {
-                        const $tooltip = $('.tooltip:visible').last();
-                        $tooltip.removeAttr('role');
+                        const $tooltip = $('.tooltip:visible').last()
+                            .attr('id', tooltipId)
+                            .removeAttr('role');
+                        if (!setFocus) {
+                            $tooltip.css('pointer-events', 'none');
+                        }
                         const $tooltipInner = $tooltip.find('.tooltip-inner');
-                        $tooltip.attr('id', tooltipId);
 
                         $tooltipInner
                             .attr('tabindex', '0')
@@ -428,7 +428,7 @@ export default class MidPointTheme {
                             $tooltipInner.focus();
                             lastTooltipTrigger = $el;
                         }
-                    }, 100);
+                    }, 1000));
                 }
             };
 
@@ -1389,6 +1389,9 @@ export default class MidPointTheme {
 
         if (!show) {
             if (popup.is(':visible')) {
+                popup.find("[data-toggle='tooltip']").each(function () {
+                    $(this).tooltip('hide').tooltip('dispose').removeAttr('data-tooltip-id aria-describedby');
+                });
                 popup.fadeOut(200);
                 ref.attr('aria-expanded', 'false');
                 ref.focus();

--- a/gui/admin-gui/src/frontend/js/midpoint-theme.js
+++ b/gui/admin-gui/src/frontend/js/midpoint-theme.js
@@ -364,21 +364,13 @@ export default class MidPointTheme {
                     const tooltipId = 'tooltip-' + Math.random().toString(16).substr(2, 6);
                     $el.attr('data-tooltip-id', tooltipId);
 
-                    const tooltipOptions = {
+                    $el.tooltip({
                         html: true,
                         title: $el.attr('data-tooltip-content') || '',
                         whiteList: wl,
                         container: container,
                         trigger: 'manual'
-                    };
-
-                    if ($el.closest('.search-popover').length !== 0) {
-                        tooltipOptions.placement = 'left';
-                        tooltipOptions.boundary = 'window';
-                        tooltipOptions.offset = '0, 2';
-                    }
-
-                    $el.tooltip(tooltipOptions);
+                    });
 
                     // "tooltipShowDelayTimer" is used to prevent tooltip from showing when user quickly moves mouse
                     // over multiple icons with tooltips or quickly tabs through them. Tooltip will be shown only for

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/component/button/SelectableItemListPopoverPanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/component/button/SelectableItemListPopoverPanel.java
@@ -166,6 +166,11 @@ public abstract class SelectableItemListPopoverPanel<T extends FilterableSearchI
                     public String getDataPlacement() {
                         return "left";
                     }
+
+                    @Override
+                    public String getDataBoundary() {
+                        return "window";
+                    }
                 });
                 help.add(new VisibleBehaviour(() -> StringUtils.isNotEmpty(helpText)));
                 help.add(AttributeAppender.append(

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/util/TooltipBehavior.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/util/TooltipBehavior.java
@@ -24,8 +24,16 @@ public class TooltipBehavior extends Behavior {
         component.setOutputMarkupId(true);
 
         component.add(AttributeModifier.replace("data-toggle", "tooltip"));
-        component.add(new AttributeModifier("data-placement", getDataPlacement()) {
+        addTooltipAttribute(component, "data-placement", getDataPlacement());
 
+        String dataBoundary = getDataBoundary();
+        if (StringUtils.isNotEmpty(dataBoundary)) {
+            addTooltipAttribute(component, "data-boundary", dataBoundary);
+        }
+    }
+
+    private void addTooltipAttribute(Component component, String attributeName, String value) {
+        component.add(new AttributeModifier(attributeName, value) {
             @Override
             protected String newValue(String currentValue, String replacementValue) {
                 if (StringUtils.isEmpty(currentValue)) {
@@ -38,5 +46,9 @@ public class TooltipBehavior extends Behavior {
 
     public String getDataPlacement() {
         return "right";
+    }
+
+    public String getDataBoundary() {
+        return null;
     }
 }

--- a/release-notes.adoc
+++ b/release-notes.adoc
@@ -143,6 +143,7 @@ Overall, midPoint 4.10 opens up the world of identity management and governance 
 * Fixed stale page recovery after viewing page source causing internal server error. See bug:MID-9998[]
 * Hided conflict warning on Shopping cart panel of the Request Access wizard in case of prune action. See bug:MID-11250[] and xref:#_behavior_changes_since_4_10[behavior changes since 4.10].
 * Fixed NPE when selecting deprecated action in resource object type editor. See bug:MID-10957[]
+* Fixed tooltip lifecycle in search popovers to prevent blinking, stuck, and duplicate tooltips. See bug:MID-10908[]
 
 === Releases Of Other Components
 


### PR DESCRIPTION
## Summary

Fixes tooltip lifecycle handling for help tooltips inside search `More` popovers.

Tooltips in the search popover could blink, stay stuck after mouse leave, duplicate, or remain visible after the popover was closed. 

## Changes

- Keep the original tooltip trigger reference when hiding delayed tooltips.
- Prevent non-focused tooltip overlays from interfering with hover handling.
- Dispose help tooltips when the related search popover is closed.

## Testing

Schrodinger test coverage was added separately:

https://github.com/Evolveum/schrodinger/pull/16