### PR TITLE
Improve connector development error messages surfaced in the wizard

### DIFF
--- a/model/smart-impl/src/main/java/com/evolveum/midpoint/smart/impl/conndev/ConnectorDevelopmentBackend.java
+++ b/model/smart-impl/src/main/java/com/evolveum/midpoint/smart/impl/conndev/ConnectorDevelopmentBackend.java
@@ -362,7 +362,7 @@ public abstract class ConnectorDevelopmentBackend {
             var propString = stream.toString(StandardCharsets.UTF_8);
             editableConnector().saveFile(CONFIGURATION_OVERRIDE, propString);
         } catch (IOException e) {
-            throw new RuntimeException(e);
+            throw new SystemException("Couldn't write connector configuration override (" + CONFIGURATION_OVERRIDE + ")", e);
         }
         var connRef = development.getConnector().getConnectorRef();
         if (connRef != null && deleteConnectorSchema) {

--- a/model/smart-impl/src/main/java/com/evolveum/midpoint/smart/impl/conndev/ConnectorDevelopmentServiceImpl.java
+++ b/model/smart-impl/src/main/java/com/evolveum/midpoint/smart/impl/conndev/ConnectorDevelopmentServiceImpl.java
@@ -238,13 +238,17 @@ public class ConnectorDevelopmentServiceImpl implements ConnectorDevelopmentServ
 
         @Override
         public List<ConnDevHttpEndpointType> suggestedEndpointsFor(String user, ConnectorDevelopmentArtifacts.KnownArtifactType knownArtifactType) {
-            var obj = stateObject.getApplication().getDetectedSchema().getObjectClass().stream()
-                    .filter(o -> o.getName().equals(user)).findFirst().orElse(null);
-
             var use = switch (knownArtifactType.scriptIntent) {
                 case ALL -> ConnDevHttpEndpointIntentType.GET_ALL;
-                default -> throw new IllegalArgumentException();
+                default -> throw new IllegalArgumentException(
+                        "Unsupported artifact type for endpoint suggestion: " + knownArtifactType);
             };
+
+            var obj = stateObject.getApplication().getDetectedSchema().getObjectClass().stream()
+                    .filter(o -> o.getName().equals(user)).findFirst().orElse(null);
+            if (obj == null) {
+                return List.of();
+            }
 
             return obj.getEndpoint().stream().filter(e -> e.getSuggestedUse().contains(use)).toList();
         }
@@ -287,7 +291,7 @@ public class ConnectorDevelopmentServiceImpl implements ConnectorDevelopmentServ
                     task, result);
             return oid;
         } catch (Exception e) {
-            throw new SystemException(e);
+            throw new SystemException("Couldn't submit task '" + name + "'", e);
         }
     }
 

--- a/model/smart-impl/src/main/java/com/evolveum/midpoint/smart/impl/conndev/RestBackend.java
+++ b/model/smart-impl/src/main/java/com/evolveum/midpoint/smart/impl/conndev/RestBackend.java
@@ -61,7 +61,7 @@ public class RestBackend extends ConnectorDevelopmentBackend {
                 return ret;
             });
         } catch (Exception e) {
-            throw new RuntimeException(e);
+            throw new SystemException("Couldn't discover basic application information", e);
         }
     }
 
@@ -71,6 +71,9 @@ public class RestBackend extends ConnectorDevelopmentBackend {
             if ("application/json".equals(doc.contentType()) || "application/yaml".equals(doc.contentType())) {
                 return doc;
             }
+        }
+        if (processedDocumentation.isEmpty()) {
+            throw new SystemException("No processed documentation is available to select from");
         }
         return processedDocumentation.get(0);
     }
@@ -92,7 +95,7 @@ public class RestBackend extends ConnectorDevelopmentBackend {
                 return ret;
             });
         } catch (Exception e) {
-            throw new RuntimeException(e);
+            throw new SystemException("Couldn't discover authorization information", e);
         }
     }
 
@@ -281,7 +284,7 @@ public class RestBackend extends ConnectorDevelopmentBackend {
                 return ret;
             });
         } catch (Exception e) {
-            throw new RuntimeException(e);
+            throw new SystemException("Couldn't discover object classes from documentation", e);
         }
     }
 
