### PR TITLE
Fix misplaced allowedValues annotation in DummyConfiguration

### DIFF
--- a/icf-connectors/dummy-connector/src/main/java/com/evolveum/icf/dummy/connector/DummyConfiguration.java
+++ b/icf-connectors/dummy-connector/src/main/java/com/evolveum/icf/dummy/connector/DummyConfiguration.java
@@ -149,7 +149,9 @@ public class DummyConfiguration extends AbstractConfiguration {
     }
 
     @ConfigurationProperty(displayMessageKey = "UI_UID_MODE",
-            helpMessageKey = "UI_UID_MODE_HELP")
+            helpMessageKey = "UI_UID_MODE_HELP",
+            allowedValues = {UidMode.V_NAME, UidMode.V_UUID, UidMode.V_EXTERNAL},
+            allowedValuesOpenness = ValueListOpenness.CLOSED)
     public String getUidMode() {
         return uidMode.getStringValue();
     }
@@ -159,9 +161,7 @@ public class DummyConfiguration extends AbstractConfiguration {
     }
 
     @ConfigurationProperty(displayMessageKey = "UI_ENFORCE_UNIQUE_NAME",
-            helpMessageKey = "UI_ENFORCE_UNIQUE_NAME",
-            allowedValues = {UidMode.V_NAME, UidMode.V_UUID, UidMode.V_EXTERNAL},
-            allowedValuesOpenness = ValueListOpenness.CLOSED)
+            helpMessageKey = "UI_ENFORCE_UNIQUE_NAME")
     public boolean isEnforceUniqueName() {
         return enforceUniqueName;
     }


### PR DESCRIPTION
The allowedValues = {name, uuid, external} (CLOSED) annotation belonged on the String getUidMode() property, but was attached to the boolean isEnforceUniqueName() getter. Once prism started serializing allowedValues into the connector schema, validating the default enforceUniqueName=false against [name, uuid, external] threw a SchemaException, breaking the TestDummyUuidNonUniqueName provisioning tests.