### PR TITLE
Smart Integration: resource test step, fix-connection recovery and connection wizard improvements

### DIFF
--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/component/wizard/ConnectorDevelopmentWizardUtil.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/component/wizard/ConnectorDevelopmentWizardUtil.java
@@ -26,6 +26,7 @@ import com.evolveum.midpoint.schema.TaskExecutionMode;
 import com.evolveum.midpoint.schema.constants.SchemaConstants;
 import com.evolveum.midpoint.schema.result.OperationResult;
 import com.evolveum.midpoint.smart.api.conndev.ConnectorDevelopmentArtifacts;
+import com.evolveum.midpoint.smart.api.conndev.SupportedAuthorization;
 import com.evolveum.midpoint.task.api.Task;
 import com.evolveum.midpoint.util.exception.CommonException;
 import com.evolveum.midpoint.util.exception.SchemaException;
@@ -587,5 +588,37 @@ public class ConnectorDevelopmentWizardUtil {
             }
         }
         result.addContext("logs", logs.toString());
+    }
+
+    public static boolean isScim(ConnectorDevelopmentDetailsModel detailsModel) {
+        try {
+            PrismPropertyWrapper<ConnDevIntegrationType> integrationType = detailsModel.getObjectWrapper().findProperty(
+                    ItemPath.create(ConnectorDevelopmentType.F_CONNECTOR, ConnDevConnectorType.F_INTEGRATION_TYPE));
+            return ConnDevIntegrationType.SCIM.equals(integrationType.getValue().getRealValue());
+        } catch (SchemaException e) {
+            return false;
+        }
+    }
+
+    public static List<ItemName> getVisibleAuthorizationAttributes(
+            ConnectorDevelopmentDetailsModel detailsModel, ConnDevAuthInfoType authType) {
+        try {
+            PrismPropertyWrapper<ConnDevIntegrationType> integration = detailsModel.getObjectWrapper().findProperty(
+                    ItemPath.create(ConnectorDevelopmentType.F_CONNECTOR, ConnDevConnectorType.F_INTEGRATION_TYPE));
+            return new ArrayList<>(SupportedAuthorization.attributesFor(integration.getValue().getRealValue(), authType.getType()));
+        } catch (SchemaException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static <T> void setTestingResourcePropertyValue(
+            ConnectorDevelopmentDetailsModel detailsModel, String panelType, ItemName propertyName, T value)
+            throws SchemaException {
+        ObjectDetailsModels<ResourceType> resourceModel = getTestingResourceModel(detailsModel, panelType);
+        ItemPath path = ItemPath.create("connectorConfiguration", SchemaConstants.ICF_CONFIGURATION_PROPERTIES_LOCAL_NAME, propertyName);
+        PrismPropertyWrapper<T> prop = resourceModel.getObjectWrapper().findProperty(path);
+        if (prop != null && !prop.getValues().isEmpty()) {
+            prop.getValue().setRealValue(value);
+        }
     }
 }

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/component/wizard/scimrest/connection/BaseUrlConnectorStepPanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/component/wizard/scimrest/connection/BaseUrlConnectorStepPanel.java
@@ -55,7 +55,7 @@ import com.evolveum.midpoint.xml.ns._public.common.common_3.*;
         containerPath = "empty")
 public class BaseUrlConnectorStepPanel extends AbstractFormWizardStepPanel<ConnectorDevelopmentDetailsModel> {
 
-    private static final String PANEL_TYPE = "cdw-base-url";
+    public static final String PANEL_TYPE = "cdw-base-url";
     public static final ItemName BASE_ADDRESS_ITEM_NAME = ItemName.from("", "baseAddress");
     public static final ItemName SCIM_BASE_URL_ITEM_NAME = ItemName.from("", "scimBaseUrl");
 

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/component/wizard/scimrest/connection/BaseUrlConnectorStepPanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/component/wizard/scimrest/connection/BaseUrlConnectorStepPanel.java
@@ -258,13 +258,7 @@ public class BaseUrlConnectorStepPanel extends AbstractFormWizardStepPanel<Conne
     }
 
     private boolean isScim() {
-        try {
-            PrismPropertyWrapper<ConnDevIntegrationType> integrationType = getDetailsModel().getObjectWrapper().findProperty(
-                    ItemPath.create(ConnectorDevelopmentType.F_CONNECTOR, ConnDevConnectorType.F_INTEGRATION_TYPE));
-            return ConnDevIntegrationType.SCIM.equals(integrationType.getValue().getRealValue());
-        } catch (SchemaException e) {
-            return false;
-        }
+        return ConnectorDevelopmentWizardUtil.isScim(getDetailsModel());
     }
 
     @Override

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/component/wizard/scimrest/connection/ConnectionConnectorStepPanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/component/wizard/scimrest/connection/ConnectionConnectorStepPanel.java
@@ -181,6 +181,8 @@ public class ConnectionConnectorStepPanel extends AbstractFormWizardStepPanel<Co
                 new CredentialsConnectorStepPanel(getHelper()),
                 new WaitingConnectivityEndpointConnectorStepPanel(getHelper()),
                 new EndpointConnectorStepPanel(getHelper()),
+                new FixConnectionConnectorStepPanel(getHelper()),
+                new ResourceTestConnectorStepPanel(getHelper()),
                 new WaitingScimSchemaConnectorStepPanel(getHelper()));
     }
 

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/component/wizard/scimrest/connection/CredentialsConnectorStepPanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/component/wizard/scimrest/connection/CredentialsConnectorStepPanel.java
@@ -39,7 +39,6 @@ import com.evolveum.midpoint.gui.impl.prism.panel.ItemPanelSettingsBuilder;
 import com.evolveum.midpoint.gui.impl.prism.panel.vertical.form.VerticalFormPanel;
 import com.evolveum.midpoint.gui.impl.prism.panel.vertical.form.VerticalFormPrismContainerPanel;
 import com.evolveum.midpoint.prism.Containerable;
-import com.evolveum.midpoint.prism.Referencable;
 import com.evolveum.midpoint.prism.path.ItemName;
 import com.evolveum.midpoint.prism.path.ItemPath;
 import com.evolveum.midpoint.schema.constants.SchemaConstants;
@@ -79,6 +78,7 @@ public class CredentialsConnectorStepPanel extends AbstractWizardStepPanel<Conne
     private static final String ID_FORM = "form";
 
     private LoadableModel<List<PrismContainerValueWrapper<ConnDevAuthInfoType>>> valuesModel;
+    private PrismContainerWrapper<?> containerWrapper;
 
     public CredentialsConnectorStepPanel(WizardPanelHelper<? extends Containerable, ConnectorDevelopmentDetailsModel> helper) {
         super(helper);
@@ -94,6 +94,16 @@ public class CredentialsConnectorStepPanel extends AbstractWizardStepPanel<Conne
     protected void onInitialize() {
         super.onInitialize();
         initLayout();
+    }
+
+    @Override
+    protected void onBeforeRender() {
+        PrismContainerWrapper<?> wrapper = getContainerFormModel().getObject();
+        if (containerWrapper != null && containerWrapper != wrapper) {
+            initLayout();
+        }
+        containerWrapper = wrapper;
+        super.onBeforeRender();
     }
 
     private void createValuesModel() {
@@ -154,15 +164,15 @@ public class CredentialsConnectorStepPanel extends AbstractWizardStepPanel<Conne
 
         Label noMethodsMessage = new Label(ID_NO_METHODS_MESSAGE, createStringResource("CredentialsConnectorStepPanel.noMethods"));
         noMethodsMessage.add(new VisibleBehaviour(() -> valuesModel.getObject().isEmpty()));
-        add(noMethodsMessage);
+        addOrReplace(noMethodsMessage);
 
         RadioGroup<String> radioGroup = new RadioGroup<>(ID_RADIO_GROUP, radioGroupModel);
         radioGroup.setOutputMarkupId(true);
-        add(radioGroup);
+        addOrReplace(radioGroup);
 
         WebMarkupContainer credentialsSection = new WebMarkupContainer(ID_CREDENTIALS_SECTION);
         credentialsSection.setOutputMarkupId(true);
-        add(credentialsSection);
+        addOrReplace(credentialsSection);
 
         ListView<PrismContainerValueWrapper<ConnDevAuthInfoType>> panel = createAuthMethodList(radioGroupModel, radioGroup, credentialsSection);
         radioGroup.add(panel);
@@ -190,7 +200,7 @@ public class CredentialsConnectorStepPanel extends AbstractWizardStepPanel<Conne
                     if (authType == null) {
                         return ItemVisibility.HIDDEN;
                     }
-                    return getVisibleItemsFor(authType).stream()
+                    return ConnectorDevelopmentWizardUtil.getVisibleAuthorizationAttributes(getDetailsModel(), authType).stream()
                             .anyMatch(vi -> StringUtils.equals(wrapper.getItemName().getLocalPart(), vi.getLocalPart()))
                             ? ItemVisibility.AUTO : ItemVisibility.HIDDEN;
                 })
@@ -276,24 +286,11 @@ public class CredentialsConnectorStepPanel extends AbstractWizardStepPanel<Conne
         return panel;
     }
 
