### PR TITLE
Sort the GUI language selector by display name

### DIFF
--- a/infra/common/src/main/java/com/evolveum/midpoint/common/AvailableLocale.java
+++ b/infra/common/src/main/java/com/evolveum/midpoint/common/AvailableLocale.java
@@ -8,6 +8,7 @@ package com.evolveum.midpoint.common;
 
 import java.io.*;
 import java.nio.charset.StandardCharsets;
+import java.text.Collator;
 import java.util.*;
 
 import org.jetbrains.annotations.NotNull;
@@ -244,30 +245,35 @@ public class AvailableLocale {
             return Objects.hash(name, flag, locale, def);
         }
 
+        /**
+         * Sort by display name as it appears in the GUI language selector. The previous
+         * implementation sorted by locale identifier (country, then language, then variant),
+         * which produced the surprising result that any locale with a country code (e.g.
+         * {@code en_US}, {@code pt_BR}, {@code zh_CN}) was pushed below every language-only
+         * entry (e.g. {@code de}, {@code fr}) regardless of how it read in the selector. Sorting
+         * by the configured {@code .name} matches what users see and works for the bare
+         * language entries and the country-suffixed entries side by side.
+         *
+         * <p>Uses the JVM's default locale for the {@link Collator}, so accents and
+         * non-Latin scripts collate sensibly for the server's environment. Null names are
+         * treated as sorting first; in practice every descriptor loaded from
+         * {@code locale.properties} has a non-null name (the loader skips entries without
+         * {@code .name}).
+         */
         @Override
         public int compareTo(@NotNull LocaleDescriptor o) {
-            Locale other = o.getLocale();
-
-            int val = compareStrings(locale.getCountry(), other.getCountry());
-            if (val != 0) {
-                return val;
-            }
-
-            val = compareStrings(locale.getLanguage(), other.getLanguage());
-            if (val != 0) {
-                return val;
-            }
-
-            val = compareStrings(locale.getVariant(), other.getVariant());
-            return val;
-        }
-
-        private int compareStrings(String s1, String s2) {
-            if (s1 == null || s2 == null) {
+            if (name == null && o.name == null) {
                 return 0;
             }
-
-            return String.CASE_INSENSITIVE_ORDER.compare(s1, s2);
+            if (name == null) {
+                return -1;
+            }
+            if (o.name == null) {
+                return 1;
+            }
+            return NAME_COLLATOR.compare(name, o.name);
         }
+
+        private static final Collator NAME_COLLATOR = Collator.getInstance();
     }
 }

