### PR TITLE
MID-10415 Fix mapping property autocomplete matching

### DIFF
--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/component/input/FocusDefinitionsMappingProvider.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/component/input/FocusDefinitionsMappingProvider.java
@@ -15,6 +15,7 @@ import com.evolveum.midpoint.prism.path.ItemPath;
 import com.evolveum.midpoint.xml.ns._public.common.common_3.*;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 import org.apache.wicket.model.IModel;
 import org.wicketstuff.select2.ChoiceProvider;
 import org.wicketstuff.select2.Response;
@@ -142,7 +143,7 @@ public class FocusDefinitionsMappingProvider extends ChoiceProvider<VariableBind
 
         for (ItemDefinition<?> def : definitions) {
             if (StringUtils.isNotBlank(input)
-                    && !def.getItemName().getLocalPart().toLowerCase().contains(input.toLowerCase())) {
+                    && !Strings.CI.contains(def.getItemName().getLocalPart(), input)) {
                 continue;
             }
 

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/component/input/FocusDefinitionsMappingProvider.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/component/input/FocusDefinitionsMappingProvider.java
@@ -141,7 +141,8 @@ public class FocusDefinitionsMappingProvider extends ChoiceProvider<VariableBind
         }
 
         for (ItemDefinition<?> def : definitions) {
-            if (StringUtils.isNotBlank(input) && !def.getItemName().getLocalPart().startsWith(input)) {
+            if (StringUtils.isNotBlank(input)
+                    && !def.getItemName().getLocalPart().toLowerCase().contains(input.toLowerCase())) {
                 continue;
             }
 

--- a/gui/admin-gui/src/test/java/com/evolveum/midpoint/gui/FocusDefinitionsMappingProviderTest.java
+++ b/gui/admin-gui/src/test/java/com/evolveum/midpoint/gui/FocusDefinitionsMappingProviderTest.java
@@ -12,11 +12,13 @@ import static org.testng.Assert.assertTrue;
 
 import java.util.List;
 
-import com.evolveum.midpoint.gui.impl.component.input.FocusDefinitionsMappingProvider;
 import org.testng.annotations.Test;
 
+import com.evolveum.midpoint.gui.impl.component.input.FocusDefinitionsMappingProvider;
+import com.evolveum.midpoint.prism.Containerable;
 import com.evolveum.midpoint.prism.PrismContainerDefinition;
 import com.evolveum.midpoint.web.AbstractGuiUnitTest;
+import com.evolveum.midpoint.xml.ns._public.common.common_3.ResourceObjectTypeDefinitionType;
 import com.evolveum.midpoint.xml.ns._public.common.common_3.UserType;
 
 /**
@@ -29,12 +31,12 @@ public class FocusDefinitionsMappingProviderTest extends AbstractGuiUnitTest {
      */
     @Test
     public void testCollectAvailableDefinitionsMatchesSubstringIgnoreCase() {
-        FocusDefinitionsMappingProvider provider = new FocusDefinitionsMappingProvider(null);
+        FocusDefinitionsMappingProvider provider = new TestFocusDefinitionsMappingProvider();
 
-        List<String> lowerCaseMatches = provider.collectAvailableDefinitions("name", getUserObjectDefinition());
+        List<String> lowerCaseMatches = provider.collectAvailableDefinitions("name", getResourceObjectType());
         assertNameMatches(lowerCaseMatches);
 
-        List<String> mixedCaseMatches = provider.collectAvailableDefinitions("Name", getUserObjectDefinition());
+        List<String> mixedCaseMatches = provider.collectAvailableDefinitions("Name", getResourceObjectType());
         assertNameMatches(mixedCaseMatches);
     }
 
@@ -43,9 +45,9 @@ public class FocusDefinitionsMappingProviderTest extends AbstractGuiUnitTest {
      */
     @Test
     public void testCollectAvailableDefinitionsDoesNotReturnNameFieldsForUnrelatedInput() {
-        FocusDefinitionsMappingProvider provider = new FocusDefinitionsMappingProvider(null);
+        FocusDefinitionsMappingProvider provider = new TestFocusDefinitionsMappingProvider();
 
-        List<String> matches = provider.collectAvailableDefinitions("unrelatedInput", getUserObjectDefinition());
+        List<String> matches = provider.collectAvailableDefinitions("unrelatedInput", getResourceObjectType());
 
         assertFalse(matches.contains(UserType.F_NAME.getLocalPart()));
         assertFalse(matches.contains(UserType.F_FAMILY_NAME.getLocalPart()));
@@ -58,10 +60,26 @@ public class FocusDefinitionsMappingProviderTest extends AbstractGuiUnitTest {
         assertTrue(matches.contains(UserType.F_GIVEN_NAME.getLocalPart()));
     }
 
+    private ResourceObjectTypeDefinitionType getResourceObjectType() {
+        return new ResourceObjectTypeDefinitionType();
+    }
+
     private PrismContainerDefinition<UserType> getUserObjectDefinition() {
         return getPrismContext()
                 .getSchemaRegistry()
                 .findObjectDefinitionByCompileTimeClass(UserType.class);
     }
 
+    private class TestFocusDefinitionsMappingProvider extends FocusDefinitionsMappingProvider {
+
+        private TestFocusDefinitionsMappingProvider() {
+            super(null);
+        }
+
+        @Override
+        protected PrismContainerDefinition<? extends Containerable> getFocusTypeDefinition(
+                ResourceObjectTypeDefinitionType resourceObjectType) {
+            return getUserObjectDefinition();
+        }
+    }
 }

--- a/gui/admin-gui/src/test/java/com/evolveum/midpoint/gui/FocusDefinitionsMappingProviderTest.java
+++ b/gui/admin-gui/src/test/java/com/evolveum/midpoint/gui/FocusDefinitionsMappingProviderTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2010-2026 Evolveum and contributors
+ *
+ * This work is dual-licensed under the Apache License 2.0
+ * and European Union Public License. See LICENSE file for details.
+ */
+
+package com.evolveum.midpoint.gui;
+
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+import java.util.List;
+
+import com.evolveum.midpoint.gui.impl.component.input.FocusDefinitionsMappingProvider;
+import org.testng.annotations.Test;
+
+import com.evolveum.midpoint.prism.PrismContainerDefinition;
+import com.evolveum.midpoint.web.AbstractGuiUnitTest;
+import com.evolveum.midpoint.xml.ns._public.common.common_3.UserType;
+
+/**
+ * Tests autocomplete matching for focus object item paths used in mapping source/target selectors.
+ */
+public class FocusDefinitionsMappingProviderTest extends AbstractGuiUnitTest {
+
+    /**
+     * Verifies that filtering matches item local-name substrings regardless of character case.
+     */
+    @Test
+    public void testCollectAvailableDefinitionsMatchesSubstringIgnoreCase() {
+        FocusDefinitionsMappingProvider provider = new FocusDefinitionsMappingProvider(null);
+
+        List<String> lowerCaseMatches = provider.collectAvailableDefinitions("name", getUserObjectDefinition());
+        assertNameMatches(lowerCaseMatches);
+
+        List<String> mixedCaseMatches = provider.collectAvailableDefinitions("Name", getUserObjectDefinition());
+        assertNameMatches(mixedCaseMatches);
+    }
+
+    /**
+     * Verifies that unrelated input does not include name-related user properties.
+     */
+    @Test
+    public void testCollectAvailableDefinitionsDoesNotReturnNameFieldsForUnrelatedInput() {
+        FocusDefinitionsMappingProvider provider = new FocusDefinitionsMappingProvider(null);
+
+        List<String> matches = provider.collectAvailableDefinitions("unrelatedInput", getUserObjectDefinition());
+
+        assertFalse(matches.contains(UserType.F_NAME.getLocalPart()));
+        assertFalse(matches.contains(UserType.F_FAMILY_NAME.getLocalPart()));
+        assertFalse(matches.contains(UserType.F_GIVEN_NAME.getLocalPart()));
+    }
+
+    private void assertNameMatches(List<String> matches) {
+        assertTrue(matches.contains(UserType.F_NAME.getLocalPart()));
+        assertTrue(matches.contains(UserType.F_FAMILY_NAME.getLocalPart()));
+        assertTrue(matches.contains(UserType.F_GIVEN_NAME.getLocalPart()));
+    }
+
+    private PrismContainerDefinition<UserType> getUserObjectDefinition() {
+        return getPrismContext()
+                .getSchemaRegistry()
+                .findObjectDefinitionByCompileTimeClass(UserType.class);
+    }
+
+}

--- a/gui/admin-gui/testng-unit.xml
+++ b/gui/admin-gui/testng-unit.xml
@@ -13,6 +13,7 @@
             <class name="com.evolveum.midpoint.web.TestPageMounter"/>
             <class name="com.evolveum.midpoint.web.TestXmlGregorianCalendarModel"/>
             <class name="com.evolveum.midpoint.gui.SelectableBeanDataProviderCountCacheTest"/>
+            <class name="com.evolveum.midpoint.gui.FocusDefinitionsMappingProviderTest"/>
         </classes>
     </test>
 </suite>

--- a/release-notes.adoc
+++ b/release-notes.adoc
@@ -138,6 +138,7 @@ Overall, midPoint 4.10 opens up the world of identity management and governance 
 * Fixed loss of unsaved resource detail changes after running Test connection. See bug:MID-10966[]
 * Fixed dashboard widget collections with inline filters by allowing explicit object type specification. See bug:MID-9879[]
 * Fixed missing .zip extension when downloading tracing report files. See bug:MID-11096[]
+* Fixed resource wizard mapping property autocomplete to find partial matches regardless of letter case. See bug:MID-10415[]
 
 === Releases Of Other Components
 


### PR DESCRIPTION
## Summary

Fixed autocomplete filtering for focus object item paths used in mapping-related GUI fields.

Previously, the provider used prefix-only matching. Because of that, typing `name` in the resource wizard inbound mapping **MidPoint property** field proposed only `name`, but did not propose other valid properties that contain the same text, such as `familyName` or `givenName`.

The filtering now uses partial matching, so matching properties are suggested even when the typed text appears later in the property name. Matching is also case-insensitive.

## Affected areas

The changed provider is `FocusDefinitionsMappingProvider`. It is used by focus object property/item-path autocomplete fields in mapping and correlation screens.

This affects suggestion filtering in places such as:

- resource wizard mapping tables:
  - inbound mapping target / MidPoint property
  - outbound mapping source
  - activation and credentials mapping source/target fields
  - smart mapping table source/target fields
- resource association wizard mapping tables:
  - association mapping source/target fields
  - association attribute mapping fields
- focus, role, and object template mapping tables:
  - focus mapping source fields
  - focus mapping target fields
  - role wizard focus mapping source fields
- correlation item reference autocomplete fields

The change only affects autocomplete suggestions for focus object properties/item paths. It does not change mapping evaluation, resource schema handling, repository queries, or resource attribute autocomplete. The resource attribute selector already used partial case-insensitive filtering through a different provider.