@@ -297,13 +300,13 @@ public class RestBackend extends ConnectorDevelopmentBackend {
                 if (ret.isEmpty()) {
                     var jsonErrors = o.get("errors");
                     if (jsonErrors != null && !jsonErrors.isEmpty()) {
-                        throw new RuntimeException("Connectivity endpoint discovery failed with errors: " + jsonErrors);
+                        throw new SystemException("Connectivity endpoint discovery failed with errors: " + jsonErrors);
                     }
                 }
                 return ret;
             });
         } catch (Exception e) {
-            throw new RuntimeException(e);
+            throw new SystemException("Couldn't discover connectivity endpoints", e);
         }
     }
 
@@ -319,7 +322,7 @@ public class RestBackend extends ConnectorDevelopmentBackend {
                 return ret;
             });
         } catch (Exception e) {
-            throw new RuntimeException(e);
+            throw new SystemException("Couldn't discover endpoints for object class " + objectClass, e);
         }
     }
 
@@ -336,7 +339,7 @@ public class RestBackend extends ConnectorDevelopmentBackend {
                 return ret;
             });
         } catch (Exception e) {
-            throw new RuntimeException(e);
+            throw new SystemException("Couldn't discover attributes for object class " + objectClass, e);
         }
     }
 
@@ -379,7 +382,7 @@ public class RestBackend extends ConnectorDevelopmentBackend {
             });
             documentations.addAll(scrapped);
         } catch (IOException e) {
-            throw new RuntimeException(e);
+            throw new SystemException("Couldn't scrape documentation", e);
         }
 
     }
@@ -423,7 +426,7 @@ public class RestBackend extends ConnectorDevelopmentBackend {
             beans.downloadFile(url, documentation.asOutputStream());
             return documentation;
         } catch (Exception e) {
-            throw new RuntimeException(e);
+            throw new SystemException("Couldn't download documentation from " + openApi.getUri(), e);
         }
 
     }
@@ -456,7 +459,7 @@ public class RestBackend extends ConnectorDevelopmentBackend {
                 });
             }
         } catch (Exception e) {
-            throw new SystemException(e.getMessage(), e);
+            throw new SystemException("Couldn't discover relations between object classes", e);
         }
     }
 

--- a/model/smart-impl/src/main/java/com/evolveum/midpoint/smart/impl/conndev/ServiceClient.java
+++ b/model/smart-impl/src/main/java/com/evolveum/midpoint/smart/impl/conndev/ServiceClient.java
@@ -1,6 +1,7 @@
 package com.evolveum.midpoint.smart.impl.conndev;
 
 import com.evolveum.axiom.concepts.CheckedFunction;
+import com.evolveum.midpoint.util.exception.SystemException;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
@@ -226,16 +227,49 @@ public class ServiceClient {
                 try {
                     Thread.sleep(sleepTime);
                 } catch (InterruptedException e) {
-                    throw new RuntimeException(e);
+                    Thread.currentThread().interrupt();
+                    throw new SystemException("Interrupted while waiting for the connector generation service", e);
                 }
                 if (!canRun.getAsBoolean()) {
-                    throw new RuntimeException("Task interrupted");
+                    throw new SystemException("Operation was cancelled while waiting for the connector generation service");
                 }
             }
-            if (isFinished()) {
+            if (status == JobStatus.FAILED) {
+                var errors = extractErrors();
+                throw new SystemException("The connector generation service reported a failure"
+                        + (errors != null ? ": " + errors : ""));
+            }
+            if (status == JobStatus.COMPLETED) {
                 return transform.apply(getResult());
             }
-            throw new IllegalStateException("Job has been finished");
+            throw new SystemException("The connector generation service job did not finish successfully");
+        }
+
+        /**
+         * Extracts the {@code errors} array (if present) from the latest job response, so that
+         * service-side failures are surfaced in the exception message shown in the GUI instead of
+         * a generic, contextless error.
+         */
+        private String extractErrors() {
+            if (latestResult == null) {
+                return null;
+            }
+            var errorsNode = latestResult.get("errors");
+            if (errorsNode == null || errorsNode.isNull()) {
+                var resultNode = latestResult.get("result");
+                errorsNode = resultNode != null ? resultNode.get("errors") : null;
+            }
+            if (errorsNode == null || !errorsNode.isArray() || errorsNode.isEmpty()) {
+                return null;
+            }
+            var sb = new StringBuilder();
+            for (var error : errorsNode) {
+                if (sb.length() > 0) {
+                    sb.append("\n");
+                }
+                sb.append(error.asText());
+            }
+            return sb.length() == 0 ? null : sb.toString();
         }
     }
 

