### PR TITLE
MID-11535 Add encoding and utf-8-bom support for GUI CSV export (support-4.10)

### DIFF
--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/api/component/button/CsvDownloadButtonPanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/api/component/button/CsvDownloadButtonPanel.java
@@ -63,8 +63,21 @@ public abstract class CsvDownloadButtonPanel extends BasePanel {
 
     private static final long serialVersionUID = 1L;
 
+    private String resolveExportEncoding() {
+        try {
+            CompiledGuiProfile profile = getPageBase().getCompiledGuiProfile();
+            if (profile.getDefaultExportSettings() != null
+                    && profile.getDefaultExportSettings().getEncoding() != null) {
+                return profile.getDefaultExportSettings().getEncoding();
+            }
+        } catch (Exception ex) {
+            LOGGER.warn("Unable to get export encoding setting, falling back to utf-8", ex);
+        }
+        return "utf-8";
+    }
+
     private void initLayout() {
-        StreamingCsvDataExporter csvDataExporter = new StreamingCsvDataExporter(getPageBase()) {
+        StreamingCsvDataExporter csvDataExporter = new StreamingCsvDataExporter(getPageBase(), resolveExportEncoding()) {
             private static final long serialVersionUID = 1L;
 
             @Override

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/component/data/provider/StreamingCsvDataExporter.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/component/data/provider/StreamingCsvDataExporter.java
@@ -41,16 +41,42 @@ public class StreamingCsvDataExporter extends CSVDataExporter {
     private static final String DOT_CLASS = StreamingCsvDataExporter.class.getName() + ".";
     private static final String OPERATION_EXPORT_DATA = DOT_CLASS + "exportData";
 
+    private static final String UTF_8_BOM_ENCODING = "utf-8-bom";
+    private static final byte[] UTF8_BOM = { (byte) 0xEF, (byte) 0xBB, (byte) 0xBF };
+
     private final PageBase pageBase;
+    private final String configuredEncoding;
+
+    public StreamingCsvDataExporter(PageBase pageBase, String encoding) {
+        this.pageBase = pageBase;
+        this.configuredEncoding = encoding;
+        setCharacterSet(resolveEffectiveCharset(encoding));
+    }
 
     public StreamingCsvDataExporter(PageBase pageBase) {
-        this.pageBase = pageBase;
+        this(pageBase, null);
+    }
+
+    private static String resolveEffectiveCharset(String encoding) {
+        if (encoding == null || UTF_8_BOM_ENCODING.equalsIgnoreCase(encoding)) {
+            return "utf-8";
+        }
+        return encoding;
+    }
+
+    private boolean isUtf8Bom() {
+        return UTF_8_BOM_ENCODING.equalsIgnoreCase(configuredEncoding);
     }
 
     @Override
     public <T> void exportData(IDataProvider<T> dataProvider,
             List<IExportableColumn<T, ?>> columns, OutputStream outputStream)
             throws IOException {
+
+        if (isUtf8Bom()) {
+            outputStream.write(UTF8_BOM);
+            outputStream.flush();
+        }
 
         if (!(dataProvider instanceof IterativeExportSupport)
                 || !((IterativeExportSupport<?>) dataProvider).supportsIterativeExport()) {

--- a/infra/schema/src/main/resources/xml/ns/public/common/common-gui-3.xsd
+++ b/infra/schema/src/main/resources/xml/ns/public/common/common-gui-3.xsd
@@ -3816,6 +3816,21 @@
                     </xsd:appinfo>
                 </xsd:annotation>
             </xsd:element>
+            <xsd:element name="encoding" type="xsd:string" minOccurs="0" maxOccurs="1">
+                <xsd:annotation>
+                    <xsd:documentation>
+                        Character encoding for exported CSV files.
+                        Default is "utf-8". Use "utf-8-bom" to prepend a UTF-8 BOM
+                        (byte order mark) to the exported file, which helps applications
+                        like Microsoft Excel on non-UTF-8 locale systems correctly
+                        recognize the file as UTF-8.
+                    </xsd:documentation>
+                    <xsd:appinfo>
+                        <a:displayName>GuiExportSettingsType.encoding</a:displayName>
+                        <a:since>4.10.4</a:since>
+                    </xsd:appinfo>
+                </xsd:annotation>
+            </xsd:element>
             <!-- TODO: later: default data language, sync/async, whether to show detail dialog or just run the export, etc. -->
         </xsd:sequence>
         <xsd:attribute name="id" type="xsd:long"/>


### PR DESCRIPTION
https://support.evolveum.com/projects/midpoint/work_packages/11535/activity

- Add `encoding` element to `GuiExportSettingsType` schema
- Support `utf-8-bom` value to prepend UTF-8 BOM to exported CSV
- Read encoding from `adminGuiConfiguration/defaultExportSettings/encoding`

Targeting `support-4.10` branch.
