### PR TITLE
Add SCIM schema refresh wizard step and fix credentials integration type path

### DIFF
--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/component/wizard/scimrest/connection/ConnectionConnectorStepPanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/component/wizard/scimrest/connection/ConnectionConnectorStepPanel.java
@@ -180,7 +180,8 @@ public class ConnectionConnectorStepPanel extends AbstractFormWizardStepPanel<Co
                 new AuthScriptsConnectorStepPanel(getHelper()),
                 new CredentialsConnectorStepPanel(getHelper()),
                 new EndpointConnectorStepPanel(getHelper()),
-                new ResourceTestConnectorStepPanel(getHelper()));
+                new ResourceTestConnectorStepPanel(getHelper()),
+                new WaitingScimSchemaConnectorStepPanel(getHelper()));
     }
 
     @Override

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/component/wizard/scimrest/connection/CredentialsConnectorStepPanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/component/wizard/scimrest/connection/CredentialsConnectorStepPanel.java
@@ -275,7 +275,7 @@ public class CredentialsConnectorStepPanel extends AbstractWizardStepPanel<Conne
         try {
             PrismPropertyWrapper<ConnDevIntegrationType> integration =
                     getDetailsModel().getObjectWrapper().findProperty(
-                            ItemPath.create(ConnectorDevelopmentType.F_APPLICATION, ConnDevApplicationInfoType.F_INTEGRATION_TYPE));
+                            ItemPath.create(ConnectorDevelopmentType.F_CONNECTOR, ConnDevConnectorType.F_INTEGRATION_TYPE));
             return new ArrayList<>(SupportedAuthorization.attributesFor(integration.getValue().getRealValue(), authType.getType()));
         } catch (SchemaException e) {
             throw new RuntimeException(e);
@@ -356,7 +356,7 @@ public class CredentialsConnectorStepPanel extends AbstractWizardStepPanel<Conne
             try {
                 PrismPropertyWrapper<ConnDevIntegrationType> integration =
                         getDetailsModel().getObjectWrapper().findProperty(
-                                ItemPath.create(ConnectorDevelopmentType.F_APPLICATION, ConnDevApplicationInfoType.F_INTEGRATION_TYPE));
+                                ItemPath.create(ConnectorDevelopmentType.F_CONNECTOR, ConnDevConnectorType.F_INTEGRATION_TYPE));
                 visibleItems.addAll(SupportedAuthorization.attributesFor(integration.getValue().getRealValue(), authType.getType()));
 
                 if (visibleItems.stream().allMatch(

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/component/wizard/scimrest/connection/WaitingScimSchemaConnectorStepPanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/component/wizard/scimrest/connection/WaitingScimSchemaConnectorStepPanel.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright (C) 2010-2025 Evolveum and contributors
+ *
+ * This work is dual-licensed under the Apache License 2.0
+ * and European Union Public License. See LICENSE file for details.
+ */
+package com.evolveum.midpoint.gui.impl.page.admin.connector.development.component.wizard.scimrest.connection;
+
+import com.evolveum.midpoint.gui.impl.component.wizard.WizardPanelHelper;
+import com.evolveum.midpoint.gui.impl.page.admin.connector.development.ConnectorDevelopmentDetailsModel;
+import com.evolveum.midpoint.gui.impl.page.admin.connector.development.component.wizard.scimrest.WaitingConnectorStepPanel;
+import com.evolveum.midpoint.prism.Containerable;
+import com.evolveum.midpoint.prism.path.ItemName;
+import com.evolveum.midpoint.prism.path.ItemPath;
+import com.evolveum.midpoint.schema.result.OperationResult;
+import com.evolveum.midpoint.smart.api.info.StatusInfo;
+import com.evolveum.midpoint.task.api.Task;
+import com.evolveum.midpoint.util.exception.ObjectNotFoundException;
+import com.evolveum.midpoint.util.exception.SchemaException;
+import com.evolveum.midpoint.web.application.PanelDisplay;
+import com.evolveum.midpoint.web.application.PanelInstance;
+import com.evolveum.midpoint.web.application.PanelType;
+import com.evolveum.midpoint.xml.ns._public.common.common_3.*;
+
+import org.apache.wicket.model.IModel;
+import org.apache.wicket.model.Model;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Waiting step panel that triggers SCIM schema refresh (object class discovery from shadows)
+ * after resource test succeeds. Only visible for SCIM connectors.
+ */
+@PanelType(name = "cdw-connector-waiting-scim-schema")
+@PanelInstance(identifier = "cdw-connector-waiting-scim-schema",
+        applicableForType = ConnectorDevelopmentType.class,
+        applicableForOperation = OperationTypeType.WIZARD,
+        display = @PanelDisplay(label = "PageConnectorDevelopment.wizard.step.connectorWaitingScimSchema", icon = "fa fa-database"),
+        containerPath = "empty")
+public class WaitingScimSchemaConnectorStepPanel extends WaitingConnectorStepPanel {
+
+    private static final String PANEL_TYPE = "cdw-connector-waiting-scim-schema";
+
+    public WaitingScimSchemaConnectorStepPanel(WizardPanelHelper<? extends Containerable, ConnectorDevelopmentDetailsModel> helper) {
+        super(helper);
+    }
+
+    @Override
+    protected ItemName getActivityType() {
+        return WorkDefinitionsType.F_REFRESH_SCIM_SCHEMA;
+    }
+
+    @Override
+    protected StatusInfo<?> obtainResult(String token, Task task, OperationResult result) throws SchemaException, ObjectNotFoundException {
+        return getDetailsModel().getServiceLocator().getConnectorService().getRefreshScimSchemaStatus(token, task, result);
+    }
+
+    @Override
+    protected String getNewTaskToken(Task task, OperationResult result, boolean regenerate) {
+        return getDetailsModel().getConnectorDevelopmentOperation().submitRefreshScimSchema(task, result);
+    }
+
+    @Override
+    protected boolean objectClassRequired() {
+        return false;
+    }
+
+    @Override
+    public String getStepId() {
+        return PANEL_TYPE;
+    }
+
+    @Override
+    public IModel<String> getTitle() {
+        return createStringResource("PageConnectorDevelopment.wizard.step.connectorWaitingScimSchema");
+    }
+
+    @Override
+    protected IModel<?> getTextModel() {
+        return createStringResource("PageConnectorDevelopment.wizard.step.connectorWaitingScimSchema.text");
+    }
+
+    @Override
+    protected IModel<?> getSubTextModel() {
+        return createStringResource("PageConnectorDevelopment.wizard.step.connectorWaitingScimSchema.subText");
+    }
+
+    @Override
+    protected @NotNull Model<String> getIconModel() {
+        return Model.of("fa fa-database");
+    }
+
+    @Override
+    public IModel<Boolean> isStepVisible() {
+        if (!isScim()) {
+            return Model.of(false);
+        }
+        return super.isStepVisible();
+    }
+
+    private boolean isScim() {
+        try {
+            var integrationType = getDetailsModel().getObjectWrapper().findProperty(
+                    ItemPath.create(ConnectorDevelopmentType.F_CONNECTOR, ConnDevConnectorType.F_INTEGRATION_TYPE));
+            return integrationType != null
+                    && ConnDevIntegrationType.SCIM.equals(integrationType.getValue().getRealValue());
+        } catch (SchemaException e) {
+            return false;
+        }
+    }
+}

--- a/infra/schema/src/main/java/com/evolveum/midpoint/schema/util/task/work/WorkDefinitionUtil.java
+++ b/infra/schema/src/main/java/com/evolveum/midpoint/schema/util/task/work/WorkDefinitionUtil.java
@@ -86,6 +86,7 @@ public class WorkDefinitionUtil {
         addTypedParameters(values, definitions.getDiscoverObjectClassAttributes());
         addTypedParameters(values, definitions.getDiscoverObjectClassEndpoints());
         addTypedParameters(values, definitions.getGenerateConnectorArtifact());
+        addTypedParameters(values, definitions.getRefreshScimSchema());
 
         addUntypedParameters(values, definitions.getExtension());
         return values;

--- a/infra/schema/src/main/resources/xml/ns/public/common/common-tasks-3.xsd
+++ b/infra/schema/src/main/resources/xml/ns/public/common/common-tasks-3.xsd
@@ -2566,6 +2566,14 @@
                     </xsd:annotation>
                 </xsd:element>
 
+                <xsd:element name="refreshScimSchema" type="tns:ConnDevRefreshScimSchemaWorkDefinitionType">
+                    <xsd:annotation>
+                        <xsd:appinfo>
+                            <a:since>4.11</a:since>
+                        </xsd:appinfo>
+                    </xsd:annotation>
+                </xsd:element>
+
             </xsd:choice>
             <xsd:element name="extension" type="tns:ExtensionType" minOccurs="0">
                 <xsd:annotation>
@@ -11399,6 +11407,28 @@
             </xsd:element>
             <xsd:element name="artifact" type="tns:ConnDevArtifactType"/>
         </xsd:sequence>
+    </xsd:complexType>
+
+    <!-- Refresh SCIM Schema -->
+
+    <xsd:complexType name="ConnDevRefreshScimSchemaWorkDefinitionType">
+        <xsd:complexContent>
+            <xsd:extension base="tns:ConnDevBaseWorkDefinitionType"/>
+        </xsd:complexContent>
+    </xsd:complexType>
+
+    <xsd:complexType name="ConnDevRefreshScimSchemaWorkStateType">
+        <xsd:complexContent>
+            <xsd:extension base="tns:AbstractActivityWorkStateType">
+                <xsd:sequence>
+                    <xsd:element name="result" type="tns:ConnDevRefreshScimSchemaResultType"/>
+                </xsd:sequence>
+            </xsd:extension>
+        </xsd:complexContent>
+    </xsd:complexType>
+
+    <xsd:complexType name="ConnDevRefreshScimSchemaResultType">
+        <xsd:sequence/>
     </xsd:complexType>
 
 </xsd:schema>

--- a/model/smart-api/src/main/java/com/evolveum/midpoint/smart/api/conndev/ConnectorDevelopmentOperation.java
+++ b/model/smart-api/src/main/java/com/evolveum/midpoint/smart/api/conndev/ConnectorDevelopmentOperation.java
@@ -184,4 +184,6 @@ public interface ConnectorDevelopmentOperation {
     List<ConnDevHttpEndpointType> suggestedEndpointsFor(String objectClass, ConnectorDevelopmentArtifacts.KnownArtifactType knownArtifactType);
 
     void authenticationSelectionUpdated(Task task, OperationResult result) throws SchemaException, ExpressionEvaluationException, CommunicationException, SecurityViolationException, ConfigurationException, ObjectNotFoundException, PolicyViolationException, ObjectAlreadyExistsException;
+
+    String submitRefreshScimSchema(Task task, OperationResult result);
 }

--- a/model/smart-api/src/main/java/com/evolveum/midpoint/smart/api/conndev/ConnectorDevelopmentService.java
+++ b/model/smart-api/src/main/java/com/evolveum/midpoint/smart/api/conndev/ConnectorDevelopmentService.java
@@ -30,4 +30,6 @@ public interface ConnectorDevelopmentService {
 
     StatusInfo<ConnDevDiscoverObjectClassEndpointsResultType> getDiscoverObjectClassEndpointsStatus(String token, Task task, OperationResult result) throws SchemaException, ObjectNotFoundException;
 
+    StatusInfo<ConnDevRefreshScimSchemaResultType> getRefreshScimSchemaStatus(String token, Task task, OperationResult result) throws SchemaException, ObjectNotFoundException;
+
 }

--- a/model/smart-impl/src/main/java/com/evolveum/midpoint/smart/impl/conndev/ConnectorDevelopmentServiceImpl.java
+++ b/model/smart-impl/src/main/java/com/evolveum/midpoint/smart/impl/conndev/ConnectorDevelopmentServiceImpl.java
@@ -256,6 +256,14 @@ public class ConnectorDevelopmentServiceImpl implements ConnectorDevelopmentServ
                     .updateConfigurationOverride();
         }
 
+        @Override
+        public String submitRefreshScimSchema(Task task, OperationResult result) {
+            return submitTask("Refreshing SCIM schema for " + connectorNameForTasks(),
+                    new WorkDefinitionsType().refreshScimSchema(new ConnDevRefreshScimSchemaWorkDefinitionType()
+                            .connectorDevelopmentRef(stateObject.getOid(), ConnectorDevelopmentType.COMPLEX_TYPE)
+                    ), task, result);
+        }
+
         private String connectorNameForTasks() {
             return stateObject.getName().getOrig();
         }
@@ -362,6 +370,15 @@ public class ConnectorDevelopmentServiceImpl implements ConnectorDevelopmentServ
                 getTask(token, result),
                 ConnDevCreateConnectorWorkStateType.F_RESULT,
                 ConnDevDiscoverObjectClassEndpointsResultType.class
+        );
+    }
+
+    @Override
+    public StatusInfo<ConnDevRefreshScimSchemaResultType> getRefreshScimSchemaStatus(String token, Task task, OperationResult result) throws SchemaException, ObjectNotFoundException {
+        return new StatusInfoImpl<>(
+                getTask(token, result),
+                ConnDevRefreshScimSchemaWorkStateType.F_RESULT,
+                ConnDevRefreshScimSchemaResultType.class
         );
     }
 }