-    private List<ItemName> getVisibleItemsFor(ConnDevAuthInfoType authType) {
-        try {
-            PrismPropertyWrapper<ConnDevIntegrationType> integration =
-                    getDetailsModel().getObjectWrapper().findProperty(
-                            ItemPath.create(ConnectorDevelopmentType.F_CONNECTOR, ConnDevConnectorType.F_INTEGRATION_TYPE));
-            return new ArrayList<>(SupportedAuthorization.attributesFor(integration.getValue().getRealValue(), authType.getType()));
-        } catch (SchemaException e) {
-            throw new RuntimeException(e);
-        }
-    }
 
     private IModel<? extends PrismContainerWrapper> getContainerFormModel() {
         try {
-            PrismReferenceWrapper<Referencable> resource = getDetailsModel().getObjectWrapper().findReference(
-                    ItemPath.create(ConnectorDevelopmentType.F_TESTING, ConnDevTestingType.F_TESTING_RESOURCE));
-
             ObjectDetailsModels<ResourceType> objectDetailsModel =
-                    resource.getValue().getNewObjectModel(getContainerConfiguration(PANEL_TYPE), getPageBase(), new OperationResult("getResourceModel"));
+                    ConnectorDevelopmentWizardUtil.getTestingResourceModel(getDetailsModel(), PANEL_TYPE);
 
             ItemPath path = ItemPath.create("connectorConfiguration", SchemaConstants.ICF_CONFIGURATION_PROPERTIES_LOCAL_NAME);
             return PrismContainerWrapperModel.fromContainerWrapper(objectDetailsModel.getObjectWrapperModel(), path);

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/component/wizard/scimrest/connection/CredentialsConnectorStepPanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/component/wizard/scimrest/connection/CredentialsConnectorStepPanel.java
@@ -54,6 +54,8 @@ import com.evolveum.midpoint.web.component.util.VisibleBehaviour;
 import com.evolveum.midpoint.web.model.PrismContainerWrapperModel;
 import com.evolveum.midpoint.xml.ns._public.common.common_3.*;
 
+import org.jspecify.annotations.NonNull;
+
 /**
  * @author lskublik
  */
@@ -162,6 +164,80 @@ public class CredentialsConnectorStepPanel extends AbstractWizardStepPanel<Conne
         credentialsSection.setOutputMarkupId(true);
         add(credentialsSection);
 
+        ListView<PrismContainerValueWrapper<ConnDevAuthInfoType>> panel = createAuthMethodList(radioGroupModel, radioGroup, credentialsSection);
+        radioGroup.add(panel);
+
+        radioGroup.add(new AjaxFormChoiceComponentUpdatingBehavior() {
+            @Override
+            protected void onUpdate(AjaxRequestTarget target) {
+                target.add(radioGroup);
+                target.add(credentialsSection);
+            }
+        });
+
+        Label noSelectionMessage = new Label(ID_NO_SELECTION_MESSAGE, () -> {
+            if (valuesModel.getObject().isEmpty()) {
+                return createStringResource("CredentialsConnectorStepPanel.noCredentialsNeeded").getObject();
+            }
+            return createStringResource("CredentialsConnectorStepPanel.selectMethod").getObject();
+        });
+        noSelectionMessage.add(new VisibleBehaviour(() -> selectedAuthModel.getObject() == null));
+        credentialsSection.add(noSelectionMessage);
+
+        ItemPanelSettings settings = new ItemPanelSettingsBuilder()
+                .visibilityHandler(wrapper -> {
+                    ConnDevAuthInfoType authType = selectedAuthModel.getObject();
+                    if (authType == null) {
+                        return ItemVisibility.HIDDEN;
+                    }
+                    return getVisibleItemsFor(authType).stream()
+                            .anyMatch(vi -> StringUtils.equals(wrapper.getItemName().getLocalPart(), vi.getLocalPart()))
+                            ? ItemVisibility.AUTO : ItemVisibility.HIDDEN;
+                })
+                .mandatoryHandler(wrapper -> false)
+                .build();
+
+        VerticalFormPanel formPanel = getVerticalFormPanel(settings);
+        formPanel.add(new VisibleBehaviour(() -> selectedAuthModel.getObject() != null));
+        formPanel.add(AttributeAppender.replace("class", "col-12 gen-list-group"));
+        credentialsSection.add(formPanel);
+    }
+
+    private @NonNull VerticalFormPanel getVerticalFormPanel(ItemPanelSettings settings) {
+        VerticalFormPanel formPanel = new VerticalFormPanel(ID_FORM, getContainerFormModel(), settings, getContainerConfiguration(getPanelType())) {
+
+            @Override
+            protected void onBeforeRender() {
+                super.onBeforeRender();
+                ((VerticalFormPrismContainerPanel) getSingleContainerPanel().getContainer().get("1"))
+                        .getContainer().add(AttributeAppender.remove("class"));
+            }
+
+            @Override
+            protected WrapperContext createWrapperContext() {
+                return getDetailsModel().createWrapperContext();
+            }
+
+            @Override
+            protected boolean isShowEmptyButtonVisible() {
+                return false;
+            }
+
+            @Override
+            protected boolean isHeaderVisible(IModel model) {
+                return false;
+            }
+
+            @Override
+            protected String getCssClassForFormContainerOfValuePanel() {
+                return "";
+            }
+        };
+        formPanel.setOutputMarkupId(true);
+        return formPanel;
+    }
+
+    private @NonNull ListView<PrismContainerValueWrapper<ConnDevAuthInfoType>> createAuthMethodList(IModel<String> radioGroupModel, RadioGroup<String> radioGroup, WebMarkupContainer credentialsSection) {
         ListView<PrismContainerValueWrapper<ConnDevAuthInfoType>> panel = new ListView<>(ID_PANEL, valuesModel) {
             @Override
             protected void populateItem(ListItem<PrismContainerValueWrapper<ConnDevAuthInfoType>> listItem) {
@@ -197,71 +273,7 @@ public class CredentialsConnectorStepPanel extends AbstractWizardStepPanel<Conne
             }
         };
         panel.setOutputMarkupId(true);
-        radioGroup.add(panel);
-
-        radioGroup.add(new AjaxFormChoiceComponentUpdatingBehavior() {
-            @Override
-            protected void onUpdate(AjaxRequestTarget target) {
-                target.add(radioGroup);
-                target.add(credentialsSection);
-            }
-        });
-
-        Label noSelectionMessage = new Label(ID_NO_SELECTION_MESSAGE, () -> {
-            if (valuesModel.getObject().isEmpty()) {
-                return createStringResource("CredentialsConnectorStepPanel.noCredentialsNeeded").getObject();
-            }
-            return createStringResource("CredentialsConnectorStepPanel.selectMethod").getObject();
-        });
-        noSelectionMessage.add(new VisibleBehaviour(() -> selectedAuthModel.getObject() == null));
-        credentialsSection.add(noSelectionMessage);
-
-        ItemPanelSettings settings = new ItemPanelSettingsBuilder()
-                .visibilityHandler(wrapper -> {
-                    ConnDevAuthInfoType authType = selectedAuthModel.getObject();
-                    if (authType == null) {
-                        return ItemVisibility.HIDDEN;
-                    }
-                    return getVisibleItemsFor(authType).stream()
-                            .anyMatch(vi -> StringUtils.equals(wrapper.getItemName().getLocalPart(), vi.getLocalPart()))
-                            ? ItemVisibility.AUTO : ItemVisibility.HIDDEN;
-                })
-                .mandatoryHandler(wrapper -> false)
-                .build();
-
-        VerticalFormPanel formPanel = new VerticalFormPanel(ID_FORM, getContainerFormModel(), settings, getContainerConfiguration(getPanelType())) {
-
-            @Override
-            protected void onBeforeRender() {
-                super.onBeforeRender();
-                ((VerticalFormPrismContainerPanel) getSingleContainerPanel().getContainer().get("1"))
-                        .getContainer().add(AttributeAppender.remove("class"));
-            }
-
-            @Override
-            protected WrapperContext createWrapperContext() {
-                return getDetailsModel().createWrapperContext();
-            }
-
-            @Override
-            protected boolean isShowEmptyButtonVisible() {
-                return false;
-            }
-
-            @Override
-            protected boolean isHeaderVisible(IModel model) {
-                return false;
-            }
-
-            @Override
-            protected String getCssClassForFormContainerOfValuePanel() {
-                return "";
-            }
-        };
-        formPanel.setOutputMarkupId(true);
-        formPanel.add(new VisibleBehaviour(() -> selectedAuthModel.getObject() != null));
-        formPanel.add(AttributeAppender.replace("class", "col-12 gen-list-group"));
-        credentialsSection.add(formPanel);
+        return panel;
     }
 
     private List<ItemName> getVisibleItemsFor(ConnDevAuthInfoType authType) {

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/component/wizard/scimrest/connection/EndpointConnectorStepPanel.html
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/component/wizard/scimrest/connection/EndpointConnectorStepPanel.html
@@ -19,24 +19,24 @@
                     <input wicket:id="radio" type="radio" onclick="event.stopPropagation()"/>
                 </div>
                 <div class="w-100 d-flex flex-row align-items-center">
-                    <div class="d-inline me-2" wicket:id="name"/>
-                    <span wicket:id="connectedBadge" class="badge bg-success">
+                    <div class="d-inline" wicket:id="name"/>
+                    <span wicket:id="connectedBadge" class="ml-2 badge bg-success">
                         <wicket:message key="EndpointConnectorStepPanel.connected"/>
                     </span>
                 </div>
             </div>
         </div>
-        <div class="d-flex flex-column gen-list-item" wicket:id="manualItem">
+        <div class="d-flex flex-column gen-list-item mt-2" wicket:id="manualItem">
             <div class="d-flex flex-row w-100 p-3">
                 <div class="h-100 m-auto pr-3">
                     <input wicket:id="manualRadio" type="radio" onclick="event.stopPropagation()"/>
                 </div>
                 <div class="w-100 d-flex flex-column">
                     <div class="d-flex flex-row align-items-center">
-                        <div class="d-inline me-2">
+                        <div class="d-inline">
                             <wicket:message key="EndpointConnectorStepPanel.manual"/>
                         </div>
-                        <span wicket:id="manualBadge" class="badge bg-success">
+                        <span wicket:id="manualBadge" class="ml-2 badge bg-success">
                             <wicket:message key="EndpointConnectorStepPanel.connected"/>
                         </span>
                     </div>

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/component/wizard/scimrest/connection/EndpointConnectorStepPanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/component/wizard/scimrest/connection/EndpointConnectorStepPanel.java
@@ -27,24 +27,24 @@ import org.apache.wicket.markup.repeater.RepeatingView;
 import org.apache.wicket.model.IModel;
 import org.apache.wicket.model.Model;
 
+import com.evolveum.midpoint.gui.api.component.wizard.WizardListener;
 import com.evolveum.midpoint.gui.api.component.wizard.WizardModel;
+import com.evolveum.midpoint.gui.api.component.wizard.WizardStep;
 import com.evolveum.midpoint.gui.api.model.LoadableModel;
 import com.evolveum.midpoint.gui.api.prism.wrapper.PrismContainerWrapper;
 import com.evolveum.midpoint.gui.api.prism.wrapper.PrismPropertyWrapper;
 import com.evolveum.midpoint.gui.api.prism.wrapper.PrismReferenceWrapper;
 import com.evolveum.midpoint.gui.impl.component.wizard.AbstractWizardStepPanel;
 import com.evolveum.midpoint.gui.impl.component.wizard.WizardPanelHelper;
+import com.evolveum.midpoint.gui.impl.component.wizard.withnavigation.WizardModelWithParentSteps;
 import com.evolveum.midpoint.gui.impl.page.admin.ObjectDetailsModels;
 import com.evolveum.midpoint.gui.impl.page.admin.connector.development.ConnectorDevelopmentDetailsModel;
 import com.evolveum.midpoint.gui.impl.page.admin.connector.development.component.wizard.ConnectorDevelopmentWizardUtil;
-import com.evolveum.midpoint.gui.impl.prism.wrapper.PrismPropertyValueWrapper;
 import com.evolveum.midpoint.prism.Containerable;
-import com.evolveum.midpoint.prism.Referencable;
 import com.evolveum.midpoint.prism.path.ItemName;
 import com.evolveum.midpoint.prism.path.ItemPath;
 import com.evolveum.midpoint.schema.constants.SchemaConstants;
 import com.evolveum.midpoint.schema.result.OperationResult;
-import com.evolveum.midpoint.task.api.Task;
 import com.evolveum.midpoint.util.exception.SchemaException;
 import com.evolveum.midpoint.web.application.PanelDisplay;
 import com.evolveum.midpoint.web.application.PanelInstance;
@@ -53,6 +53,8 @@ import com.evolveum.midpoint.web.component.AjaxIconButton;
 import com.evolveum.midpoint.web.component.util.VisibleBehaviour;
 import com.evolveum.midpoint.web.component.util.VisibleEnableBehaviour;
 import com.evolveum.midpoint.xml.ns._public.common.common_3.*;
+
+import org.jspecify.annotations.NonNull;
 
 /**
  * @author lskublik
@@ -63,9 +65,9 @@ import com.evolveum.midpoint.xml.ns._public.common.common_3.*;
         applicableForOperation = OperationTypeType.WIZARD,
         display = @PanelDisplay(label = "PageConnectorDevelopment.wizard.step.endpointPath", icon = "fa fa-wrench"),
         containerPath = "empty")
-public class EndpointConnectorStepPanel extends AbstractWizardStepPanel<ConnectorDevelopmentDetailsModel> {
+public class EndpointConnectorStepPanel extends AbstractWizardStepPanel<ConnectorDevelopmentDetailsModel> implements WizardListener {
 
-    private static final String PANEL_TYPE = "cdw-endpoint-path";
+    public static final String PANEL_TYPE = "cdw-endpoint-path";
 
     public static final ItemName PROPERTY_ITEM_NAME = ItemName.from("", "restTestEndpoint");
 
@@ -95,6 +97,7 @@ public class EndpointConnectorStepPanel extends AbstractWizardStepPanel<Connecto
     @Override
     public void init(WizardModel wizard) {
         super.init(wizard);
+        wizard.addWizardListener(this);
 
         endpointsModel = new LoadableModel<>() {
             @Override
@@ -135,9 +138,14 @@ public class EndpointConnectorStepPanel extends AbstractWizardStepPanel<Connecto
         manualUrlModel = Model.of("");
         connectedUrl = Model.of((String) null);
 
+        refreshUrlModels();
+    }
+
+    private void refreshUrlModels() {
         Object existingUrlObj = ConnectorDevelopmentWizardUtil.getTestingResourcePropertyValue(
                 getDetailsModel(), PANEL_TYPE, PROPERTY_ITEM_NAME);
         String existingUrl = existingUrlObj instanceof String s ? s : null;
+        connectedUrl.setObject(null);
         if (StringUtils.isNotEmpty(existingUrl)) {
             boolean matchesSuggested = endpointsModel.getObject().stream()
                     .anyMatch(e -> existingUrl.equals(e.getUri()));
@@ -147,10 +155,18 @@ public class EndpointConnectorStepPanel extends AbstractWizardStepPanel<Connecto
                 selectedModel.setObject(MANUAL_OPTION);
                 manualUrlModel.setObject(existingUrl);
             }
-            if (isCompleted()) {
+            if (ConnectorDevelopmentWizardUtil.isConnectionComplete(getDetailsModel(), PANEL_TYPE)) {
                 connectedUrl.setObject(existingUrl);
             }
         }
+    }
+
+    @Override
+    public void onStepChanged(WizardStep newStep) {
+        if (!EndpointConnectorStepPanel.this.equals(newStep)) {
+            return;
+        }
+        refreshUrlModels();
     }
 
     @Override
@@ -169,35 +185,7 @@ public class EndpointConnectorStepPanel extends AbstractWizardStepPanel<Connecto
         radioGroup.setOutputMarkupId(true);
         add(radioGroup);
 
-        ListView<ConnDevHttpEndpointType> panel = new ListView<>(ID_PANEL, endpointsModel) {
-            @Override
-            protected void populateItem(ListItem<ConnDevHttpEndpointType> item) {
-                ConnDevHttpEndpointType endpoint = item.getModelObject();
-
-                Radio<String> radio = new Radio<>(ID_RADIO, Model.of(endpoint.getUri()), radioGroup);
-                radio.setOutputMarkupId(true);
-                item.add(radio);
-
-                item.add(new Label(ID_NAME, StringUtils.defaultString(endpoint.getUri())));
-
-                WebMarkupContainer badge = new WebMarkupContainer(ID_CONNECTED_BADGE);
-                badge.setOutputMarkupPlaceholderTag(true);
-                badge.add(new VisibleBehaviour(() ->
-                        StringUtils.equals(endpoint.getUri(), connectedUrl.getObject())));
-                item.add(badge);
-
-                item.add(AttributeAppender.append("style", "cursor: pointer;"));
-                item.add(new AjaxEventBehavior("click") {
-                    @Override
-                    protected void onEvent(AjaxRequestTarget target) {
-                        selectedModel.setObject(endpoint.getUri());
-                        target.add(radioGroup);
-                        target.add(getButtonContainer());
-                    }
-                });
-            }
-        };
-        panel.setOutputMarkupId(true);
+        ListView<ConnDevHttpEndpointType> panel = createSuggestedEndpointList(radioGroup);
         radioGroup.add(panel);
 
         WebMarkupContainer manualItem = new WebMarkupContainer(ID_MANUAL_ITEM);
@@ -247,42 +235,52 @@ public class EndpointConnectorStepPanel extends AbstractWizardStepPanel<Connecto
         });
     }
 
+    private @NonNull ListView<ConnDevHttpEndpointType> createSuggestedEndpointList(RadioGroup<String> radioGroup) {
+        ListView<ConnDevHttpEndpointType> panel = new ListView<>(ID_PANEL, endpointsModel) {
+            @Override
+            protected void populateItem(ListItem<ConnDevHttpEndpointType> item) {
+                ConnDevHttpEndpointType endpoint = item.getModelObject();
+
+                Radio<String> radio = new Radio<>(ID_RADIO, Model.of(endpoint.getUri()), radioGroup);
+                radio.setOutputMarkupId(true);
+                item.add(radio);
+
+                item.add(new Label(ID_NAME, StringUtils.defaultString(endpoint.getUri())));
+
+                WebMarkupContainer badge = new WebMarkupContainer(ID_CONNECTED_BADGE);
+                badge.setOutputMarkupPlaceholderTag(true);
+                badge.add(new VisibleBehaviour(() ->
+                        StringUtils.equals(endpoint.getUri(), connectedUrl.getObject())));
+                item.add(badge);
+
+                item.add(AttributeAppender.append("style", "cursor: pointer;"));
+                item.add(new AjaxEventBehavior("click") {
+                    @Override
+                    protected void onEvent(AjaxRequestTarget target) {
+                        selectedModel.setObject(endpoint.getUri());
+                        target.add(radioGroup);
+                        target.add(getButtonContainer());
+                    }
+                });
+            }
+        };
+        panel.setOutputMarkupId(true);
+        return panel;
+    }
+
     private String getSelectedUrl() {
         return MANUAL_OPTION.equals(selectedModel.getObject())
                 ? manualUrlModel.getObject()
                 : selectedModel.getObject();
     }
 
-    private boolean isCurrentUrlConnected() {
-        String url = getSelectedUrl();
-        return StringUtils.isNotEmpty(url) && url.equals(connectedUrl.getObject());
-    }
-
-    @SuppressWarnings({"unchecked", "rawtypes"})
     private void setRestTestEndpoint(String url) throws SchemaException {
         ObjectDetailsModels<ResourceType> resourceModel = ConnectorDevelopmentWizardUtil.getTestingResourceModel(getDetailsModel(), PANEL_TYPE);
         ItemPath path = ItemPath.create("connectorConfiguration", SchemaConstants.ICF_CONFIGURATION_PROPERTIES_LOCAL_NAME, PROPERTY_ITEM_NAME);
-        PrismPropertyWrapper prop = resourceModel.getObjectWrapper().findProperty(path);
+        PrismPropertyWrapper<String> prop = resourceModel.getObjectWrapper().findProperty(path);
         if (prop != null && !prop.getValues().isEmpty()) {
-            ((PrismPropertyValueWrapper) prop.getValue()).setRealValue(url);
+            prop.getValue().setRealValue(url);
         }
-    }
-
-    private OperationResult runResourceTest() throws SchemaException {
-        PrismReferenceWrapper<Referencable> resource = getDetailsModel().getObjectWrapper().findReference(
-                ItemPath.create(ConnectorDevelopmentType.F_TESTING, ConnDevTestingType.F_TESTING_RESOURCE));
-        String resourceOid = resource.getValue().getRealValue().getOid();
-
-        Task task = getPageBase().createSimpleTask("testResource");
-        ConnectorDevelopmentWizardUtil.enableConnectorLogCapture(task);
-        OperationResult result = task.getResult();
-        try {
-            getPageBase().getModelService().testResource(resourceOid, task, result);
-        } catch (Throwable t) {
-            result.recordFatalError(t);
-        }
-        result.computeStatus();
-        return result;
     }
 
     private void testConnection(AjaxRequestTarget target) {
@@ -299,18 +297,8 @@ public class EndpointConnectorStepPanel extends AbstractWizardStepPanel<Connecto
 
         OperationResult saveResult = getHelper().onSaveObjectPerformed(target);
         if (saveResult != null && !saveResult.isError()) {
-            try {
-                OperationResult testResult = runResourceTest();
-                if (!testResult.isError()) {
-                    connectedUrl.setObject(url);
-                    target.add(get(ID_RADIO_GROUP));
-                } else {
-                    getPageBase().showResult(testResult);
-                }
-                target.add(getFeedback());
-            } catch (SchemaException e) {
-                throw new RuntimeException(e);
-            }
+            getDetailsModel().reloadPrismObjectByOid();
+            super.onNextPerformed(target);
         } else {
             target.add(getFeedback());
         }
@@ -319,23 +307,15 @@ public class EndpointConnectorStepPanel extends AbstractWizardStepPanel<Connecto
 
     @Override
     public boolean onNextPerformed(AjaxRequestTarget target) {
-        if (isCurrentUrlConnected()) {
-            super.onNextPerformed(target);
-            return false;
-        }
         testConnection(target);
         return false;
     }
 
     @Override
     protected void initCustomButtons(RepeatingView customButtons) {
-        IModel<String> iconModel = () -> isCurrentUrlConnected()
-                ? "fa fa-arrow-right"
-                : "fa fa-tower-broadcast";
+        IModel<String> iconModel = () -> "fa fa-tower-broadcast";
 
-        IModel<String> labelModel = () -> isCurrentUrlConnected()
-                ? getString("EndpointConnectorStepPanel.continue")
-                : getString("EndpointConnectorStepPanel.submit");
+        IModel<String> labelModel = () -> getString("EndpointConnectorStepPanel.submit");
 
         actionButton = new AjaxIconButton(customButtons.newChildId(), iconModel, labelModel) {
             @Override
@@ -346,11 +326,6 @@ public class EndpointConnectorStepPanel extends AbstractWizardStepPanel<Connecto
         actionButton.showTitleAsLabel(true);
         actionButton.setOutputMarkupId(true);
         actionButton.add(AttributeAppender.replace("class", "btn btn-primary"));
-        actionButton.add(AttributeAppender.append("onclick",
-                "if(!this.classList.contains('connected-btn')){"
-                + "this.innerHTML='<i class=\"fa fa-spinner fa-spin mr-1\"></i>"
-                + getString("EndpointConnectorStepPanel.connecting") + "';"
-                + "this.style.pointerEvents='none';}"));
         customButtons.add(actionButton);
     }
 
@@ -376,6 +351,10 @@ public class EndpointConnectorStepPanel extends AbstractWizardStepPanel<Connecto
 
     @Override
     public boolean isCompleted() {
+        if (getWizard() instanceof WizardModelWithParentSteps wizardModel
+                && wizardModel.isStepWithError(FixConnectionConnectorStepPanel.PANEL_TYPE)) {
+            return true;
+        }
         return ConnectorDevelopmentWizardUtil.isConnectionComplete(getDetailsModel(), PANEL_TYPE);
     }
 

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/component/wizard/scimrest/connection/FixConnectionConnectorStepPanel.html
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/component/wizard/scimrest/connection/FixConnectionConnectorStepPanel.html
@@ -1,0 +1,82 @@
+<!--
+  ~ Copyright (C) 2010-2025 Evolveum and contributors
+  ~
+  ~ This work is dual-licensed under the Apache License 2.0
+  ~ and European Union Public License. See LICENSE file for details.
+  -->
+
+<!DOCTYPE html>
+<html xmlns:wicket="http://wicket.apache.org">
+<wicket:extend>
+    <div wicket:id="feedbackContainer" class="col-12 feedbackContainer">
+        <div wicket:id="feedback" class="messagePanel"/>
+    </div>
+
+    <div class="col-12 card mb-3">
+        <div class="card-header">
+            <h6 class="mb-0 fw-semibold">
+                <wicket:message key="FixConnectionConnectorStepPanel.targetUrls"/>
+            </h6>
+        </div>
+        <div class="card-body">
+            <div class="mb-3">
+                <label class="form-label fw-semibold">
+                    <wicket:message key="FixConnectionConnectorStepPanel.baseUrl"/>
+                </label>
+                <input class="form-control" wicket:id="baseUrl" type="text"/>
+            </div>
+            <div>
+                <label class="form-label fw-semibold">
+                    <wicket:message key="FixConnectionConnectorStepPanel.testEndpoint"/>
+                </label>
+                <input class="form-control" wicket:id="endpoint" type="text"/>
+            </div>
+        </div>
+    </div>
+
+    <div class="col-12 card">
+        <div class="card-header">
+            <h6 class="mb-0 fw-semibold">
+                <wicket:message key="FixConnectionConnectorStepPanel.authentication"/>
+            </h6>
+        </div>
+        <div class="card-body">
+            <h6 class="mt-0 mb-3 fw-semibold">
+                <wicket:message key="FixConnectionConnectorStepPanel.method"/>
+            </h6>
+            <div wicket:id="noMethodsMessage" class="text-secondary fst-italic mb-3"/>
+            <div class="col-12 gen-list-group mb-3" wicket:id="radioGroup">
+                <div class="d-flex flex-column gen-list-item" wicket:id="authPanel">
+                    <div class="d-flex flex-row w-100 p-3">
+                        <div class="h-100 m-auto pr-3">
+                            <input wicket:id="radio" type="radio"/>
+                        </div>
+                        <div class="w-100 d-flex flex-column">
+                            <div class="d-inline" wicket:id="name"/>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <h6 class="mt-3 mb-3 fw-semibold">
+                <wicket:message key="FixConnectionConnectorStepPanel.credentials"/>
+            </h6>
+            <div class="col-12" wicket:id="credentialsSection">
+                <div wicket:id="noSelectionMessage" class="text-secondary fst-italic"/>
+                <div wicket:id="credentialsForm"/>
+            </div>
+        </div>
+    </div>
+
+    <div class="col-12 card mt-3" wicket:id="authScriptSection">
+        <div class="card-header">
+            <h6 class="mb-0 fw-semibold">
+                <wicket:message key="FixConnectionConnectorStepPanel.authScript"/>
+            </h6>
+        </div>
+        <div class="card-body">
+            <div wicket:id="authScriptPanel" class="d-flex flex-column w-100 border rounded"/>
+        </div>
+    </div>
+</wicket:extend>
+</html>

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/component/wizard/scimrest/connection/FixConnectionConnectorStepPanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/component/wizard/scimrest/connection/FixConnectionConnectorStepPanel.java
@@ -1,0 +1,518 @@
+/*
+ * Copyright (C) 2010-2025 Evolveum and contributors
+ *
+ * This work is dual-licensed under the Apache License 2.0
+ * and European Union Public License. See LICENSE file for details.
+ */
+package com.evolveum.midpoint.gui.impl.page.admin.connector.development.component.wizard.scimrest.connection;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Optional;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.wicket.ajax.AjaxRequestTarget;
+import org.apache.wicket.ajax.AjaxEventBehavior;
+import org.apache.wicket.ajax.attributes.AjaxRequestAttributes;
+import org.apache.wicket.ajax.form.AjaxFormChoiceComponentUpdatingBehavior;
+import org.apache.wicket.ajax.form.AjaxFormComponentUpdatingBehavior;
+import org.apache.wicket.behavior.AttributeAppender;
+import org.apache.wicket.markup.html.WebMarkupContainer;
+import org.apache.wicket.markup.html.basic.Label;
+import org.apache.wicket.markup.html.form.Radio;
+import org.apache.wicket.markup.html.form.RadioGroup;
+import org.apache.wicket.markup.html.form.TextField;
+import org.apache.wicket.markup.html.list.ListItem;
+import org.apache.wicket.markup.html.list.ListView;
+import org.apache.wicket.model.IModel;
+import org.apache.wicket.model.Model;
+
+import com.evolveum.midpoint.gui.api.component.wizard.WizardModel;
+import com.evolveum.midpoint.gui.api.factory.wrapper.WrapperContext;
+import com.evolveum.midpoint.gui.api.model.LoadableModel;
+import com.evolveum.midpoint.gui.api.util.WebPrismUtil;
+import com.evolveum.midpoint.gui.api.prism.wrapper.*;
+import com.evolveum.midpoint.gui.impl.component.wizard.AbstractWizardStepPanel;
+import com.evolveum.midpoint.gui.impl.component.wizard.WizardPanelHelper;
+import com.evolveum.midpoint.gui.impl.component.wizard.withnavigation.WizardModelWithParentSteps;
+import com.evolveum.midpoint.gui.impl.page.admin.ObjectDetailsModels;
+import com.evolveum.midpoint.gui.impl.page.admin.connector.development.ConnectorDevelopmentDetailsModel;
+import com.evolveum.midpoint.gui.impl.page.admin.connector.development.component.wizard.ConnectorDevelopmentWizardUtil;
+import com.evolveum.midpoint.gui.impl.prism.panel.ItemPanelSettings;
+import com.evolveum.midpoint.gui.impl.prism.panel.ItemPanelSettingsBuilder;
+import com.evolveum.midpoint.gui.impl.prism.panel.vertical.form.VerticalFormPanel;
+import com.evolveum.midpoint.gui.impl.prism.panel.vertical.form.VerticalFormPrismContainerPanel;
+import com.evolveum.midpoint.prism.Containerable;
+import com.evolveum.midpoint.prism.Referencable;
+import com.evolveum.midpoint.prism.path.ItemName;
+import com.evolveum.midpoint.prism.path.ItemPath;
+import com.evolveum.midpoint.schema.constants.SchemaConstants;
+import com.evolveum.midpoint.schema.result.OperationResult;
+import com.evolveum.midpoint.smart.api.conndev.ConnectorDevelopmentArtifacts;
+import com.evolveum.midpoint.task.api.Task;
+import com.evolveum.midpoint.util.exception.CommonException;
+import com.evolveum.midpoint.util.exception.SchemaException;
+import com.evolveum.midpoint.web.application.PanelDisplay;
+import com.evolveum.midpoint.web.application.PanelInstance;
+import com.evolveum.midpoint.web.application.PanelType;
+import com.evolveum.midpoint.web.component.AceEditor;
+import com.evolveum.midpoint.web.component.prism.ItemVisibility;
+import com.evolveum.midpoint.web.component.util.VisibleBehaviour;
+import com.evolveum.midpoint.web.component.util.VisibleEnableBehaviour;
+import com.evolveum.midpoint.web.model.PrismContainerWrapperModel;
+import com.evolveum.midpoint.web.page.admin.reports.component.SimpleAceEditorPanel;
+import com.evolveum.midpoint.xml.ns._public.common.common_3.*;
+
+@PanelType(name = "cdw-fix-connection")
+@PanelInstance(identifier = "cdw-fix-connection",
+        applicableForType = ConnectorDevelopmentType.class,
+        applicableForOperation = OperationTypeType.WIZARD,
+        display = @PanelDisplay(label = "PageConnectorDevelopment.wizard.step.fixConnection", icon = "fa fa-wrench"),
+        containerPath = "empty")
+public class FixConnectionConnectorStepPanel extends AbstractWizardStepPanel<ConnectorDevelopmentDetailsModel> {
+
+    public static final String PANEL_TYPE = "cdw-fix-connection";
+
+    private static final String CREDENTIALS_PANEL_TYPE = "cdw-testing-credentials";
+
+    private static final String ID_BASE_URL = "baseUrl";
+    private static final String ID_ENDPOINT = "endpoint";
+    private static final String ID_RADIO_GROUP = "radioGroup";
+    private static final String ID_AUTH_PANEL = "authPanel";
+    private static final String ID_RADIO = "radio";
+    private static final String ID_NAME = "name";
+    private static final String ID_CREDENTIALS_SECTION = "credentialsSection";
+    private static final String ID_CREDENTIALS_FORM = "credentialsForm";
+    private static final String ID_NO_METHODS_MESSAGE = "noMethodsMessage";
+    private static final String ID_NO_SELECTION_MESSAGE = "noSelectionMessage";
+    private static final String ID_AUTH_SCRIPT_SECTION = "authScriptSection";
+    private static final String ID_AUTH_SCRIPT_PANEL = "authScriptPanel";
+
+    private IModel<String> baseUrlModel;
+    private IModel<String> endpointModel;
+    private LoadableModel<List<PrismContainerValueWrapper<ConnDevAuthInfoType>>> authValuesModel;
+    private LoadableModel<ConnDevArtifactType> authScriptModel;
+
+    public FixConnectionConnectorStepPanel(WizardPanelHelper<? extends Containerable, ConnectorDevelopmentDetailsModel> helper) {
+        super(helper);
+    }
+
+    @Override
+    public void init(WizardModel wizard) {
+        super.init(wizard);
+        initModels();
+    }
+
+    private void initModels() {
+        baseUrlModel = new LoadableModel<>(false) {
+            @Override
+            protected String load() {
+                ItemName urlField = ConnectorDevelopmentWizardUtil.isScim(getDetailsModel())
+                        ? BaseUrlConnectorStepPanel.SCIM_BASE_URL_ITEM_NAME
+                        : BaseUrlConnectorStepPanel.BASE_ADDRESS_ITEM_NAME;
+                Object val = ConnectorDevelopmentWizardUtil.getTestingResourcePropertyValue(
+                        getDetailsModel(), BaseUrlConnectorStepPanel.PANEL_TYPE, urlField);
+                return val instanceof String s ? s : "";
+            }
+        };
+
+        endpointModel = new LoadableModel<>(false) {
+            @Override
+            protected String load() {
+                Object val = ConnectorDevelopmentWizardUtil.getTestingResourcePropertyValue(
+                        getDetailsModel(), EndpointConnectorStepPanel.PANEL_TYPE, EndpointConnectorStepPanel.PROPERTY_ITEM_NAME);
+                return val instanceof String s ? s : "";
+            }
+        };
+
+        authValuesModel = new LoadableModel<>() {
+            @Override
+            protected List<PrismContainerValueWrapper<ConnDevAuthInfoType>> load() {
+                try {
+                    PrismContainerWrapper<ConnDevAuthInfoType> container = getDetailsModel().getObjectWrapper().findContainer(
+                            ItemPath.create(ConnectorDevelopmentType.F_CONNECTOR, ConnDevConnectorType.F_AUTH));
+                    List<PrismContainerValueWrapper<ConnDevAuthInfoType>> values = container.getValues();
+                    if (values.size() == 1) {
+                        values.get(0).setSelected(true);
+                    }
+                    return values;
+                } catch (SchemaException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        };
+
+        authScriptModel = new LoadableModel<>(false) {
+            @Override
+            protected ConnDevArtifactType load() {
+                if (!ConnectorDevelopmentWizardUtil.existScript(getDetailsModel(),
+                        ConnectorDevelopmentArtifacts.KnownArtifactType.AUTHENTICATION_CUSTOMIZATION, null)) {
+                    return null;
+                }
+                try {
+                    PrismContainerValueWrapper<ConnDevArtifactType> wrapper = ConnectorDevelopmentWizardUtil.getScript(
+                            getDetailsModel(), ConnectorDevelopmentArtifacts.KnownArtifactType.AUTHENTICATION_CUSTOMIZATION, null);
+                    if (wrapper == null) {
+                        return null;
+                    }
+                    ConnDevArtifactType artifact = wrapper.getRealValue().clone();
+                    Task task = getPageBase().createSimpleTask("loadAuthScript");
+                    String content = getDetailsModel().getConnectorDevelopmentOperation()
+                            .getArtifactContent(artifact, task, task.getResult());
+                    artifact.setContent(content);
+                    return artifact;
+                } catch (IOException e) {
+                    return null;
+                }
+            }
+        };
+    }
+
+    @Override
+    protected void onInitialize() {
+        super.onInitialize();
+        initLayout();
+    }
+
+    private void initLayout() {
+        getTextLabel().add(AttributeAppender.replace("class", "mb-2 col-12 gen-step-title"));
+        getSubtextLabel().add(AttributeAppender.replace("class", "border-bottom pb-4 d-inline-block w-100"));
+        getButtonContainer().add(AttributeAppender.replace("class", "d-flex align-items-center flex-nowrap flex-row mt-4 gap-2 wizard-actions-strip col-12"));
+        getFeedback().add(AttributeAppender.replace("class", "col-12 feedbackContainer"));
+
+        TextField<String> baseUrlField = new TextField<>(ID_BASE_URL, baseUrlModel);
+        baseUrlField.setOutputMarkupId(true);
+        baseUrlField.add(new AjaxFormComponentUpdatingBehavior("change") {
+            @Override
+            protected void onUpdate(AjaxRequestTarget target) {
+            }
+        });
+        add(baseUrlField);
+
+        TextField<String> endpointField = new TextField<>(ID_ENDPOINT, endpointModel);
+        endpointField.setOutputMarkupId(true);
+        endpointField.add(new AjaxFormComponentUpdatingBehavior("change") {
+            @Override
+            protected void onUpdate(AjaxRequestTarget target) {
+            }
+        });
+        add(endpointField);
+
+        IModel<String> radioGroupModel = createRadioGroupModel();
+        IModel<ConnDevAuthInfoType> selectedAuthModel = () -> {
+            String name = radioGroupModel.getObject();
+            if (name == null) {
+                return null;
+            }
+            return authValuesModel.getObject().stream()
+                    .filter(v -> StringUtils.equals(v.getRealValue().getName(), name))
+                    .map(PrismContainerValueWrapper::getRealValue)
+                    .findFirst().orElse(null);
+        };
+
+        Label noMethodsMessage = new Label(ID_NO_METHODS_MESSAGE, createStringResource("CredentialsConnectorStepPanel.noMethods"));
+        noMethodsMessage.add(new VisibleBehaviour(() -> authValuesModel.getObject().isEmpty()));
+        add(noMethodsMessage);
+
+        RadioGroup<String> radioGroup = new RadioGroup<>(ID_RADIO_GROUP, radioGroupModel);
+        radioGroup.setOutputMarkupId(true);
+        add(radioGroup);
+
+        WebMarkupContainer credentialsSection = new WebMarkupContainer(ID_CREDENTIALS_SECTION);
+        credentialsSection.setOutputMarkupId(true);
+        add(credentialsSection);
+
+        ListView<PrismContainerValueWrapper<ConnDevAuthInfoType>> authPanel = new ListView<>(ID_AUTH_PANEL, authValuesModel) {
+            @Override
+            protected void populateItem(ListItem<PrismContainerValueWrapper<ConnDevAuthInfoType>> listItem) {
+                listItem.setOutputMarkupId(true);
+                listItem.add(AttributeAppender.append("style", "cursor: pointer;"));
+                listItem.add(new AjaxEventBehavior("click") {
+                    @Override
+                    protected void onEvent(AjaxRequestTarget target) {
+                        radioGroupModel.setObject(listItem.getModelObject().getRealValue().getName());
+                        target.add(radioGroup);
+                        target.add(credentialsSection);
+                    }
+                });
+
+                Radio<String> radio = new Radio<>(ID_RADIO, Model.of(listItem.getModelObject().getRealValue().getName()), radioGroup);
+                radio.setOutputMarkupId(true);
+                radio.add(new AjaxEventBehavior("click") {
+                    @Override
+                    protected void onEvent(AjaxRequestTarget target) {
+                    }
+
+                    @Override
+                    protected void updateAjaxAttributes(AjaxRequestAttributes attributes) {
+                        super.updateAjaxAttributes(attributes);
+                        attributes.setEventPropagation(AjaxRequestAttributes.EventPropagation.STOP);
+                    }
+                });
+                listItem.add(radio);
+
+                Label name = new Label(ID_NAME, () -> listItem.getModelObject().getRealValue().getName());
+                name.setOutputMarkupId(true);
+                listItem.add(name);
+            }
+        };
+        authPanel.setOutputMarkupId(true);
+        radioGroup.add(authPanel);
+
+        radioGroup.add(new AjaxFormChoiceComponentUpdatingBehavior() {
+            @Override
+            protected void onUpdate(AjaxRequestTarget target) {
+                target.add(radioGroup);
+                target.add(credentialsSection);
+            }
+        });
+
+        Label noSelectionMessage = new Label(ID_NO_SELECTION_MESSAGE, () -> {
+            if (authValuesModel.getObject().isEmpty()) {
+                return createStringResource("CredentialsConnectorStepPanel.noCredentialsNeeded").getObject();
+            }
+            return createStringResource("CredentialsConnectorStepPanel.selectMethod").getObject();
+        });
+        noSelectionMessage.add(new VisibleBehaviour(() -> selectedAuthModel.getObject() == null));
+        credentialsSection.add(noSelectionMessage);
+
+        ItemPanelSettings settings = new ItemPanelSettingsBuilder()
+                .visibilityHandler(wrapper -> {
+                    ConnDevAuthInfoType authType = selectedAuthModel.getObject();
+                    if (authType == null) {
+                        return ItemVisibility.HIDDEN;
+                    }
+                    return ConnectorDevelopmentWizardUtil.getVisibleAuthorizationAttributes(getDetailsModel(), authType).stream()
+                            .anyMatch(vi -> StringUtils.equals(wrapper.getItemName().getLocalPart(), vi.getLocalPart()))
+                            ? ItemVisibility.AUTO : ItemVisibility.HIDDEN;
+                })
+                .mandatoryHandler(wrapper -> false)
+                .build();
+
+        VerticalFormPanel credentialsForm = new VerticalFormPanel(ID_CREDENTIALS_FORM, getCredentialsFormModel(), settings, getContainerConfiguration(CREDENTIALS_PANEL_TYPE)) {
+            @Override
+            protected void onBeforeRender() {
+                super.onBeforeRender();
+                ((VerticalFormPrismContainerPanel) getSingleContainerPanel().getContainer().get("1"))
+                        .getContainer().add(AttributeAppender.remove("class"));
+            }
+
+            @Override
+            protected WrapperContext createWrapperContext() {
+                return getDetailsModel().createWrapperContext();
+            }
+
+            @Override
+            protected boolean isShowEmptyButtonVisible() {
+                return false;
+            }
+
+            @Override
+            protected boolean isHeaderVisible(IModel model) {
+                return false;
+            }
+
+            @Override
+            protected String getCssClassForFormContainerOfValuePanel() {
+                return "";
+            }
+        };
+        credentialsForm.setOutputMarkupId(true);
+        credentialsForm.add(new VisibleBehaviour(() -> selectedAuthModel.getObject() != null));
+        credentialsForm.add(AttributeAppender.replace("class", "col-12 gen-list-group"));
+        credentialsSection.add(credentialsForm);
+
+        getSubmit().add(AttributeAppender.replace("class", "btn btn-primary"));
+
+        WebMarkupContainer authScriptSection = new WebMarkupContainer(ID_AUTH_SCRIPT_SECTION);
+        authScriptSection.setOutputMarkupId(true);
+        add(authScriptSection);
+
+        IModel<String> editorModel = new IModel<>() {
+            @Override
+            public String getObject() {
+                ConnDevArtifactType artifact = authScriptModel.getObject();
+                return artifact != null ? artifact.getContent() : "";
+            }
+
+            @Override
+            public void setObject(String content) {
+                ConnDevArtifactType artifact = authScriptModel.getObject();
+                if (artifact == null) {
+                    artifact = ConnectorDevelopmentArtifacts.authenticationScript();
+                    authScriptModel.setObject(artifact);
+                }
+                artifact.setContent(content);
+            }
+        };
+
+        SimpleAceEditorPanel authScriptPanel = new SimpleAceEditorPanel(ID_AUTH_SCRIPT_PANEL, editorModel, 400) {
+            @Override
+            protected AceEditor createEditor(String id, IModel<String> model, int minSize) {
+                AceEditor editor = new AceEditor(id, model);
+                editor.setReadonly(false);
+                editor.setMinHeight(minSize);
+                editor.setHeight(400);
+                editor.setResizeToMaxHeight(false);
+                editor.setMode(AceEditor.Mode.GROOVY);
+                add(editor);
+                return editor;
+            }
+        };
+        ((AceEditor) authScriptPanel.getBaseFormComponent()).setConvertEmptyInputStringToNull(false);
+        authScriptPanel.add(AttributeAppender.append("class", "d-flex flex-column w-100 border rounded"));
+        authScriptSection.add(authScriptPanel);
+    }
+
+    private IModel<String> createRadioGroupModel() {
+        return new IModel<>() {
+            @Override
+            public String getObject() {
+                Optional<PrismContainerValueWrapper<ConnDevAuthInfoType>> selected = authValuesModel.getObject().stream()
+                        .filter(PrismContainerValueWrapper::isSelected)
+                        .findFirst();
+                return selected.map(v -> v.getRealValue().getName()).orElse(null);
+            }
+
+            @Override
+            public void setObject(String object) {
+                authValuesModel.getObject().forEach(value -> value.setSelected(false));
+                authValuesModel.getObject().stream()
+                        .filter(value -> StringUtils.equals(value.getRealValue().getName(), object))
+                        .findFirst()
+                        .ifPresent(value -> value.setSelected(true));
+            }
+        };
+    }
+
+    private IModel<? extends PrismContainerWrapper> getCredentialsFormModel() {
+        try {
+            PrismReferenceWrapper<Referencable> resource = getDetailsModel().getObjectWrapper().findReference(
+                    ItemPath.create(ConnectorDevelopmentType.F_TESTING, ConnDevTestingType.F_TESTING_RESOURCE));
+            ObjectDetailsModels<ResourceType> objectDetailsModel =
+                    resource.getValue().getNewObjectModel(getContainerConfiguration(CREDENTIALS_PANEL_TYPE), getPageBase(), new OperationResult("getResourceModel"));
+            ItemPath path = ItemPath.create("connectorConfiguration", SchemaConstants.ICF_CONFIGURATION_PROPERTIES_LOCAL_NAME);
+            return PrismContainerWrapperModel.fromContainerWrapper(objectDetailsModel.getObjectWrapperModel(), path);
+        } catch (SchemaException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private boolean saveAuthScript(AjaxRequestTarget target) {
+        ConnDevArtifactType artifact = authScriptModel.getObject();
+        if (artifact == null || StringUtils.isBlank(artifact.getContent())) {
+            return true;
+        }
+        Task task = getPageBase().createSimpleTask("saveAuthScript");
+        try {
+            ConnDevArtifactType script = artifact.clone();
+            WebPrismUtil.cleanupEmptyContainerValue(script.asPrismContainerValue());
+            getDetailsModel().getConnectorDevelopmentOperation().saveAuthenticationScript(script, task, task.getResult());
+        } catch (IOException | CommonException e) {
+            throw new RuntimeException(e);
+        }
+        if (task.getResult() == null || task.getResult().isError()) {
+            target.add(getFeedback());
+            return false;
+        }
+        return true;
+    }
+
+    private void testConnection(AjaxRequestTarget target) {
+        String url = endpointModel.getObject();
+        String baseUrl = baseUrlModel.getObject();
+
+        try {
+            if (StringUtils.isNotEmpty(baseUrl)) {
+                ItemName urlField = ConnectorDevelopmentWizardUtil.isScim(getDetailsModel())
+                        ? BaseUrlConnectorStepPanel.SCIM_BASE_URL_ITEM_NAME
+                        : BaseUrlConnectorStepPanel.BASE_ADDRESS_ITEM_NAME;
+                ConnectorDevelopmentWizardUtil.setTestingResourcePropertyValue(getDetailsModel(), PANEL_TYPE, urlField, baseUrl);
+            }
+            if (StringUtils.isNotEmpty(url)) {
+                ConnectorDevelopmentWizardUtil.setTestingResourcePropertyValue(
+                        getDetailsModel(), PANEL_TYPE, EndpointConnectorStepPanel.PROPERTY_ITEM_NAME, url);
+            }
+        } catch (SchemaException e) {
+            throw new RuntimeException(e);
+        }
+
+        if (!saveAuthScript(target)) {
+            return;
+        }
+
+        OperationResult saveResult = getHelper().onSaveObjectPerformed(target);
+        if (saveResult != null && !saveResult.isError()) {
+            getDetailsModel().reloadPrismObjectByOid();
+            super.onNextPerformed(target);
+        } else {
+            target.add(getFeedback());
+        }
+        target.add(getButtonContainer());
+    }
+
+    @Override
+    protected void onSubmitPerformed(AjaxRequestTarget target) {
+        testConnection(target);
+    }
+
+    @Override
+    protected IModel<String> getSubmitLabelModel() {
+        return createStringResource("FixConnectionConnectorStepPanel.submit");
+    }
+
+    @Override
+    public IModel<Boolean> isStepVisible() {
+        return () -> {
+            if (getWizard() instanceof WizardModelWithParentSteps wizardModel) {
+                return wizardModel.isStepWithError(PANEL_TYPE);
+            }
+            return false;
+        };
+    }
+
+    @Override
+    public boolean isCompleted() {
+        return ConnectorDevelopmentWizardUtil.isConnectionComplete(getDetailsModel());
+    }
+
+    @Override
+    public String getStepId() {
+        return PANEL_TYPE;
+    }
+
+    @Override
+    public IModel<String> getTitle() {
+        return createStringResource("PageConnectorDevelopment.wizard.step.fixConnection");
+    }
+
+    @Override
+    protected IModel<?> getTextModel() {
+        return createStringResource("PageConnectorDevelopment.wizard.step.fixConnection.text");
+    }
+
+    @Override
+    protected IModel<?> getSubTextModel() {
+        return createStringResource("PageConnectorDevelopment.wizard.step.fixConnection.subText");
+    }
+
+    @Override
+    public String appendCssToWizard() {
+        return "col-12";
+    }
+
+    @Override
+    protected boolean isSubmitVisible() {
+        return true;
+    }
+
+    @Override
+    public VisibleEnableBehaviour getNextBehaviour() {
+        return VisibleEnableBehaviour.ALWAYS_INVISIBLE;
+    }
+
+    @Override
+    protected String getSubTextContainerCssClass() {
+        return "text-secondary col-12 pb-4";
+    }
+}

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/component/wizard/scimrest/connection/ResourceTestConnectorStepPanel.html
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/component/wizard/scimrest/connection/ResourceTestConnectorStepPanel.html
@@ -1,0 +1,16 @@
+<!--
+  ~ Copyright (C) 2010-2025 Evolveum and contributors
+  ~
+  ~ This work is dual-licensed under the Apache License 2.0
+  ~ and European Union Public License. See LICENSE file for details.
+  -->
+
+<!DOCTYPE html>
+<html xmlns:wicket="http://wicket.apache.org">
+<wicket:extend>
+    <div wicket:id="feedbackContainer" class="col-12 feedbackContainer">
+        <div wicket:id="feedback" class="messagePanel"/>
+    </div>
+    <div class="col-12 p-0 mt-1" wicket:id="panel"/>
+</wicket:extend>
+</html>

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/component/wizard/scimrest/connection/ResourceTestConnectorStepPanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/component/wizard/scimrest/connection/ResourceTestConnectorStepPanel.java
@@ -1,0 +1,192 @@
+/*
+ * Copyright (C) 2010-2025 Evolveum and contributors
+ *
+ * This work is dual-licensed under the Apache License 2.0
+ * and European Union Public License. See LICENSE file for details.
+ */
+package com.evolveum.midpoint.gui.impl.page.admin.connector.development.component.wizard.scimrest.connection;
+
+import com.evolveum.midpoint.task.api.Task;
+
+import org.apache.wicket.Component;
+import org.apache.wicket.ajax.AjaxRequestTarget;
+import org.apache.wicket.behavior.AttributeAppender;
+import org.apache.wicket.model.IModel;
+
+import com.evolveum.midpoint.gui.api.component.wizard.WizardListener;
+import com.evolveum.midpoint.gui.api.component.wizard.WizardModel;
+import com.evolveum.midpoint.gui.api.component.wizard.WizardStep;
+import com.evolveum.midpoint.gui.api.model.LoadableModel;
+import com.evolveum.midpoint.gui.api.prism.wrapper.PrismReferenceWrapper;
+import com.evolveum.midpoint.gui.impl.component.wizard.AbstractWizardStepPanel;
+import com.evolveum.midpoint.gui.impl.component.wizard.WizardPanelHelper;
+import com.evolveum.midpoint.gui.impl.component.wizard.withnavigation.WizardModelWithParentSteps;
+import com.evolveum.midpoint.gui.impl.page.admin.connector.development.ConnectorDevelopmentDetailsModel;
+import com.evolveum.midpoint.gui.impl.page.admin.connector.development.component.wizard.ConnectorDevelopmentWizardUtil;
+import com.evolveum.midpoint.prism.Containerable;
+import com.evolveum.midpoint.prism.Referencable;
+import com.evolveum.midpoint.prism.path.ItemPath;
+import com.evolveum.midpoint.util.exception.SchemaException;
+import com.evolveum.midpoint.web.application.PanelDisplay;
+import com.evolveum.midpoint.web.application.PanelInstance;
+import com.evolveum.midpoint.web.application.PanelType;
+import com.evolveum.midpoint.web.component.util.VisibleBehaviour;
+import com.evolveum.midpoint.web.component.util.VisibleEnableBehaviour;
+import com.evolveum.midpoint.xml.ns._public.common.common_3.ConnDevTestingType;
+import com.evolveum.midpoint.xml.ns._public.common.common_3.ConnectorDevelopmentType;
+import com.evolveum.midpoint.xml.ns._public.common.common_3.OperationTypeType;
+
+/**
+ * @author lskublik
+ */
+@PanelType(name = "cdw-resource-test")
+@PanelInstance(identifier = "cdw-resource-test",
+        applicableForType = ConnectorDevelopmentType.class,
+        applicableForOperation = OperationTypeType.WIZARD,
+        display = @PanelDisplay(label = "PageConnectorDevelopment.wizard.step.resourceTest", icon = "fa fa-wrench"),
+        containerPath = "empty")
+public class ResourceTestConnectorStepPanel extends AbstractWizardStepPanel<ConnectorDevelopmentDetailsModel> implements WizardListener {
+
+    public static final String PANEL_TYPE = "cdw-resource-test";
+
+    private static final String ID_PANEL = "panel";
+
+    private LoadableModel<String> resourceOidModel;
+    private boolean nextButtonVisible = false;
+
+    public ResourceTestConnectorStepPanel(WizardPanelHelper<? extends Containerable, ConnectorDevelopmentDetailsModel> helper) {
+        super(helper);
+    }
+
+    @Override
+    protected void onInitialize() {
+        super.onInitialize();
+        createValuesModel();
+        initLayout();
+    }
+
+    @Override
+    public void init(WizardModel wizard) {
+        super.init(wizard);
+        wizard.addWizardListener(this);
+    }
+
+    private void createValuesModel() {
+        resourceOidModel = new LoadableModel<>() {
+            @Override
+            protected String load() {
+                try {
+                    PrismReferenceWrapper<Referencable> resource = getDetailsModel().getObjectWrapper().findReference(
+                            ItemPath.create(ConnectorDevelopmentType.F_TESTING, ConnDevTestingType.F_TESTING_RESOURCE));
+                    return resource.getValue().getRealValue().getOid();
+                } catch (SchemaException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        };
+    }
+
+    private void initLayout() {
+        getTextLabel().add(VisibleEnableBehaviour.ALWAYS_INVISIBLE);
+        getSubtextLabel().add(VisibleEnableBehaviour.ALWAYS_INVISIBLE);
+        getButtonContainer().add(AttributeAppender.replace("class", "d-flex align-items-center flex-nowrap flex-row mt-4 gap-2 wizard-actions-strip col-12 col-md-8 col-lg-6 col-xl-4 col-xxl-3"));
+        getFeedback().add(AttributeAppender.replace("class", "col-12 feedbackContainer"));
+
+        getButtonContainer().add(AttributeAppender.append("class", isOnlyChildCentered() ? " only-child-centered" : ""));
+
+        ResourceTestPanel waitingPanel = new ResourceTestPanel(ID_PANEL, resourceOidModel) {
+            @Override
+            protected void onTestingStarted(AjaxRequestTarget target) {
+                nextButtonVisible = false;
+                target.add(getButtonContainer());
+            }
+
+            @Override
+            protected void onFinishActionPerform(AjaxRequestTarget target) {
+                nextButtonVisible = true;
+                target.add(getButtonContainer());
+            }
+
+            @Override
+            protected void onFailureActionPerform(AjaxRequestTarget target) {
+                if (getWizard() instanceof WizardModelWithParentSteps wizardModel) {
+                    wizardModel.addOperationResult(PANEL_TYPE, FixConnectionConnectorStepPanel.PANEL_TYPE, getLastFailedResult());
+                    wizardModel.setActiveStepById(FixConnectionConnectorStepPanel.PANEL_TYPE);
+                    wizardModel.fireActiveStepChanged(wizardModel.getActiveStep());
+                    target.add(wizardModel.getPanel());
+                }
+            }
+
+            @Override
+            protected void customizeTask(Task task) {
+                ConnectorDevelopmentWizardUtil.enableConnectorLogCapture(task);
+            }
+
+            @Override
+            public Component getFeedbackPanel() {
+                return getFeedback();
+            }
+        };
+        waitingPanel.setOutputMarkupId(true);
+        add(waitingPanel);
+    }
+
+    @Override
+    public IModel<String> getTitle() {
+        return createStringResource("PageConnectorDevelopment.wizard.step.resourceTest");
+    }
+
+    @Override
+    public String appendCssToWizard() {
+        return "col-12";
+    }
+
+    @Override
+    protected boolean isSubmitVisible() {
+        return false;
+    }
+
+    @Override
+    protected IModel<String> getNextLabelModel() {
+        return null;
+    }
+
+    @Override
+    public VisibleEnableBehaviour getNextBehaviour() {
+        return new VisibleBehaviour(this::getNextButtonVisible);
+    }
+
+    private Boolean getNextButtonVisible() {
+        return nextButtonVisible;
+    }
+
+    @Override
+    protected boolean isSubmitEnable() {
+        return false;
+    }
+
+    @Override
+    public String getStepId() {
+        return PANEL_TYPE;
+    }
+
+    @Override
+    public void onStepChanged(WizardStep newStep) {
+        if (!ResourceTestConnectorStepPanel.this.equals(newStep)) {
+            return;
+        }
+
+        nextButtonVisible = false;
+        ((ResourceTestPanel)get(ID_PANEL)).refresh();
+    }
+
+    @Override
+    public boolean isCompleted() {
+        return ConnectorDevelopmentWizardUtil.isConnectionComplete(getDetailsModel(), PANEL_TYPE);
+    }
+
+    @Override
+    protected boolean isOnlyChildCentered() {
+        return true;
+    }
+}

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/component/wizard/scimrest/connection/ResourceTestPanel.html
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/component/wizard/scimrest/connection/ResourceTestPanel.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<!--
+  ~ Copyright (c) 2025 Evolveum
+  ~
+  ~ This work is dual-licensed under the Apache License 2.0
+  ~ and European Union Public License. See LICENSE file for details.
+  -->
+<html xmlns:wicket="http://wicket.apache.org">
+<wicket:panel>
+    <div wicket:id="panelContainer" class="d-flex flex-column align-items-center gap-3 my-5">
+        <i class="text-center mb-2 font-weight-bold fa-2x" wicket:id="titleIcon"></i>
+        <div class="text-center mb-0 h3" wicket:id="text"></div>
+        <div class="text-center text-secondary mb-2 col-6 lh-2" wicket:id="subText"></div>
+        <div wicket:id="bodyContainer" class="d-flex flex-column align-items-center w-100 text-center">
+            <span class="text-muted" wicket:id="elapsedTime"></span>
+        </div>
+    </div>
+</wicket:panel>
+</html>

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/component/wizard/scimrest/connection/ResourceTestPanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/component/wizard/scimrest/connection/ResourceTestPanel.java
@@ -1,0 +1,213 @@
+/*
+ * Copyright (C) 2010-2025 Evolveum and contributors
+ *
+ * This work is dual-licensed under the Apache License 2.0
+ * and European Union Public License. See LICENSE file for details.
+ */
+package com.evolveum.midpoint.gui.impl.page.admin.connector.development.component.wizard.scimrest.connection;
+
+import java.time.Duration;
+import javax.xml.datatype.XMLGregorianCalendar;
+
+import org.apache.wicket.AttributeModifier;
+import org.apache.wicket.ajax.AbstractAjaxTimerBehavior;
+import org.apache.wicket.ajax.AjaxRequestTarget;
+import org.apache.wicket.markup.html.WebMarkupContainer;
+import org.apache.wicket.markup.html.basic.Label;
+import org.apache.wicket.model.IModel;
+import org.jetbrains.annotations.NotNull;
+
+import com.evolveum.midpoint.gui.api.component.BasePanel;
+import com.evolveum.midpoint.gui.impl.page.admin.resource.component.wizard.schemaHandling.objectType.smart.component.TimerProgressPanel;
+import com.evolveum.midpoint.prism.xml.XmlTypeConverter;
+import com.evolveum.midpoint.schema.result.OperationResult;
+import com.evolveum.midpoint.task.api.Task;
+import com.evolveum.midpoint.util.logging.Trace;
+import com.evolveum.midpoint.util.logging.TraceManager;
+import com.evolveum.midpoint.web.component.util.VisibleBehaviour;
+
+public class ResourceTestPanel extends BasePanel<String> {
+
+    private static final String ID_PANEL_CONTAINER = "panelContainer";
+    private static final String ID_TITLE_ICON = "titleIcon";
+    private static final String ID_TEXT = "text";
+    private static final String ID_SUBTEXT = "subText";
+
+    private static final String ID_BODY_CONTAINER = "bodyContainer";
+    private static final String ID_ELAPSED_TIME = "elapsedTime";
+
+    private static final Trace LOGGER = TraceManager.getTrace(ResourceTestPanel.class);
+
+    private final XMLGregorianCalendar startTimestamp = XmlTypeConverter.createXMLGregorianCalendar(System.currentTimeMillis());
+    private State state = State.RUNNING;
+    private AbstractAjaxTimerBehavior timerBehavior;
+    private OperationResult lastFailedResult;
+
+    private enum State {
+        RUNNING,
+        SUCCESS,
+        FAILED
+    }
+
+    public ResourceTestPanel(String id, IModel<String> resourceOidModel) {
+        super(id, resourceOidModel);
+    }
+
+    @Override
+    protected void onInitialize() {
+        super.onInitialize();
+        initLayout();
+    }
+
+    private void initLayout() {
+        setOutputMarkupId(true);
+
+        WebMarkupContainer panelContainer = new WebMarkupContainer(ID_PANEL_CONTAINER);
+        panelContainer.setOutputMarkupId(true);
+        add(panelContainer);
+
+        initIntroPart(panelContainer);
+
+        WebMarkupContainer bodyContainer = new WebMarkupContainer(ID_BODY_CONTAINER);
+        bodyContainer.setOutputMarkupId(true);
+        panelContainer.add(bodyContainer);
+
+        initCorePart(bodyContainer);
+
+        timerBehavior = createSuggestionAjaxTimerBehavior();
+        bodyContainer.add(timerBehavior);
+    }
+
+    private AbstractAjaxTimerBehavior createSuggestionAjaxTimerBehavior() {
+
+        return new AbstractAjaxTimerBehavior(getRefreshInterval()) {
+            @Override
+            protected void onTimer(AjaxRequestTarget target) {
+                onTestingStarted(target);
+
+                try {
+                    boolean failed;
+                    Task task = getPageBase().createSimpleTask("testResource");
+                    customizeTask(task);
+                    OperationResult result = task.getResult();
+                    try {
+                        getPageBase().getModelService().testResource(getModelObject(), task, result);
+                    } catch (Throwable t) {
+                        state = State.FAILED;
+                        stop(target);
+                        return;
+                    }
+
+                    result.computeStatus();
+                    failed = result.isError();
+
+                    if (!failed) {
+                        try {
+                            onFinishActionPerform(target);
+                            state = State.SUCCESS;
+                        } catch (Exception e) {
+                            LOGGER.error("Error during finishing resource test", e);
+                            state = State.FAILED;
+                        } finally {
+                            stop(target);
+                        }
+                    } else {
+                        lastFailedResult = result;
+                        getPageBase().showResult(result);
+                        target.add(getFeedbackPanel());
+                        state = State.FAILED;
+                        stop(target);
+                        onFailureActionPerform(target);
+                    }
+
+                } finally {
+                    target.add(get(ID_PANEL_CONTAINER));
+                }
+            }
+        };
+    }
+
+    protected void customizeTask(Task task) {
+        // NOOP: for overriding
+    }
+
+    private void initCorePart(@NotNull WebMarkupContainer bodyContainer) {
+        TimerProgressPanel elapsedTime = new TimerProgressPanel(ID_ELAPSED_TIME, () -> startTimestamp);
+        elapsedTime.setOutputMarkupId(true);
+        elapsedTime.add(new VisibleBehaviour(() -> state == State.RUNNING));
+        bodyContainer.add(elapsedTime);
+    }
+
+    private void initIntroPart(@NotNull WebMarkupContainer panelContainer) {
+        WebMarkupContainer titleIcon = new WebMarkupContainer(ID_TITLE_ICON);
+        titleIcon.setOutputMarkupId(true);
+        titleIcon.add(AttributeModifier.append("class", getIconCssModel()));
+        panelContainer.add(titleIcon);
+
+        Label title = new Label(ID_TEXT, getTitleModel());
+        title.setOutputMarkupId(true);
+        panelContainer.add(title);
+
+        Label subTitle = new Label(ID_SUBTEXT, getSubTitleModel());
+        subTitle.setOutputMarkupId(true);
+        panelContainer.add(subTitle);
+    }
+
+    /** Polling interval; override if you want a different cadence. */
+    protected Duration getRefreshInterval() {
+        return Duration.ofSeconds(1);
+    }
+
+    protected void onFinishActionPerform(AjaxRequestTarget target) {
+    }
+
+    protected void onFailureActionPerform(AjaxRequestTarget target) {
+    }
+
+    public OperationResult getLastFailedResult() {
+        return lastFailedResult;
+    }
+
+    protected IModel<String> getIconCssModel() {
+        return () -> {
+            switch (state){
+                case SUCCESS -> {
+                    return "fa fa-check-circle text-success";
+                }
+                case FAILED -> {
+                    return "fa fa-times-circle text-danger";
+                }
+                default -> {
+                    return "fa fa-tower-broadcast text-primary spinner-fade-fast";
+                }
+            }
+        };
+    }
+
+    protected IModel<String> getTitleModel() {
+        return createTextModel("PageConnectorDevelopment.wizard.step.resourceTest.text");
+    }
+
+    protected IModel<String> getSubTitleModel() {
+        return createTextModel("PageConnectorDevelopment.wizard.step.resourceTest.subText");
+    }
+
+    private @NotNull IModel<String> createTextModel(String keyPrefix) {
+        return () -> {
+            String key = keyPrefix;
+            switch (state){
+                case SUCCESS -> key += ".success";
+                case FAILED -> key += ".fails";
+            }
+            return createStringResource(key).getString();
+        };
+    }
+
+    public void refresh() {
+        state = State.RUNNING;
+        timerBehavior.restart(null);
+    }
+
+    protected void onTestingStarted(AjaxRequestTarget target) {
+    }
+}

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/component/wizard/scimrest/connection/SupportedAuthMethodConnectorStepPanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/component/wizard/scimrest/connection/SupportedAuthMethodConnectorStepPanel.java
@@ -9,7 +9,9 @@ package com.evolveum.midpoint.gui.impl.page.admin.connector.development.componen
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.apache.wicket.ajax.AjaxEventBehavior;
 import org.apache.wicket.ajax.AjaxRequestTarget;
@@ -28,12 +30,17 @@ import com.evolveum.midpoint.gui.api.model.LoadableModel;
 import com.evolveum.midpoint.gui.api.prism.wrapper.ItemWrapper;
 import com.evolveum.midpoint.gui.api.prism.wrapper.PrismContainerValueWrapper;
 import com.evolveum.midpoint.gui.api.prism.wrapper.PrismContainerWrapper;
+import com.evolveum.midpoint.gui.api.prism.wrapper.PrismPropertyWrapper;
 import com.evolveum.midpoint.gui.impl.component.wizard.AbstractWizardStepPanel;
 import com.evolveum.midpoint.gui.impl.component.wizard.WizardPanelHelper;
+import com.evolveum.midpoint.gui.impl.page.admin.ObjectDetailsModels;
 import com.evolveum.midpoint.gui.impl.page.admin.connector.development.ConnectorDevelopmentDetailsModel;
 import com.evolveum.midpoint.gui.impl.page.admin.connector.development.component.wizard.ConnectorDevelopmentWizardUtil;
+import com.evolveum.midpoint.gui.impl.prism.wrapper.PrismPropertyValueWrapper;
 import com.evolveum.midpoint.prism.Containerable;
+import com.evolveum.midpoint.prism.path.ItemName;
 import com.evolveum.midpoint.prism.path.ItemPath;
+import com.evolveum.midpoint.schema.constants.SchemaConstants;
 import com.evolveum.midpoint.schema.result.OperationResult;
 import com.evolveum.midpoint.smart.api.conndev.SupportedAuthorization;
 import com.evolveum.midpoint.util.exception.SchemaException;
@@ -93,6 +100,11 @@ public class SupportedAuthMethodConnectorStepPanel extends AbstractWizardStepPan
                             ItemPath.create(ConnectorDevelopmentType.F_APPLICATION, ConnDevApplicationInfoType.F_AUTH));
                     List<PrismContainerValueWrapper<ConnDevAuthInfoType>> values = new ArrayList<>(container.getValues());
 
+                    PrismContainerWrapper<ConnDevAuthInfoType> connContainer = getDetailsModel().getObjectWrapper().findContainer(
+                            ItemPath.create(ConnectorDevelopmentType.F_CONNECTOR, ConnDevConnectorType.F_AUTH));
+                    List<ConnDevHttpAuthTypeType> alreadySelected = connContainer.getValues().stream()
+                            .map(v -> v.getRealValue().getType())
+                            .toList();
                     if (showAllModel.getObject()) {
                         for (SupportedAuthorization auth : SupportedAuthorization.values()) {
                             if (auth == SupportedAuthorization.NONE) {
@@ -109,17 +121,22 @@ public class SupportedAuthMethodConnectorStepPanel extends AbstractWizardStepPan
                         values = values.stream()
                                 .filter(v -> Boolean.TRUE.equals(v.getRealValue().isRecommended()))
                                 .collect(Collectors.toCollection(ArrayList::new));
+                        for (ConnDevHttpAuthTypeType selectedType : alreadySelected) {
+                            boolean alreadyPresent = values.stream()
+                                    .anyMatch(v -> selectedType.equals(v.getRealValue().getType()));
+                            if (!alreadyPresent) {
+                                SupportedAuthorization auth = SupportedAuthorization.forAuthorizationType(selectedType);
+                                if (auth != null && auth != SupportedAuthorization.NONE) {
+                                    ConnDevAuthInfoType newVal = auth.crateBasicInformation();
+                                    values.add(getPageBase().createValueWrapper(container, newVal.asPrismContainerValue(), ValueStatus.NOT_CHANGED, getDetailsModel().createWrapperContext()));
+                                }
+                            }
+                        }
                     }
 
                     values.sort(Comparator.comparing((PrismContainerValueWrapper<ConnDevAuthInfoType> v) ->
                                     !Boolean.TRUE.equals(v.getRealValue().isRecommended()))
                             .thenComparing(v -> v.getRealValue().getName()));
-
-                    PrismContainerWrapper<ConnDevAuthInfoType> connContainer = getDetailsModel().getObjectWrapper().findContainer(
-                            ItemPath.create(ConnectorDevelopmentType.F_CONNECTOR, ConnDevConnectorType.F_AUTH));
-                    List<ConnDevHttpAuthTypeType> alreadySelected = connContainer.getValues().stream()
-                            .map(v -> v.getRealValue().getType())
-                            .toList();
 
                     if (!alreadySelected.isEmpty()) {
                         values.forEach(v -> v.setSelected(alreadySelected.contains(v.getRealValue().getType())));
@@ -285,7 +302,6 @@ public class SupportedAuthMethodConnectorStepPanel extends AbstractWizardStepPan
                     .filter(PrismContainerValueWrapper::isSelected)
                     .map(v -> v.getRealValue().getType())
                     .collect(Collectors.toCollection(ArrayList::new));
-
             new ArrayList<>(container.getValues()).forEach(existing -> {
                 if (selectedTypes.remove(existing.getRealValue().getType())) {
                     if (existing.getStatus() == ValueStatus.DELETED) {
@@ -295,25 +311,60 @@ public class SupportedAuthMethodConnectorStepPanel extends AbstractWizardStepPan
                     existing.setStatus(ValueStatus.DELETED);
                 }
             });
+            PrismPropertyWrapper<ConnDevIntegrationType> integrationProp = getDetailsModel().getObjectWrapper().findProperty(
+                    ItemPath.create(ConnectorDevelopmentType.F_CONNECTOR, ConnDevConnectorType.F_INTEGRATION_TYPE));
+            ConnDevIntegrationType integrationType = integrationProp != null && integrationProp.getValue() != null
+                    ? integrationProp.getValue().getRealValue() : null;
+            if (integrationType != null) {
+                Set<String> neededLocalParts = Stream.concat(
+                        container.getValues().stream()
+                                .filter(v -> v.getStatus() != ValueStatus.DELETED)
+                                .map(v -> v.getRealValue().getType()),
+                        selectedTypes.stream()
+                ).flatMap(t -> SupportedAuthorization.attributesFor(integrationType, t).stream())
+                .map(n -> n.getLocalPart())
+                .collect(Collectors.toSet());
+                ObjectDetailsModels<ResourceType> resourceModel =
+                        ConnectorDevelopmentWizardUtil.getTestingResourceModel(getDetailsModel(), getPanelType());
 
-            for (ConnDevHttpAuthTypeType type : selectedTypes) {
-                valuesModel.getObject().stream()
-                        .filter(v -> type.equals(v.getRealValue().getType()))
-                        .findFirst()
-                        .ifPresent(value -> {
-                            try {
-                                //noinspection unchecked
-                                PrismContainerValueWrapper<ConnDevAuthInfoType> newVal =
-                                        (PrismContainerValueWrapper<ConnDevAuthInfoType>) getPageBase().createValueWrapper(
-                                                container, value.getRealValue().asPrismContainerValue().clone(),
-                                                ValueStatus.ADDED, getDetailsModel().createWrapperContext());
-                                container.getItem().add(newVal.getRealValue().asPrismContainerValue());
-                                container.getValues().add(newVal);
-                            } catch (SchemaException e) {
-                                throw new RuntimeException(e);
-                            }
-                        });
+                Set<String> toClear = Stream.of(SupportedAuthorization.values())
+                        .filter(a -> a != SupportedAuthorization.NONE)
+                        .flatMap(a -> a.attributesFor(integrationType).stream())
+                        .map(ItemName::getLocalPart)
+                        .filter(lp -> !neededLocalParts.contains(lp))
+                        .collect(Collectors.toSet());
+
+                for (String localPart : toClear) {
+                    ItemPath propPath = ItemPath.create("connectorConfiguration",
+                            SchemaConstants.ICF_CONFIGURATION_PROPERTIES_LOCAL_NAME, localPart);
+                    //noinspection rawtypes
+                    PrismPropertyWrapper prop = resourceModel.getObjectWrapper().findProperty(propPath);
+                    if (prop != null && !prop.getValues().isEmpty()) {
+                        //noinspection unchecked,rawtypes
+                        PrismPropertyValueWrapper valueWrapper = (PrismPropertyValueWrapper) prop.getValue();
+                        if (valueWrapper.getRealValue() != null) {
+                            valueWrapper.setRealValue(null);
+                            valueWrapper.setStatus(ValueStatus.MODIFIED);
+                        }
+                    }
+                }
             }
+
+            valuesModel.getObject().stream()
+                    .filter(v -> selectedTypes.contains(v.getRealValue().getType()))
+                    .forEach(value -> {
+                        try {
+                            //noinspection unchecked
+                            PrismContainerValueWrapper<ConnDevAuthInfoType> newVal =
+                                    (PrismContainerValueWrapper<ConnDevAuthInfoType>) getPageBase().createValueWrapper(
+                                            container, value.getRealValue().asPrismContainerValue().clone(),
+                                            ValueStatus.ADDED, getDetailsModel().createWrapperContext());
+                            container.getItem().add(newVal.getRealValue().asPrismContainerValue());
+                            container.getValues().add(newVal);
+                        } catch (SchemaException e) {
+                            throw new RuntimeException(e);
+                        }
+                    });
 
         } catch (SchemaException e) {
             throw new RuntimeException(e);

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/component/wizard/summary/ConnectorDevelopmentWizardSummaryPanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/component/wizard/summary/ConnectorDevelopmentWizardSummaryPanel.java
@@ -191,7 +191,7 @@ public class ConnectorDevelopmentWizardSummaryPanel extends WizardStepPanel impl
 
                 @Override
                 public boolean isEditButtonVisible() {
-                    return ConnectorDevelopmentWizardUtil.isConnectionComplete(detailsModel);
+                    return ConnectorDevelopmentWizardUtil.isBasicSettingsComplete(detailsModel.getObjectWrapper());
                 }
             }.setStatusCssIcon(() -> ConnectorDevelopmentWizardUtil.isConnectionComplete(detailsModel) ?
                     "fa fa-circle-check" : "fa fa-circle-xmark"));

--- a/infra/schema/src/main/java/com/evolveum/midpoint/schema/processor/NativeShadowAttributeDefinitionImpl.java
+++ b/infra/schema/src/main/java/com/evolveum/midpoint/schema/processor/NativeShadowAttributeDefinitionImpl.java
@@ -58,7 +58,7 @@ public class NativeShadowAttributeDefinitionImpl<T>
         ShadowAttributeUcfDefinition.Delegable, ShadowAttributeUcfDefinition.Mutable.Delegable,
         PrismItemValuesDefinition.Delegable<T>, PrismItemValuesDefinition.Mutator.Delegable<T>,
         PrismItemMatchingDefinition.Delegable<T>, PrismItemMatchingDefinition.Mutator.Delegable,
-        SerializableItemDefinition, SerializablePropertyDefinition, SerializableContainerDefinition {
+        SerializableItemDefinition, SerializablePropertyDefinition<T>, SerializableContainerDefinition {
 
     @NotNull private final PrismItemBasicDefinition.Data prismItemBasicData;
     @NotNull private final PrismItemAccessDefinition.Data prismItemAccessData = new PrismItemAccessDefinition.Data();
@@ -573,6 +573,16 @@ public class NativeShadowAttributeDefinitionImpl<T>
     @Override
     public void setAllowedValues(Collection<? extends DisplayableValue<T>> displayableValues) {
         prismItemValues.setAllowedValues(displayableValues);
+    }
+
+    @Override
+    public Collection<? extends DisplayableValue<T>> getAllowedValues() {
+        return PrismItemValuesDefinition.Delegable.super.getAllowedValues();
+    }
+
+    @Override
+    public Collection<? extends DisplayableValue<T>> getSuggestedValues() {
+        return PrismItemValuesDefinition.Delegable.super.getSuggestedValues();
     }
 
     @Override

--- a/model/smart-impl/src/main/java/com/evolveum/midpoint/smart/impl/conndev/ConnectorManifestWriter.java
+++ b/model/smart-impl/src/main/java/com/evolveum/midpoint/smart/impl/conndev/ConnectorManifestWriter.java
@@ -32,11 +32,12 @@ public class ConnectorManifestWriter {
 
 
     private void writeConnector(ConnDevConnectorType connector) {
-        var operations = FACTORY.arrayNode();
         var schemas = FACTORY.arrayNode();
-        // Write schema scripts
+        var authorization = FACTORY.arrayNode();
+        var operations = FACTORY.arrayNode();
+
+        writeScript(authorization, connector.getAuthenticationScript());
         writeScript(operations, connector.getTestOperation());
-        writeScript(operations, connector.getAuthenticationScript());
 
         for (var objClass : connector.getObjectClass()) {
             writeScript(schemas, objClass.getNativeSchemaScript());
@@ -47,9 +48,16 @@ public class ConnectorManifestWriter {
             writeScript(operations, objClass.getCreateScript());
             writeScript(operations, objClass.getUpdateScript());
             writeScript(operations, objClass.getDeleteScript());
-
         }
+
+        for (var relation : connector.getRelation()) {
+            writeScript(schemas, relation.getSchemaScript());
+        }
+
         this.connector.set("schema", schemas);
+        if (!authorization.isEmpty()) {
+            this.connector.set("authorization", authorization);
+        }
         this.connector.set("operation", operations);
     }
 

--- a/provisioning/ucf-impl-connid/src/main/java/com/evolveum/midpoint/provisioning/ucf/impl/connid/ConnectorFactoryConnIdImpl.java
+++ b/provisioning/ucf-impl-connid/src/main/java/com/evolveum/midpoint/provisioning/ucf/impl/connid/ConnectorFactoryConnIdImpl.java
@@ -22,10 +22,12 @@ import java.net.URL;
 import java.security.Key;
 import java.util.*;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.stream.Collectors;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
 
 import com.evolveum.midpoint.prism.PrismPropertyDefinition.PrismPropertyDefinitionMutator;
+import com.evolveum.midpoint.prism.impl.DisplayableValueImpl;
 import com.evolveum.midpoint.prism.impl.xml.GlobalDynamicNamespacePrefixMapper;
 import com.evolveum.midpoint.schema.processor.ConnectorSchema;
 import com.evolveum.midpoint.schema.processor.ConnectorSchemaFactory;
@@ -41,6 +43,8 @@ import com.evolveum.midpoint.prism.path.ItemName;
 
 import org.apache.commons.configuration2.Configuration;
 import org.identityconnectors.common.Version;
+import org.identityconnectors.framework.common.objects.SuggestedValues;
+import org.identityconnectors.framework.common.objects.ValueListOpenness;
 import org.identityconnectors.common.security.Encryptor;
 import org.identityconnectors.common.security.EncryptorFactory;
 import org.identityconnectors.common.security.GuardedString;
@@ -450,6 +454,21 @@ public class ConnectorFactoryConnIdImpl implements ConnectorFactory {
             }
             propertyDefinition.setDisplayOrder(displayOrder);
             displayOrder++;
+
+            SuggestedValues allowedValues = icfProperty.getAllowedValues();
+            if (allowedValues != null && !allowedValues.getValues().isEmpty()) {
+                @SuppressWarnings("rawtypes")
+                Collection displayableValues = allowedValues.getValues().stream()
+                        .map(v -> new DisplayableValueImpl<>(v, v != null ? v.toString() : null, null))
+                        .collect(Collectors.toList());
+                if (ValueListOpenness.OPEN.equals(allowedValues.getOpenness())) {
+                    //noinspection unchecked
+                    propertyDefinition.setSuggestedValues(displayableValues);
+                } else {
+                    //noinspection unchecked
+                    propertyDefinition.setAllowedValues(displayableValues);
+                }
+            }
         }
 
         // Create common ICF configuration property containers as a references to a static schema


### PR DESCRIPTION
- ConnId schema: Map SuggestedValues from ICF connector properties to midPoint allowedValues/suggestedValues, distinguishing open (suggested) vs. closed (allowed) lists. Fix generic type parameter on SerializablePropertyDefinition in NativeShadowAttributeDefinitionImpl.                                                                                                                                      
- ConnectorManifestWriter: Move authentication script to a dedicated authorization section in the manifest (was incorrectly placed in operation). Include relation schema scripts in the manifest output.   
- New wizard steps: Add ResourceTestConnectorStepPanel which runs testResource() with visual progress feedback (spinner, elapsed time, success/failure state). On failure, automatically redirects to the new FixConnectionConnectorStepPanel where the user can correct base URL, test endpoint, credentials and auth script, then retry — without leaving the wizard.                                               
- Endpoint step refactor: Remove inline testResource() call from EndpointConnectorStepPanel. The step now saves the endpoint choice and advances to ResourceTestConnectorStepPanel. Implements WizardListener to refresh URL selection state when navigating back to the step.                                                                                                                             
- Credentials step: Fix getContainerFormModel() to use the shared ConnectorDevelopmentWizardUtil.getTestingResourceModel() instead of resolving the testing resource reference directly. Add onBeforeRender() guard to reinitialise the layout when the underlying container wrapper changes.                                                                                                            
- Auth method step: In non-show-all mode, preserve auth methods that were selected in a previous session even if not marked as recommended. On next, clear connector config fields that belong to deselected auth types to avoid stale credential values.                                                                                                                                                                
- Shared utilities: Extract isScim(), getVisibleAuthorizationAttributes() and setTestingResourcePropertyValue() from three separate panels into ConnectorDevelopmentWizardUtil to eliminate duplication.    
- Summary panel: Make the configure button on the connection status widget visible whenever basic connector information is filled in, not only after a successful connection test.