--- a/infra/common/src/test/java/com/evolveum/midpoint/common/AvailableLocaleTest.java
+++ b/infra/common/src/test/java/com/evolveum/midpoint/common/AvailableLocaleTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (C) 2026 Evolveum and contributors
+ *
+ * Licensed under the EUPL-1.2 or later.
+ */
+
+package com.evolveum.midpoint.common;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.text.Collator;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+
+import org.testng.annotations.Test;
+
+/**
+ * Verifies that {@link AvailableLocale.LocaleDescriptor} sorts by display name (the value
+ * configured as {@code <locale>.name} in {@code locale.properties}) rather than by locale
+ * identifier. The old sort key was country -> language -> variant, which pushed every
+ * country-coded locale ({@code en_US}, {@code pt_BR}, {@code zh_CN}) below every
+ * language-only locale ({@code de}, {@code fr}) regardless of how the entries read in the
+ * GUI language selector.
+ */
+public class AvailableLocaleTest {
+
+    private static AvailableLocale.LocaleDescriptor desc(String name, String flag, Locale locale) {
+        return new AvailableLocale.LocaleDescriptor(name, flag, null, locale);
+    }
+
+    /**
+     * After sorting, the display names must be in non-decreasing collation order per the JVM
+     * default {@link Collator}. The exact order may vary slightly by JVM locale (accent
+     * handling etc.), but the list must remain monotonically sorted.
+     */
+    @Test
+    public void sortedListIsMonotonicByDisplayName() {
+        List<AvailableLocale.LocaleDescriptor> list = new ArrayList<>(List.of(
+                desc("English (US)", "us", new Locale("en", "US")),
+                desc("English (UK)", "gb", new Locale("en", "GB")),
+                desc("Français", "fr", new Locale("fr")),
+                desc("Deutsch", "de", new Locale("de")),
+                desc("Português (Brasil)", "br", new Locale("pt", "BR"))));
+        Collections.sort(list);
+
+        Collator collator = Collator.getInstance();
+        for (int i = 1; i < list.size(); i++) {
+            assertThat(collator.compare(list.get(i - 1).getName(), list.get(i).getName()))
+                    .as("element %d (%s) must collate <= element %d (%s)",
+                            i - 1, list.get(i - 1).getName(), i, list.get(i).getName())
+                    .isLessThanOrEqualTo(0);
+        }
+    }
+
+    /**
+     * A country-coded locale ({@code zh_CN}, display name "Chinese") must NOT be pushed below
+     * a language-only locale ({@code de}, display name "Deutsch") just because it has a
+     * country code. "C" collates before "D" in every Locale's collation, so this assertion is
+     * robust across test environments.
+     */
+    @Test
+    public void countryCodedLocaleIsNotPushedBelowLanguageOnlyByCountryCode() {
+        AvailableLocale.LocaleDescriptor zhCn = desc("Chinese", "cn", new Locale("zh", "CN"));
+        AvailableLocale.LocaleDescriptor de = desc("Deutsch", "de", new Locale("de"));
+
+        List<AvailableLocale.LocaleDescriptor> list = new ArrayList<>(List.of(zhCn, de));
+        Collections.sort(list);
+
+        assertThat(list.get(0).getName()).isEqualTo("Chinese");
+        assertThat(list.get(1).getName()).isEqualTo("Deutsch");
+    }
+
+    /**
+     * Two locales with identical display names compare as equal regardless of their locale
+     * identifier. Edge case to guard against the previous implementation's fallback to
+     * country/language comparison sneaking back in.
+     */
+    @Test
+    public void identicalDisplayNamesCompareEqual() {
+        AvailableLocale.LocaleDescriptor a = desc("Same", "us", new Locale("en", "US"));
+        AvailableLocale.LocaleDescriptor b = desc("Same", "gb", new Locale("en", "GB"));
+        assertThat(a.compareTo(b)).isZero();
+        assertThat(b.compareTo(a)).isZero();
+    }
+}


### PR DESCRIPTION
# Sort the GUI language selector by display name

## Summary

The GUI language selector lists locales in an unusual order. This pull 
request changes the order to sort by the configured display name, which
is what users typically would expect. The change affects only the visual 
presentation; locale resolution is not touched.

## Problem

The comparator in `AvailableLocale.LocaleDescriptor` sorts by country code
first, then by language, then by variant. `Locale.getCountry()` returns an
empty string for language-only locales such as `en` or `de`, and an empty
string sorts before any real country code. As a result, every locale with a
country code (for example `en_US`, `pt_BR`, `zh_CN`) appears below every
language-only entry, regardless of how the entries read in the selector.
Adding `en_US` and `en_GB` to `${midpoint.home}/localization/locale.properties`
places both at the bottom of the list. There is no separate sort property in
`locale.properties`, so the comparator is the only place this can be fixed.

## Change

The comparator now sorts by the configured display name (`.name` in
`locale.properties`) using `java.text.Collator` with the JVM default locale.
The country code, language code, and variant no longer affect the order. With
this change, "English (UK)" appears between "Deutsch" and "Español"; the
familiar `pt_BR` and `zh_CN` defaults move to the alphabetical position of
their display names ("Português (Brasil)", "中文").

Using `Collator` rather than plain string comparison handles accents and
non-Latin scripts as users would expect.

<img width="138" height="562" alt="grafik" src="https://github.com/user-attachments/assets/e7247b76-d538-4679-a883-751e8da03a82" />   <img width="139" height="564" alt="grafik" src="https://github.com/user-attachments/assets/7f8e5408-dce6-45f3-9755-e9613103188a" />

(Before vs. After)

## Compatibility

`AvailableLocale.AVAILABLE_LOCALES` is read only by code that presents the
list to a user. Locale resolution compares `Locale` objects directly and
does not depend on the descriptor order. Existing `locale.properties` files
keep working unchanged.

## Tests

A new `AvailableLocaleTest` in `infra/common` adds three cases: the sorted
list is in non-decreasing collation order; a country-coded locale "Chinese"
(`zh_CN`) sorts before a language-only locale "Deutsch" (`de`); two locales
with identical display names compare as equal.