--- a/model/smart-impl/src/main/java/com/evolveum/midpoint/smart/impl/conndev/ScimBackend.java
+++ b/model/smart-impl/src/main/java/com/evolveum/midpoint/smart/impl/conndev/ScimBackend.java
@@ -33,19 +33,7 @@ public class ScimBackend extends RestBackend {
         super(beans, connDev, task, result);
     }
 
-    @Override
-    public List<ConnDevDocumentationSourceType> discoverDocumentation(boolean skipCache) {
-        return super.discoverDocumentation(skipCache);
-    }
-
-    @Override
-    public void ensureDocumentationIsProcessed() throws SchemaException, ExpressionEvaluationException, CommunicationException, SecurityViolationException, ConfigurationException, ObjectNotFoundException, PolicyViolationException, ObjectAlreadyExistsException {
-        super.ensureDocumentationIsProcessed();
-
-        refreshScimDocumentation();
-    }
-
-    private void refreshScimDocumentation() throws SchemaException, ExpressionEvaluationException, CommunicationException, SecurityViolationException, ConfigurationException, ObjectNotFoundException, PolicyViolationException, ObjectAlreadyExistsException {
+    public void refreshScimDocumentation() throws SchemaException, ExpressionEvaluationException, CommunicationException, SecurityViolationException, ConfigurationException, ObjectNotFoundException, PolicyViolationException, ObjectAlreadyExistsException {
         var testingResourceOid = getTestingResourceOid();
 
         if (!isScimDiscoveryConfigured(testingResourceOid)) {

--- a/model/smart-impl/src/main/java/com/evolveum/midpoint/smart/impl/conndev/activity/RefreshScimSchemaActivityHandler.java
+++ b/model/smart-impl/src/main/java/com/evolveum/midpoint/smart/impl/conndev/activity/RefreshScimSchemaActivityHandler.java
@@ -1,0 +1,62 @@
+package com.evolveum.midpoint.smart.impl.conndev.activity;
+
+import com.evolveum.midpoint.repo.common.activity.definition.WorkDefinitionFactory;
+import com.evolveum.midpoint.repo.common.activity.run.AbstractActivityRun;
+import com.evolveum.midpoint.repo.common.activity.run.ActivityRunInstantiationContext;
+import com.evolveum.midpoint.repo.common.activity.run.ActivityRunResult;
+import com.evolveum.midpoint.repo.common.activity.run.LocalActivityRun;
+import com.evolveum.midpoint.schema.result.OperationResult;
+import com.evolveum.midpoint.smart.impl.conndev.ScimBackend;
+import com.evolveum.midpoint.smart.impl.conndev.ConnectorDevelopmentBackend;
+import com.evolveum.midpoint.util.exception.CommonException;
+import com.evolveum.midpoint.util.exception.ConfigurationException;
+import com.evolveum.midpoint.xml.ns._public.common.common_3.*;
+
+import org.jetbrains.annotations.NotNull;
+import org.springframework.stereotype.Component;
+
+@Component
+public class RefreshScimSchemaActivityHandler
+        extends AbstractConnDevActivityHandler<RefreshScimSchemaActivityHandler.WorkDefinition, RefreshScimSchemaActivityHandler> {
+
+    public RefreshScimSchemaActivityHandler() {
+        super(
+                ConnDevRefreshScimSchemaWorkDefinitionType.COMPLEX_TYPE,
+                WorkDefinitionsType.F_REFRESH_SCIM_SCHEMA,
+                ConnDevRefreshScimSchemaWorkStateType.COMPLEX_TYPE,
+                RefreshScimSchemaActivityHandler.WorkDefinition.class,
+                RefreshScimSchemaActivityHandler.WorkDefinition::new);
+    }
+
+    @Override
+    public AbstractActivityRun<WorkDefinition, RefreshScimSchemaActivityHandler, ?> createActivityRun(
+            @NotNull ActivityRunInstantiationContext<WorkDefinition, RefreshScimSchemaActivityHandler> context,
+            @NotNull OperationResult result) {
+        return new MyActivityRun(context);
+    }
+
+    public static class WorkDefinition extends AbstractWorkDefinition<ConnDevRefreshScimSchemaWorkDefinitionType> {
+        public WorkDefinition(WorkDefinitionFactory.@NotNull WorkDefinitionInfo info) throws ConfigurationException {
+            super(info);
+        }
+    }
+
+    public static class MyActivityRun
+            extends LocalActivityRun<WorkDefinition, RefreshScimSchemaActivityHandler, FocusTypeSuggestionWorkStateType> {
+
+        MyActivityRun(ActivityRunInstantiationContext<WorkDefinition, RefreshScimSchemaActivityHandler> context) {
+            super(context);
+            setInstanceReady();
+        }
+
+        @Override
+        protected @NotNull ActivityRunResult runLocally(OperationResult result) throws CommonException {
+            var task = getRunningTask();
+            var backend = ConnectorDevelopmentBackend.backendFor(getWorkDefinition().connectorDevelopmentOid, task, result);
+            if (backend instanceof ScimBackend scimBackend) {
+                scimBackend.refreshScimDocumentation();
+            }
+            return ActivityRunResult.success();
+        }
+    }
+}


### PR DESCRIPTION
- Added WaitingScimSchemaConnectorStepPanel wizard step that triggers SCIM schema discovery from shadows
- Added RefreshScimSchemaActivityHandler activity with ScimBackend.refreshScimDocumentation() implementation
- Registered refreshScimSchema work definition in XSD schema and WorkDefinitionUtil
- Extended ConnectorDevelopmentOperation/Service API with submitRefreshScimSchema and getRefreshScimSchemaStatus
- Fixed CredentialsConnectorStepPanel: wrong path F_APPLICATION -> F_CONNECTOR for integration type lookup