--- a/model/smart-impl/src/main/java/com/evolveum/midpoint/smart/impl/conndev/activity/CreateConnectorActivityHandler.java
+++ b/model/smart-impl/src/main/java/com/evolveum/midpoint/smart/impl/conndev/activity/CreateConnectorActivityHandler.java
@@ -115,8 +115,7 @@ public class CreateConnectorActivityHandler
                 editable.asEditable().updateProperty(
                         "Messages.properties", "manifest.connector.display", backend.connectorDisplayName());
             } catch (IOException e) {
-                // FIXME: Add proper exception
-                throw new SystemException(e);
+                throw new SystemException("Couldn't set the connector display name in Messages.properties", e);
             }
 
             editable.asEditable().renameBundle(connDef.getGroupId(), connDef.getArtifactId(), connDef.getVersion());
@@ -124,6 +123,11 @@ public class CreateConnectorActivityHandler
             // Install template
             var lookups = editable.install(result);
 
+            if (lookups.isEmpty()) {
+                throw new SystemException(
+                        "Connector installation produced no connector definition for '" + targetDir
+                                + "'; the generated connector is either already installed or is not a valid ConnId bundle");
+            }
             var lookup = lookups.get(0);
 
             var query = PrismContext.get().queryFor(ConnectorType.class)
@@ -134,6 +138,11 @@ public class CreateConnectorActivityHandler
 
 
             var connectors = beans.modelService.searchObjects(ConnectorType.class, query, null, task, result);
+            if (connectors.isEmpty()) {
+                throw new SystemException(
+                        "Installed connector was not found in the repository for bundle '" + lookup.getConnectorBundle()
+                                + "', type '" + lookup.getConnectorType() + "', version '" + lookup.getConnectorVersion() + "'");
+            }
             var connector = connectors.get(0);
 
             var state = getActivityState();

--- a/model/smart-impl/src/main/java/com/evolveum/midpoint/smart/impl/conndev/activity/DownloadConnectorActivityHandler.java
+++ b/model/smart-impl/src/main/java/com/evolveum/midpoint/smart/impl/conndev/activity/DownloadConnectorActivityHandler.java
@@ -91,6 +91,11 @@ public class DownloadConnectorActivityHandler
             // Install template
             var lookups = template.install(result);
 
+            if (lookups.isEmpty()) {
+                throw new SystemException(
+                        "Connector installation produced no connector definition for '" + connectorUrl
+                                + "'; the downloaded connector is either already installed or is not a valid ConnId bundle");
+            }
             var lookup = lookups.get(0);
 
             var query = PrismContext.get().queryFor(ConnectorType.class)
@@ -101,6 +106,11 @@ public class DownloadConnectorActivityHandler
 
 
             var connectors = beans.modelService.searchObjects(ConnectorType.class, query, null, task, result);
+            if (connectors.isEmpty()) {
+                throw new SystemException(
+                        "Installed connector was not found in the repository for bundle '" + lookup.getConnectorBundle()
+                                + "', type '" + lookup.getConnectorType() + "', version '" + lookup.getConnectorVersion() + "'");
+            }
             var connector = connectors.get(0);
 
             var state = getActivityState();


### PR DESCRIPTION
Wizard 'waiting' steps run backend activity tasks; when those fail, the raw exception message is what the GUI error box shows. Replace vague and opaque failures with operation-scoped messages:

- guard empty install lookups in CreateConnector/DownloadConnector activity handlers instead of letting 'Index 0 out of bounds' escape; explain the likely causes (already installed or not a valid ConnId bundle)
- replace opaque RuntimeException(e)/SystemException(e) in RestBackend, ServiceClient, ConnectorDevelopmentBackend and ConnectorDevelopmentServiceImpl with contextual messages
- surface the service 'errors' array into the exception on job failure in ServiceClient, and fix the no-message IllegalStateException on the failed path