### PR TITLE
Refine LLM-discovered auth methods and connectivity endpoints

### DIFF
--- a/model/smart-impl/src/main/java/com/evolveum/midpoint/smart/impl/conndev/ConnectorDevelopmentBackend.java
+++ b/model/smart-impl/src/main/java/com/evolveum/midpoint/smart/impl/conndev/ConnectorDevelopmentBackend.java
@@ -34,6 +34,7 @@ public abstract class ConnectorDevelopmentBackend {
     private static final JsonNodeFactory JSON_FACTORY = JsonNodeFactory.instance;
     private static final String CONNECTOR_MANIFEST = "connector.manifest.json";
     private static final String CONFIGURATION_OVERRIDE = "configurationOverride.properties";
+    private static final int MAX_SUGGESTED_CONNECTIVITY_ENDPOINTS = 5;
     protected final Task task;
     protected final OperationResult result;
 
@@ -336,7 +337,7 @@ public abstract class ConnectorDevelopmentBackend {
     public void populateConnectivityEndpoints(List<ConnDevHttpEndpointType> endpoints) throws CommonException {
         var delta = PrismContext.get().deltaFor(ConnectorDevelopmentType.class)
                 .item(ConnectorDevelopmentType.F_TESTING, ConnDevTestingType.F_SUGGESTED_ENDPOINT)
-                .replaceRealValues(endpoints)
+                .replaceRealValues(endpoints.stream().limit(MAX_SUGGESTED_CONNECTIVITY_ENDPOINTS).toList())
                 .<ConnectorDevelopmentType>asObjectDelta(development.getOid());
         beans.modelService.executeChanges(List.of(delta), null, task, result);
         reload();

--- a/model/smart-impl/src/main/java/com/evolveum/midpoint/smart/impl/conndev/ConnectorDevelopmentBackend.java
+++ b/model/smart-impl/src/main/java/com/evolveum/midpoint/smart/impl/conndev/ConnectorDevelopmentBackend.java
@@ -118,7 +118,10 @@ public abstract class ConnectorDevelopmentBackend {
     public void populateApplicationAuthInfo(List<ConnDevAuthInfoType> authInfo) throws CommonException {
         var delta = PrismContext.get().deltaFor(ConnectorDevelopmentType.class)
                 .item(ConnectorDevelopmentType.F_APPLICATION, ConnDevApplicationInfoType.F_AUTH)
-                .addRealValues( authInfo.stream().map(ConnDevAuthInfoType::clone).toList())
+                .addRealValues(authInfo.stream()
+                        .filter(info -> info.getType() != ConnDevHttpAuthTypeType.OTHER)
+                        .map(ConnDevAuthInfoType::clone)
+                        .toList())
                 .<ConnectorDevelopmentType>asObjectDelta(development.getOid());
         beans.modelService.executeChanges(List.of(delta), null, task, result);
         reload();


### PR DESCRIPTION
- Skip auth methods with `type: other` discovered by the LLM  
- Keep only the first 5 discovered connectivity endpoints     
