### PR TITLE
MID-10504 Fix enum values in role analysis attribute queries

### DIFF
--- a/infra/common/src/main/java/com/evolveum/midpoint/common/mining/objects/analysis/RoleAnalysisAttributeDef.java
+++ b/infra/common/src/main/java/com/evolveum/midpoint/common/mining/objects/analysis/RoleAnalysisAttributeDef.java
@@ -16,6 +16,7 @@ import com.evolveum.midpoint.xml.ns._public.common.common_3.AssignmentHolderType
 import org.jetbrains.annotations.NotNull;
 
 import com.evolveum.midpoint.prism.*;
+import com.evolveum.midpoint.prism.binding.TypeSafeEnum;
 import com.evolveum.midpoint.prism.impl.PrismPropertyValueImpl;
 import com.evolveum.midpoint.prism.path.ItemPath;
 import com.evolveum.midpoint.prism.polystring.PolyString;
@@ -102,6 +103,8 @@ public class RoleAnalysisAttributeDef implements Serializable {
                 return ((PolyString) object).getOrig();
             } else if (object instanceof ObjectReferenceType) {
                 return ((ObjectReferenceType) object).getOid();
+            } else if (object instanceof TypeSafeEnum) {
+                return ((TypeSafeEnum) object).value();
             } else if (object instanceof PrismPropertyValueImpl) {
                 Object realValue = ((PrismPropertyValueImpl<?>) object).getRealValue();
                 if (realValue != null) {

--- a/infra/common/src/test/java/com/evolveum/midpoint/common/test/RoleAnalysisAttributeDefTest.java
+++ b/infra/common/src/test/java/com/evolveum/midpoint/common/test/RoleAnalysisAttributeDefTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2026 Evolveum and contributors
+ *
+ * Licensed under the EUPL-1.2 or later.
+ */
+
+package com.evolveum.midpoint.common.test;
+
+import static org.testng.AssertJUnit.assertEquals;
+
+import java.io.IOException;
+import java.util.Objects;
+
+import org.testng.annotations.BeforeSuite;
+import org.testng.annotations.Test;
+import org.xml.sax.SAXException;
+
+import com.evolveum.midpoint.common.mining.objects.analysis.RoleAnalysisAttributeDef;
+import com.evolveum.midpoint.prism.ItemDefinition;
+import com.evolveum.midpoint.prism.PrismContext;
+import com.evolveum.midpoint.prism.PrismObjectDefinition;
+import com.evolveum.midpoint.prism.path.ItemPath;
+import com.evolveum.midpoint.prism.query.EqualFilter;
+import com.evolveum.midpoint.prism.util.PrismTestUtil;
+import com.evolveum.midpoint.schema.MidPointPrismContextFactory;
+import com.evolveum.midpoint.tools.testng.AbstractUnitTest;
+import com.evolveum.midpoint.util.exception.SchemaException;
+import com.evolveum.midpoint.xml.ns._public.common.common_3.ActivationStatusType;
+import com.evolveum.midpoint.xml.ns._public.common.common_3.ActivationType;
+import com.evolveum.midpoint.xml.ns._public.common.common_3.FocusType;
+import com.evolveum.midpoint.xml.ns._public.common.common_3.UserType;
+
+/**
+ * Tests role-analysis attribute value handling for typed schema values.
+ */
+public class RoleAnalysisAttributeDefTest extends AbstractUnitTest {
+
+    @BeforeSuite
+    public void setup() throws SchemaException, SAXException, IOException {
+        PrismTestUtil.resetPrismContext(MidPointPrismContextFactory.FACTORY);
+    }
+
+    /** Verifies that enum attribute values can be extracted as strings and rebuilt into typed queries. */
+    @Test
+    public void enumAttributeExtractedValueBuildsTypedQuery() {
+        RoleAnalysisAttributeDef attributeDef = createEffectiveStatusAttributeDef();
+        UserType user = new UserType()
+                .activation(new ActivationType()
+                        .effectiveStatus(ActivationStatusType.ENABLED));
+
+        String resolvedValue = attributeDef.resolveSingleValueItem(
+                user.asPrismObject(),
+                attributeDef.getPath());
+
+        assertEquals("enabled", resolvedValue);
+
+        EqualFilter<?> filter = (EqualFilter<?>) attributeDef.getQuery(resolvedValue).getFilter();
+        assertEquals(ActivationStatusType.ENABLED, Objects.requireNonNull(filter.getSingleValue()).getRealValue());
+    }
+
+    private RoleAnalysisAttributeDef createEffectiveStatusAttributeDef() {
+        PrismObjectDefinition<UserType> userDefinition = PrismContext.get().getSchemaRegistry()
+                .findObjectDefinitionByCompileTimeClass(UserType.class);
+        ItemPath itemPath = ItemPath.create(FocusType.F_ACTIVATION, ActivationType.F_EFFECTIVE_STATUS);
+        ItemDefinition<?> definition = userDefinition.findItemDefinition(itemPath);
+        return new RoleAnalysisAttributeDef(itemPath, definition, UserType.class);
+    }
+}

--- a/infra/common/testng-unit.xml
+++ b/infra/common/testng-unit.xml
@@ -15,6 +15,7 @@
     <test name="Utils" preserve-order="false">
         <classes>
             <class name="com.evolveum.midpoint.common.test.UtilsTest" />
+            <class name="com.evolveum.midpoint.common.test.RoleAnalysisAttributeDefTest" />
             <class name="com.evolveum.midpoint.common.TestActivationComputerDefault" />
             <class name="com.evolveum.midpoint.common.TestActivationComputerLifecycle" />
             <class name="com.evolveum.midpoint.common.TestStaticValues" />

--- a/release-notes.adoc
+++ b/release-notes.adoc
@@ -118,6 +118,7 @@ Overall, midPoint 4.10 opens up the world of identity management and governance 
 * Fixed Privileged access initial object. See bug:MID-11004[]
 * Fixed assignment name for policy rule. See bug:MID-11005[]
 * Fixed object list view columns while report creation. See bug:MID-10967[]
+* Fixed role analysis attribute queries for enum-based attributes such as effective status. See bug:MID-10504[]
 
 === Releases Of Other Components
 


### PR DESCRIPTION
## Summary

Fixes role analysis attribute query construction for enum-based attributes.

Role analysis stores extracted attribute values as strings and later rebuilds repository queries from them. For enum attributes such as `effectiveStatus`, the extracted value used the Java enum name instead of the schema lexical value, which caused the rebuilt query to use an incompatible value type and fail in SQL.

This change extracts `TypeSafeEnum` values using their schema value, so the query can be rebuilt with the correct typed enum value.

## Testing

Added `RoleAnalysisAttributeDefTest` covering enum attribute value extraction and typed query reconstruction for `effectiveStatus`.