### PR TITLE
Connector generator: forward the conndev dev-schema export to the midpilot service

### DIFF
--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/component/wizard/scimrest/connection/ConnectionConnectorStepPanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/component/wizard/scimrest/connection/ConnectionConnectorStepPanel.java
@@ -183,7 +183,7 @@ public class ConnectionConnectorStepPanel extends AbstractFormWizardStepPanel<Co
                 new EndpointConnectorStepPanel(getHelper()),
                 new FixConnectionConnectorStepPanel(getHelper()),
                 new ResourceTestConnectorStepPanel(getHelper()),
-                new WaitingScimSchemaConnectorStepPanel(getHelper()));
+                new WaitingSchemaConnectorStepPanel(getHelper()));
     }
 
     @Override

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/component/wizard/scimrest/connection/WaitingSchemaConnectorStepPanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/component/wizard/scimrest/connection/WaitingSchemaConnectorStepPanel.java
@@ -11,7 +11,6 @@ import com.evolveum.midpoint.gui.impl.page.admin.connector.development.Connector
 import com.evolveum.midpoint.gui.impl.page.admin.connector.development.component.wizard.scimrest.WaitingConnectorStepPanel;
 import com.evolveum.midpoint.prism.Containerable;
 import com.evolveum.midpoint.prism.path.ItemName;
-import com.evolveum.midpoint.prism.path.ItemPath;
 import com.evolveum.midpoint.schema.result.OperationResult;
 import com.evolveum.midpoint.smart.api.info.StatusInfo;
 import com.evolveum.midpoint.task.api.Task;
@@ -27,36 +26,37 @@ import org.apache.wicket.model.Model;
 import org.jetbrains.annotations.NotNull;
 
 /**
- * Waiting step panel that triggers SCIM schema refresh (object class discovery from shadows)
- * after resource test succeeds. Only visible for SCIM connectors.
+ * Waiting step panel that triggers connector-agnostic schema discovery (reading {@code conndev_ObjectClass}
+ * from shadows) after the resource test succeeds. Connectors that expose no such object class (e.g. plain
+ * REST) simply finish this step immediately with no documentation produced.
  */
-@PanelType(name = "cdw-connector-waiting-scim-schema")
-@PanelInstance(identifier = "cdw-connector-waiting-scim-schema",
+@PanelType(name = "cdw-connector-waiting-schema")
+@PanelInstance(identifier = "cdw-connector-waiting-schema",
         applicableForType = ConnectorDevelopmentType.class,
         applicableForOperation = OperationTypeType.WIZARD,
-        display = @PanelDisplay(label = "PageConnectorDevelopment.wizard.step.connectorWaitingScimSchema", icon = "fa fa-database"),
+        display = @PanelDisplay(label = "PageConnectorDevelopment.wizard.step.connectorWaitingSchema", icon = "fa fa-database"),
         containerPath = "empty")
-public class WaitingScimSchemaConnectorStepPanel extends WaitingConnectorStepPanel {
+public class WaitingSchemaConnectorStepPanel extends WaitingConnectorStepPanel {
 
-    private static final String PANEL_TYPE = "cdw-connector-waiting-scim-schema";
+    private static final String PANEL_TYPE = "cdw-connector-waiting-schema";
 
-    public WaitingScimSchemaConnectorStepPanel(WizardPanelHelper<? extends Containerable, ConnectorDevelopmentDetailsModel> helper) {
+    public WaitingSchemaConnectorStepPanel(WizardPanelHelper<? extends Containerable, ConnectorDevelopmentDetailsModel> helper) {
         super(helper);
     }
 
     @Override
     protected ItemName getActivityType() {
-        return WorkDefinitionsType.F_REFRESH_SCIM_SCHEMA;
+        return WorkDefinitionsType.F_REFRESH_SCHEMA;
     }
 
     @Override
     protected StatusInfo<?> obtainResult(String token, Task task, OperationResult result) throws SchemaException, ObjectNotFoundException {
-        return getDetailsModel().getServiceLocator().getConnectorService().getRefreshScimSchemaStatus(token, task, result);
+        return getDetailsModel().getServiceLocator().getConnectorService().getRefreshSchemaStatus(token, task, result);
     }
 
     @Override
     protected String getNewTaskToken(Task task, OperationResult result, boolean regenerate) {
-        return getDetailsModel().getConnectorDevelopmentOperation().submitRefreshScimSchema(task, result);
+        return getDetailsModel().getConnectorDevelopmentOperation().submitRefreshSchema(task, result);
     }
 
     @Override
@@ -71,40 +71,21 @@ public class WaitingScimSchemaConnectorStepPanel extends WaitingConnectorStepPan
 
     @Override
     public IModel<String> getTitle() {
-        return createStringResource("PageConnectorDevelopment.wizard.step.connectorWaitingScimSchema");
+        return createStringResource("PageConnectorDevelopment.wizard.step.connectorWaitingSchema");
     }
 
     @Override
     protected IModel<?> getTextModel() {
-        return createStringResource("PageConnectorDevelopment.wizard.step.connectorWaitingScimSchema.text");
+        return createStringResource("PageConnectorDevelopment.wizard.step.connectorWaitingSchema.text");
     }
 
     @Override
     protected IModel<?> getSubTextModel() {
-        return createStringResource("PageConnectorDevelopment.wizard.step.connectorWaitingScimSchema.subText");
+        return createStringResource("PageConnectorDevelopment.wizard.step.connectorWaitingSchema.subText");
     }
 
     @Override
     protected @NotNull Model<String> getIconModel() {
         return Model.of("fa fa-database");
-    }
-
-    @Override
-    public IModel<Boolean> isStepVisible() {
-        if (!isScim()) {
-            return Model.of(false);
-        }
-        return super.isStepVisible();
-    }
-
-    private boolean isScim() {
-        try {
-            var integrationType = getDetailsModel().getObjectWrapper().findProperty(
-                    ItemPath.create(ConnectorDevelopmentType.F_CONNECTOR, ConnDevConnectorType.F_INTEGRATION_TYPE));
-            return integrationType != null
-                    && ConnDevIntegrationType.SCIM.equals(integrationType.getValue().getRealValue());
-        } catch (SchemaException e) {
-            return false;
-        }
     }
 }

--- a/infra/schema/src/main/java/com/evolveum/midpoint/schema/util/task/work/WorkDefinitionUtil.java
+++ b/infra/schema/src/main/java/com/evolveum/midpoint/schema/util/task/work/WorkDefinitionUtil.java
@@ -87,7 +87,7 @@ public class WorkDefinitionUtil {
         addTypedParameters(values, definitions.getDiscoverObjectClassEndpoints());
         addTypedParameters(values, definitions.getDiscoverConnectivityEndpoint());
         addTypedParameters(values, definitions.getGenerateConnectorArtifact());
-        addTypedParameters(values, definitions.getRefreshScimSchema());
+        addTypedParameters(values, definitions.getRefreshSchema());
 
         addUntypedParameters(values, definitions.getExtension());
         return values;

--- a/infra/schema/src/main/resources/xml/ns/public/common/common-smart-integration-3.xsd
+++ b/infra/schema/src/main/resources/xml/ns/public/common/common-smart-integration-3.xsd
@@ -1663,7 +1663,7 @@
             <xsd:element name="connDevDiscoverObjectClassInformationResult" type="tns:ConnDevDiscoverObjectClassInformationResultType" minOccurs="0" />
             <xsd:element name="connDevDiscoverObjectClassAttributesResult" type="tns:ConnDevDiscoverObjectClassAttributesResultType" minOccurs="0" />
             <xsd:element name="connDevDiscoverObjectClassEndpointsResult" type="tns:ConnDevDiscoverObjectClassEndpointsResultType" minOccurs="0" />
-            <xsd:element name="connDevRefreshScimSchemaResult" type="tns:ConnDevRefreshScimSchemaResultType" minOccurs="0" />
+            <xsd:element name="connDevRefreshSchemaResult" type="tns:ConnDevRefreshSchemaResultType" minOccurs="0" />
             <xsd:element name="connDevDiscoverConnectivityEndpointResult" type="tns:ConnDevDiscoverConnectivityEndpointResultType" minOccurs="0" />
         </xsd:sequence>
     </xsd:complexType>

--- a/infra/schema/src/main/resources/xml/ns/public/common/common-tasks-3.xsd
+++ b/infra/schema/src/main/resources/xml/ns/public/common/common-tasks-3.xsd
@@ -2586,7 +2586,7 @@
                     </xsd:annotation>
                 </xsd:element>
 
-                <xsd:element name="refreshScimSchema" type="tns:ConnDevRefreshScimSchemaWorkDefinitionType">
+                <xsd:element name="refreshSchema" type="tns:ConnDevRefreshSchemaWorkDefinitionType">
                     <xsd:annotation>
                         <xsd:appinfo>
                             <a:since>4.11</a:since>
@@ -11453,25 +11453,25 @@
         </xsd:sequence>
     </xsd:complexType>
 
-    <!-- Refresh SCIM Schema -->
+    <!-- Refresh Schema -->
 
-    <xsd:complexType name="ConnDevRefreshScimSchemaWorkDefinitionType">
+    <xsd:complexType name="ConnDevRefreshSchemaWorkDefinitionType">
         <xsd:complexContent>
             <xsd:extension base="tns:ConnDevBaseWorkDefinitionType"/>
         </xsd:complexContent>
     </xsd:complexType>
 
-    <xsd:complexType name="ConnDevRefreshScimSchemaWorkStateType">
+    <xsd:complexType name="ConnDevRefreshSchemaWorkStateType">
         <xsd:complexContent>
             <xsd:extension base="tns:AbstractActivityWorkStateType">
                 <xsd:sequence>
-                    <xsd:element name="result" type="tns:ConnDevRefreshScimSchemaResultType"/>
+                    <xsd:element name="result" type="tns:ConnDevRefreshSchemaResultType"/>
                 </xsd:sequence>
             </xsd:extension>
         </xsd:complexContent>
     </xsd:complexType>
 
-    <xsd:complexType name="ConnDevRefreshScimSchemaResultType">
+    <xsd:complexType name="ConnDevRefreshSchemaResultType">
         <xsd:sequence/>
     </xsd:complexType>
 

--- a/model/model-api/src/main/java/com/evolveum/midpoint/model/api/util/ConnectorGeneratorConstants.java
+++ b/model/model-api/src/main/java/com/evolveum/midpoint/model/api/util/ConnectorGeneratorConstants.java
@@ -28,8 +28,8 @@ public class ConnectorGeneratorConstants {
     public static final String RPC_DISCOVER_OBJECT_CLASS_ENDPOINTS_SUBMIT_OPERATION = "/rpc/discoverObjectClassEndpointsSubmitOperation";
     public static final String RPC_DISCOVER_OBJECT_CLASS_ENDPOINTS_STATUS_INFO = "/rpc/discoverObjectClassEndpointsStatusInfo";
 
-    public static final String RPC_REFRESH_SCIM_SCHEMA_SUBMIT_OPERATION = "/rpc/refreshScimSchemaSubmitOperation";
-    public static final String RPC_REFRESH_SCIM_SCHEMA_STATUS_INFO = "/rpc/refreshScimSchemaStatusInfo";
+    public static final String RPC_REFRESH_SCHEMA_SUBMIT_OPERATION = "/rpc/refreshSchemaSubmitOperation";
+    public static final String RPC_REFRESH_SCHEMA_STATUS_INFO = "/rpc/refreshSchemaStatusInfo";
 
     public static final String RPC_DISCOVER_CONNECTIVITY_ENDPOINT_SUBMIT_OPERATION = "/rpc/discoverConnectivityEndpointSubmitOperation";
     public static final String RPC_DISCOVER_CONNECTIVITY_ENDPOINT_STATUS_INFO = "/rpc/discoverConnectivityEndpointStatusInfo";

--- a/model/rest-impl/src/main/java/com/evolveum/midpoint/rest/impl/ConnectorDevelopmentRestController.java
+++ b/model/rest-impl/src/main/java/com/evolveum/midpoint/rest/impl/ConnectorDevelopmentRestController.java
@@ -436,8 +436,8 @@ public class ConnectorDevelopmentRestController extends AbstractRestController {
             abstractSmartIntegrationOperationResultType.setConnDevDiscoverObjectClassAttributesResult(connDevDiscoverObjectClassAttributesResultType);
         } else if (statusInfo.getResult() instanceof ConnDevDiscoverObjectClassEndpointsResultType connDevDiscoverObjectClassEndpointsResultType) {
             abstractSmartIntegrationOperationResultType.setConnDevDiscoverObjectClassEndpointsResult(connDevDiscoverObjectClassEndpointsResultType);
-        } else if (statusInfo.getResult() instanceof ConnDevRefreshScimSchemaResultType connDevRefreshScimSchemaResultType) {
-            abstractSmartIntegrationOperationResultType.setConnDevRefreshScimSchemaResult(connDevRefreshScimSchemaResultType);
+        } else if (statusInfo.getResult() instanceof ConnDevRefreshSchemaResultType connDevRefreshSchemaResultType) {
+            abstractSmartIntegrationOperationResultType.setConnDevRefreshSchemaResult(connDevRefreshSchemaResultType);
         } else if (statusInfo.getResult() instanceof ConnDevDiscoverConnectivityEndpointResultType connDevDiscoverConnectivityEndpointResultType) {
             abstractSmartIntegrationOperationResultType.setConnDevDiscoverConnectivityEndpointResult(connDevDiscoverConnectivityEndpointResultType);
         }

--- a/model/smart-api/src/main/java/com/evolveum/midpoint/smart/api/conndev/ConnectorDevelopmentOperation.java
+++ b/model/smart-api/src/main/java/com/evolveum/midpoint/smart/api/conndev/ConnectorDevelopmentOperation.java
@@ -187,5 +187,5 @@ public interface ConnectorDevelopmentOperation {
 
     void authenticationSelectionUpdated(Task task, OperationResult result) throws SchemaException, ExpressionEvaluationException, CommunicationException, SecurityViolationException, ConfigurationException, ObjectNotFoundException, PolicyViolationException, ObjectAlreadyExistsException;
 
-    String submitRefreshScimSchema(Task task, OperationResult result);
+    String submitRefreshSchema(Task task, OperationResult result);
 }

--- a/model/smart-api/src/main/java/com/evolveum/midpoint/smart/api/conndev/ConnectorDevelopmentService.java
+++ b/model/smart-api/src/main/java/com/evolveum/midpoint/smart/api/conndev/ConnectorDevelopmentService.java
@@ -30,7 +30,7 @@ public interface ConnectorDevelopmentService {
 
     StatusInfo<ConnDevDiscoverObjectClassEndpointsResultType> getDiscoverObjectClassEndpointsStatus(String token, Task task, OperationResult result) throws SchemaException, ObjectNotFoundException;
 
-    StatusInfo<ConnDevRefreshScimSchemaResultType> getRefreshScimSchemaStatus(String token, Task task, OperationResult result) throws SchemaException, ObjectNotFoundException;
+    StatusInfo<ConnDevRefreshSchemaResultType> getRefreshSchemaStatus(String token, Task task, OperationResult result) throws SchemaException, ObjectNotFoundException;
 
     StatusInfo<ConnDevDiscoverConnectivityEndpointResultType> getDiscoverConnectivityEndpointStatus(String token, Task task, OperationResult result) throws SchemaException, ObjectNotFoundException;
 

--- a/model/smart-api/src/main/java/com/evolveum/midpoint/smart/api/conndev/SupportedAuthorization.java
+++ b/model/smart-api/src/main/java/com/evolveum/midpoint/smart/api/conndev/SupportedAuthorization.java
@@ -29,7 +29,7 @@ public enum SupportedAuthorization {
             "JwtSecret",
             "JwtSecretBase64Encoded",
             "JwtPayload",
-            "JwtLocalization"),
+            "JwtLocation"),
     HTTP_APIKEY(ConnDevHttpAuthTypeType.API_KEY, new ConnDevAuthInfoType()
             .name("HTTP API Key Authorization")
             .description("Authorization using preshared API key"),

--- a/model/smart-impl/src/main/java/com/evolveum/midpoint/smart/impl/conndev/ConnDevShadowUnwrapper.java
+++ b/model/smart-impl/src/main/java/com/evolveum/midpoint/smart/impl/conndev/ConnDevShadowUnwrapper.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (C) 2010-2026 Evolveum and contributors
+ *
+ * Licensed under the EUPL-1.2 or later.
+ */
+
+package com.evolveum.midpoint.smart.impl.conndev;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+
+/**
+ * Faithfully unwraps a prism-serialized {@code conndev_*} shadow attributes container into plain JSON
+ * for the connector-generation service. The transformation is purely structural — it strips prism
+ * serialization artifacts and forwards everything else untouched:
+ * <ul>
+ *     <li>{@code @...} metadata entries (e.g. {@code @ns}) are dropped,</li>
+ *     <li>namespace prefixes of keys are stripped ({@code icfs:name} → {@code name}),</li>
+ *     <li>embedded prism objects ({@code { "t:type": "c:ShadowType", "object": { ..., "attributes":
+ *         {...} } }}) are replaced by their {@code object.attributes} content, recursively.</li>
+ * </ul>
+ * There is deliberately <b>no field allow-list</b>: the content of {@code conndev_ObjectClass} is owned
+ * by the connector side (single source of the schema mapping), so midPoint must not interpret it —
+ * SQL/SCIM specifics and any future fields ({@code locator}, native types, ...) flow through unchanged.
+ */
+public class ConnDevShadowUnwrapper {
+
+    private static final JsonNodeFactory NODES = JsonNodeFactory.instance;
+
+    public JsonNode unwrap(JsonNode node) {
+        if (node == null || node.isNull()) {
+            return NODES.nullNode();
+        }
+        if (node.isArray()) {
+            var out = NODES.arrayNode();
+            node.forEach(value -> out.add(unwrap(value)));
+            return out;
+        }
+        if (node.isObject()) {
+            var embedded = embeddedAttributes(node);
+            if (embedded != null) {
+                return unwrap(embedded);
+            }
+            var out = NODES.objectNode();
+            node.fields().forEachRemaining(entry -> {
+                if (entry.getKey().startsWith("@")) {
+                    return;
+                }
+                out.set(localName(entry.getKey()), unwrap(entry.getValue()));
+            });
+            return out;
+        }
+        return node;
+    }
+
+    /**
+     * Detects the prism wrapper of an embedded object value and returns the connector data inside
+     * ({@code object.attributes}); the wrapper itself (type hint, shadow scaffolding) is serialization
+     * noise. Returns {@code null} when the node is a regular object.
+     */
+    private static JsonNode embeddedAttributes(JsonNode node) {
+        var object = node.get("object");
+        if (object != null && object.isObject() && object.has("attributes")) {
+            return object.get("attributes");
+        }
+        return null;
+    }
+
+    private static String localName(String field) {
+        int colon = field.indexOf(':');
+        return colon >= 0 ? field.substring(colon + 1) : field;
+    }
+}

--- a/model/smart-impl/src/main/java/com/evolveum/midpoint/smart/impl/conndev/ConnectorDevelopmentBackend.java
+++ b/model/smart-impl/src/main/java/com/evolveum/midpoint/smart/impl/conndev/ConnectorDevelopmentBackend.java
@@ -2,10 +2,15 @@ package com.evolveum.midpoint.smart.impl.conndev;
 
 import com.evolveum.midpoint.prism.PrismContainer;
 import com.evolveum.midpoint.prism.PrismContext;
+import com.evolveum.midpoint.prism.PrismObject;
 import com.evolveum.midpoint.prism.path.ItemName;
 import com.evolveum.midpoint.prism.path.ItemPath;
+import com.evolveum.midpoint.model.api.util.ResourceUtils;
 import com.evolveum.midpoint.provisioning.ucf.api.EditableConnector;
+import com.evolveum.midpoint.schema.GetOperationOptionsBuilder;
+import com.evolveum.midpoint.schema.constants.SchemaConstants;
 import com.evolveum.midpoint.schema.result.OperationResult;
+import com.evolveum.midpoint.schema.util.Resource;
 import com.evolveum.midpoint.smart.api.conndev.ConnectorDevelopmentArtifacts;
 import com.evolveum.midpoint.smart.api.conndev.SupportedAuthorization;
 import com.evolveum.midpoint.smart.impl.conndev.activity.ConnDevBeans;
@@ -15,18 +20,23 @@ import com.evolveum.midpoint.task.api.Task;
 import com.evolveum.midpoint.util.exception.*;
 import com.evolveum.midpoint.xml.ns._public.common.common_3.*;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import org.apache.hc.client5.http.entity.EntityBuilder;
 import org.apache.hc.core5.http.ContentType;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import javax.xml.namespace.QName;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Properties;
+import java.util.UUID;
 import java.util.function.BooleanSupplier;
 
 public abstract class ConnectorDevelopmentBackend {
@@ -35,6 +45,8 @@ public abstract class ConnectorDevelopmentBackend {
     private static final String CONNECTOR_MANIFEST = "connector.manifest.json";
     private static final String CONFIGURATION_OVERRIDE = "configurationOverride.properties";
     private static final int MAX_SUGGESTED_CONNECTIVITY_ENDPOINTS = 5;
+    private static final String CONNDEV_OBJECT_CLASS = "conndev_ObjectClass";
+    private static final String CONNDEV_CONTENT_TYPE = "application/com.evolveum.conndev+json";
     protected final Task task;
     protected final OperationResult result;
 
@@ -587,7 +599,7 @@ public abstract class ConnectorDevelopmentBackend {
                                 var body = new String(documentation.asInputStream().readAllBytes(), StandardCharsets.UTF_8);
                                 return EntityBuilder.create()
                                         .setText(body)
-                                        .setContentType(ContentType.APPLICATION_JSON)
+                                        .setContentType(ContentType.create(documentation.contentType(), StandardCharsets.UTF_8))
                                         .build();
                             } catch (IOException e) {
                                 throw new SystemException("Couldn't build documentation upload body", e);
@@ -608,6 +620,146 @@ public abstract class ConnectorDevelopmentBackend {
         };
         */
         return documentation.uri();
+    }
+
+    /**
+     * Connector-agnostic dev-schema refresh: refreshes the testing resource, and if it exposes the
+     * shared {@code conndev_ObjectClass} (SCIM/SQL/... in development mode), reads the development
+     * object classes ({@link #devDocumentationObjectClasses()}) and turns their objects into
+     * {@link ProcessedDocumentation}. Classic REST has no schema standard, so it simply does not
+     * expose {@code conndev_ObjectClass} and is skipped — no connector-type branching needed.
+     */
+    public void refreshConnDevDocumentation() throws CommonException {
+        var testing = developmentObject().getTesting();
+        if (testing == null || testing.getTestingResource() == null) {
+            return;
+        }
+        var testingResourceOid = testing.getTestingResource().getOid();
+
+        ResourceUtils.deleteSchema(testingResourceOid, beans.modelService, task, result);
+        beans.provisioningService.testResource(testingResourceOid, task, result);
+
+        if (!exposesConnDevObjectClass(testingResourceOid)) {
+            return; // classic REST, or development mode off — nothing to discover
+        }
+
+        var objectClasses = devDocumentationObjectClasses();
+        var newDocs = objectClasses.stream()
+                .flatMap(objectClass -> loadShadowsAsDocumentation(testingResourceOid, objectClass).stream())
+                .map(ProcessedDocumentation::toBean)
+                .toList();
+
+        var mergedDocs = new ArrayList<>(
+                developmentObject().getProcessedDocumentation().stream()
+                        .filter(d -> objectClasses.stream().noneMatch(c -> d.getUri().startsWith(c)))
+                        .map(ProcessedDocumentationType::clone)
+                        .toList());
+        mergedDocs.addAll(newDocs);
+
+        var delta = PrismContext.get().deltaFor(ConnectorDevelopmentType.class)
+                .item(ConnectorDevelopmentType.F_PROCESSED_DOCUMENTATION)
+                .replaceRealValues(mergedDocs)
+                .<ConnectorDevelopmentType>asObjectDelta(developmentObject().getOid());
+        beans.modelService.executeChanges(List.of(delta), null, task, result);
+        reload();
+    }
+
+    /**
+     * Development object classes whose objects are forwarded as documentation: the shared
+     * {@code conndev_ObjectClass} for every connector; backends may add their own raw exports
+     * (e.g. SCIM adds {@code conndev_ScimSchema}/{@code conndev_ScimResource}).
+     */
+    protected List<String> devDocumentationObjectClasses() {
+        return List.of(CONNDEV_OBJECT_CLASS);
+    }
+
+    private boolean exposesConnDevObjectClass(String resourceOid) {
+        try {
+            var resource = beans.modelService.getObject(ResourceType.class, resourceOid, null, task, result).asObjectable();
+            var schema = Resource.of(resource).getCompleteSchema();
+            return schema != null
+                    && schema.findObjectClassDefinition(new QName(SchemaConstants.NS_RI, CONNDEV_OBJECT_CLASS)) != null;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    /**
+     * Loads shadows of a given {@code conndev_*} object class from a testing resource and forwards each
+     * as a {@link ProcessedDocumentation}, faithfully: the shadow content is only structurally unwrapped
+     * from prism serialization ({@link ConnDevShadowUnwrapper}), never interpreted — the connector owns
+     * the schema-mapping content (single source), midPoint reads only the name (for uri/uuid).
+     * Connector-agnostic core: any connector exposing {@code conndev_ObjectClass} (SCIM, SQL, ...) works
+     * unchanged, including future fields.
+     */
+    protected List<ProcessedDocumentation> loadShadowsAsDocumentation(String resourceOid, String objectClassLocalName) {
+        try {
+            var objectClass = new QName(SchemaConstants.NS_RI, objectClassLocalName);
+            var query = PrismContext.get().queryFor(ShadowType.class)
+                    .item(ShadowType.F_RESOURCE_REF).ref(resourceOid)
+                    .and().item(ShadowType.F_OBJECT_CLASS).eq(objectClass)
+                    .build();
+
+            // Associations must not be fetched: the embedded reference values have no OID/identifiers,
+            // so the validity checker would fail them with "No effective operation policy".
+            var options = GetOperationOptionsBuilder.create()
+                    .item(ShadowType.F_ASSOCIATIONS).dontRetrieve()
+                    .build();
+            var shadows = beans.provisioningService.searchObjects(ShadowType.class, query, options, task, result);
+            if (shadows.isEmpty()) {
+                return List.of();
+            }
+
+            var serializer = PrismContext.get().jsonSerializer();
+            var mapper = new ObjectMapper();
+            var writer = mapper.writerWithDefaultPrettyPrinter();
+            var unwrapper = new ConnDevShadowUnwrapper();
+            var docs = new ArrayList<ProcessedDocumentation>();
+            for (var shadow : shadows) {
+                var attrs = shadow.findContainer(ShadowType.F_ATTRIBUTES);
+                if (attrs == null || attrs.isEmpty()) {
+                    continue;
+                }
+
+                var json = serializer.serialize(attrs.getValue());
+                var attributesContainer = mapper.readTree(json).get("attributes");
+                if (attributesContainer == null) {
+                    continue;
+                }
+
+                var document = unwrapper.unwrap(attributesContainer);
+                var content = writer.writeValueAsString(document);
+
+                var name = resolveDocName(shadow, document);
+                var uri = objectClassLocalName + "_" + name + ".json";
+                var uuid = UUID.nameUUIDFromBytes(uri.getBytes(StandardCharsets.UTF_8)).toString();
+                var doc = new ProcessedDocumentation(uuid, uri).contentType(CONNDEV_CONTENT_TYPE);
+                doc.write(content);
+                docs.add(doc);
+            }
+            return docs;
+        } catch (Exception e) {
+            throw new SystemException("Could not load shadow documentation for " + objectClassLocalName, e);
+        }
+    }
+
+    /**
+     * Human-readable name for a dev shadow: the discovered object class name (the unwrapped
+     * {@code icfs:name}), then the shadow's own name (__NAME__), finally the OID. This is the only
+     * piece of the forwarded content midPoint reads — everything else is passed through untouched.
+     */
+    protected String resolveDocName(PrismObject<ShadowType> shadow, JsonNode document) {
+        var name = document.path("name");
+        if (name.isArray() && !name.isEmpty()) {
+            name = name.get(0);
+        }
+        if (name.isTextual() && !name.asText().isBlank()) {
+            return name.asText();
+        }
+        if (shadow.getName() != null && shadow.getName().getOrig() != null) {
+            return shadow.getName().getOrig();
+        }
+        return shadow.getOid();
     }
 
 }

--- a/model/smart-impl/src/main/java/com/evolveum/midpoint/smart/impl/conndev/ConnectorDevelopmentBackend.java
+++ b/model/smart-impl/src/main/java/com/evolveum/midpoint/smart/impl/conndev/ConnectorDevelopmentBackend.java
@@ -518,7 +518,11 @@ public abstract class ConnectorDevelopmentBackend {
             endpointEntry.set("type", JSON_FACTORY.textNode("constant"));
             var endpointsArray = JSON_FACTORY.arrayNode();
             endpointsArray.add(endpointEntry);
-            infoMetadata.set("baseApiEndpoint", endpointsArray);
+            var availability = JSON_FACTORY.objectNode();
+            availability.set("baseApiEndpoint", endpointsArray);
+            var availabilityKey = app.getIntegrationType() == ConnDevIntegrationType.SCIM
+                    ? "scimAvailability" : "restAvailability";
+            infoMetadata.set(availabilityKey, availability);
         }
 
         var body = JSON_FACTORY.objectNode();

--- a/model/smart-impl/src/main/java/com/evolveum/midpoint/smart/impl/conndev/ConnectorDevelopmentServiceImpl.java
+++ b/model/smart-impl/src/main/java/com/evolveum/midpoint/smart/impl/conndev/ConnectorDevelopmentServiceImpl.java
@@ -268,9 +268,9 @@ public class ConnectorDevelopmentServiceImpl implements ConnectorDevelopmentServ
         }
 
         @Override
-        public String submitRefreshScimSchema(Task task, OperationResult result) {
-            return submitTask("Refreshing SCIM schema for " + connectorNameForTasks(),
-                    new WorkDefinitionsType().refreshScimSchema(new ConnDevRefreshScimSchemaWorkDefinitionType()
+        public String submitRefreshSchema(Task task, OperationResult result) {
+            return submitTask("Refreshing schema for " + connectorNameForTasks(),
+                    new WorkDefinitionsType().refreshSchema(new ConnDevRefreshSchemaWorkDefinitionType()
                             .connectorDevelopmentRef(stateObject.getOid(), ConnectorDevelopmentType.COMPLEX_TYPE)
                     ), task, result);
         }
@@ -385,11 +385,11 @@ public class ConnectorDevelopmentServiceImpl implements ConnectorDevelopmentServ
     }
 
     @Override
-    public StatusInfo<ConnDevRefreshScimSchemaResultType> getRefreshScimSchemaStatus(String token, Task task, OperationResult result) throws SchemaException, ObjectNotFoundException {
+    public StatusInfo<ConnDevRefreshSchemaResultType> getRefreshSchemaStatus(String token, Task task, OperationResult result) throws SchemaException, ObjectNotFoundException {
         return new StatusInfoImpl<>(
                 getTask(token, result),
-                ConnDevRefreshScimSchemaWorkStateType.F_RESULT,
-                ConnDevRefreshScimSchemaResultType.class
+                ConnDevRefreshSchemaWorkStateType.F_RESULT,
+                ConnDevRefreshSchemaResultType.class
         );
     }
 

--- a/model/smart-impl/src/main/java/com/evolveum/midpoint/smart/impl/conndev/ProcessedDocumentation.java
+++ b/model/smart-impl/src/main/java/com/evolveum/midpoint/smart/impl/conndev/ProcessedDocumentation.java
@@ -33,6 +33,11 @@ public class ProcessedDocumentation {
         storage = new File(directory, uuid);
     }
 
+    ProcessedDocumentation contentType(String contentType) {
+        this.mimeType = contentType;
+        return this;
+    }
+
     public InputStream asInputStream() throws FileNotFoundException {
         return new FileInputStream(storage);
     }

--- a/model/smart-impl/src/main/java/com/evolveum/midpoint/smart/impl/conndev/RestBackend.java
+++ b/model/smart-impl/src/main/java/com/evolveum/midpoint/smart/impl/conndev/RestBackend.java
@@ -12,6 +12,7 @@ import com.evolveum.midpoint.util.logging.Trace;
 import com.evolveum.midpoint.util.logging.TraceManager;
 import com.evolveum.midpoint.xml.ns._public.common.common_3.*;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
@@ -38,7 +39,7 @@ public class RestBackend extends ConnectorDevelopmentBackend {
             return job.waitAndProcess(SLEEP_TIME, canRun(), o -> {
                 var ret = new ConnDevApplicationInfoType();
 
-                var jsonInfo = o.get("infoMetadata");
+                var jsonInfo = o.path("infoMetadata");
                 if (jsonInfo.isEmpty()) {
                     // Should we re
                     return ret;
@@ -52,10 +53,10 @@ public class RestBackend extends ConnectorDevelopmentBackend {
                 if (jsonInfo.get("apiVersion") != null) {
                     ret.apiVersion(jsonInfo.get("apiVersion").asText());
                 }
-                // FIXME for proper detection
-                ret.integrationType(ConnDevIntegrationType.REST);
-                if (jsonInfo.get("baseApiEndpoint") != null && jsonInfo.get("baseApiEndpoint").get(0) != null) {
-                    ret.baseApiEndpoint(jsonInfo.get("baseApiEndpoint").get(0).get("uri").asText());
+                ret.integrationType(integrationTypeOf(jsonInfo));
+                var baseApiEndpoint = baseApiEndpointOf(jsonInfo);
+                if (baseApiEndpoint != null) {
+                    ret.baseApiEndpoint(baseApiEndpoint);
                 }
                 // FIXME: Add dynamic
                 return ret;
@@ -63,6 +64,44 @@ public class RestBackend extends ConnectorDevelopmentBackend {
         } catch (Exception e) {
             throw new SystemException("Couldn't discover basic application information", e);
         }
+    }
+
+    /**
+     * The digester reports the supported API styles in {@code apiType} (e.g. {@code ["rest","scim"]}).
+     * When an application supports both, REST is preferred (the historical default); pure-SCIM
+     * applications get SCIM. Missing/unknown values keep the REST default.
+     */
+    private static ConnDevIntegrationType integrationTypeOf(JsonNode jsonInfo) {
+        var apiType = jsonInfo.path("apiType");
+        if (apiType.isArray()) {
+            for (var type : apiType) {
+                if ("rest".equalsIgnoreCase(type.asText())) {
+                    return ConnDevIntegrationType.REST;
+                }
+            }
+            for (var type : apiType) {
+                if ("scim".equalsIgnoreCase(type.asText())) {
+                    return ConnDevIntegrationType.SCIM;
+                }
+            }
+        }
+        return ConnDevIntegrationType.REST;
+    }
+
+    /**
+     * The base API endpoint moved from the top level of {@code infoMetadata} into the per-style
+     * availability blocks ({@code restAvailability}/{@code scimAvailability}); the old top-level
+     * location is still read as a fallback for older digesters.
+     */
+    private static String baseApiEndpointOf(JsonNode jsonInfo) {
+        for (var container : List.of(
+                jsonInfo.path("restAvailability"), jsonInfo.path("scimAvailability"), jsonInfo)) {
+            var uri = container.path("baseApiEndpoint").path(0).path("uri");
+            if (uri.isTextual() && !uri.asText().isBlank()) {
+                return uri.asText();
+            }
+        }
+        return null;
     }
 
     private ProcessedDocumentation selectBestDocumentation(List<ProcessedDocumentation> processedDocumentation) {

--- a/model/smart-impl/src/main/java/com/evolveum/midpoint/smart/impl/conndev/RestBackend.java
+++ b/model/smart-impl/src/main/java/com/evolveum/midpoint/smart/impl/conndev/RestBackend.java
@@ -268,6 +268,17 @@ public class RestBackend extends ConnectorDevelopmentBackend {
         return beans.client(sessionId(), this::restoreSession, this::synchronizeSession, result);
     }
 
+    /**
+     * REST/SCIM backends additionally push the freshly saved documentation to the connector-generation
+     * service. The upload is idempotent (HEAD-guarded {@code putDocumentationIfMissing}), and with stable
+     * documentation UUIDs it uploads only genuinely new/changed docs.
+     */
+    @Override
+    public void refreshConnDevDocumentation() throws CommonException {
+        super.refreshConnDevDocumentation();
+        ensureDocumentationIsUploaded(client().synchronizationClient());
+    }
+
 
     @Override
     public List<ConnDevBasicObjectClassInfoType> discoverObjectClassesUsingDocumentation(List<ConnDevBasicObjectClassInfoType> connectorDiscovered, boolean includeUnrelated, boolean skipCache) {

--- a/model/smart-impl/src/main/java/com/evolveum/midpoint/smart/impl/conndev/ScimBackend.java
+++ b/model/smart-impl/src/main/java/com/evolveum/midpoint/smart/impl/conndev/ScimBackend.java
@@ -1,135 +1,34 @@
 package com.evolveum.midpoint.smart.impl.conndev;
 
-import com.evolveum.midpoint.model.api.util.ResourceUtils;
-import com.evolveum.midpoint.prism.PrismContext;
-import com.evolveum.midpoint.prism.path.ItemPath;
-import com.evolveum.midpoint.schema.constants.SchemaConstants;
 import com.evolveum.midpoint.schema.result.OperationResult;
-import com.evolveum.midpoint.smart.api.conndev.ScimRestConfigurationProperties;
-import com.evolveum.midpoint.util.logging.Trace;
-import com.evolveum.midpoint.util.logging.TraceManager;
 import com.evolveum.midpoint.smart.impl.conndev.activity.ConnDevBeans;
 import com.evolveum.midpoint.task.api.Task;
-import com.evolveum.midpoint.util.exception.*;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.evolveum.midpoint.xml.ns._public.common.common_3.ConnectorDevelopmentType;
-import com.evolveum.midpoint.xml.ns._public.common.common_3.ProcessedDocumentationType;
-import com.evolveum.midpoint.xml.ns._public.common.common_3.ResourceType;
-import com.evolveum.midpoint.xml.ns._public.common.common_3.ShadowType;
 
-import javax.xml.namespace.QName;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.UUID;
 
+/**
+ * SCIM backend. Schema discovery is connector-agnostic and lives in {@link ConnectorDevelopmentBackend}
+ * (via the shared {@code conndev_ObjectClass} dev model); on top of that the SCIM connector exports the
+ * raw discovered schema ({@code conndev_ScimSchema}/{@code conndev_ScimResource} — full /Schemas and
+ * /ResourceTypes JSON), which is forwarded to the generation service as well: it carries details the
+ * precomputed mapping does not (complex attributes, extension schemas).
+ */
 public class ScimBackend extends RestBackend {
 
-    private static final Trace LOGGER = TraceManager.getTrace(ScimBackend.class);
-
-    private static final List<String> SCIM_OBJECT_CLASSES = List.of("conndev_ScimSchema", "conndev_ScimResource");
+    private static final String CONNDEV_SCIM_SCHEMA = "conndev_ScimSchema";
+    private static final String CONNDEV_SCIM_RESOURCE = "conndev_ScimResource";
 
     public ScimBackend(ConnDevBeans beans, ConnectorDevelopmentType connDev, Task task, OperationResult result) {
         super(beans, connDev, task, result);
     }
 
-    public void refreshScimDocumentation() throws SchemaException, ExpressionEvaluationException, CommunicationException, SecurityViolationException, ConfigurationException, ObjectNotFoundException, PolicyViolationException, ObjectAlreadyExistsException {
-        var testingResourceOid = getTestingResourceOid();
-
-        if (!isScimDiscoveryConfigured(testingResourceOid)) {
-            LOGGER.info("Testing resource {} is not configured for SCIM discovery (missing scimBaseUrl or developmentMode), skipping", testingResourceOid);
-            return;
-        }
-
-        LOGGER.info("Starting SCIM schema discovery from shadows on testing resource {}", testingResourceOid);
-        ResourceUtils.deleteSchema(testingResourceOid, beans.modelService, task, result);
-        beans.provisioningService.testResource(testingResourceOid, task, result);
-
-        var newScimDocs = SCIM_OBJECT_CLASSES
-                .stream()
-                .flatMap(objectClass -> loadShadowsAsDocumentation(testingResourceOid, objectClass).stream())
-                .map(ProcessedDocumentation::toBean)
-                .toList();
-
-        var mergedDocs = new ArrayList<>(
-                developmentObject()
-                        .getProcessedDocumentation()
-                        .stream()
-                        .filter(d -> SCIM_OBJECT_CLASSES.stream().noneMatch(c -> d.getUri().startsWith(c)))
-                        .map(ProcessedDocumentationType::clone)
-                        .toList()
-        );
-        mergedDocs.addAll(newScimDocs);
-
-        var delta = PrismContext.get().deltaFor(ConnectorDevelopmentType.class)
-                .item(ConnectorDevelopmentType.F_PROCESSED_DOCUMENTATION)
-                .replaceRealValues(mergedDocs)
-                .<ConnectorDevelopmentType>asObjectDelta(developmentObject().getOid());
-        beans.modelService.executeChanges(List.of(delta), null, task, result);
-        reload();
-        ensureDocumentationIsUploaded(client().synchronizationClient());
-    }
-
-    private List<ProcessedDocumentation> loadShadowsAsDocumentation(String resourceOid, String objectClassLocalName) {
-        try {
-            var objectClass = new QName(SchemaConstants.NS_RI, objectClassLocalName);
-            var query = PrismContext.get().queryFor(ShadowType.class)
-                    .item(ShadowType.F_RESOURCE_REF).ref(resourceOid)
-                    .and().item(ShadowType.F_OBJECT_CLASS).eq(objectClass)
-                    .build();
-
-            var shadows = beans.provisioningService.searchObjects(ShadowType.class, query, null, task, result);
-            if (shadows.isEmpty()) {
-                LOGGER.warn("No shadows found for object class {} on resource {}", objectClassLocalName, resourceOid);
-                return List.of();
-            }
-
-            var serializer = PrismContext.get().jsonSerializer();
-            var mapper = new ObjectMapper();
-            var docs = new ArrayList<ProcessedDocumentation>();
-            for (var shadow : shadows) {
-                var attrs = shadow.findContainer(ShadowType.F_ATTRIBUTES);
-                if (attrs != null && !attrs.isEmpty()) {
-                    var json = serializer.serialize(attrs.getValue());
-                    var parsedAttrs = mapper.readTree(json).get("attributes");
-                    var idNode = parsedAttrs.get("id");
-                    var name = idNode != null
-                            ? idNode.asText()
-                            : shadow.getOid();
-                    var doc = new ProcessedDocumentation(UUID.randomUUID().toString(), objectClassLocalName + "_" + name);
-                    doc.write(parsedAttrs.toString());
-                    docs.add(doc);
-                }
-            }
-            return docs;
-        } catch (Exception e) {
-            throw new SystemException("Could not load shadow documentation for " + objectClassLocalName, e);
-        }
-    }
-
-    private String getTestingResourceOid() {
-        var testing = developmentObject().getTesting();
-        if (testing == null || testing.getTestingResource() == null) {
-            throw new SystemException("No testing resource configured");
-        }
-        return testing.getTestingResource().getOid();
-    }
-
-    private boolean isScimDiscoveryConfigured(String testingResourceOid) {
-        try {
-            var resource = beans.modelService.getObject(ResourceType.class, testingResourceOid, null, task, result).asObjectable();
-            var connectorConfig = ItemPath.create(ResourceType.F_CONNECTOR_CONFIGURATION, SchemaConstants.ICF_CONFIGURATION_PROPERTIES_LOCAL_NAME);
-
-            var scimBaseUrl = resource.asPrismObject().findProperty(ItemPath.create(connectorConfig, ScimRestConfigurationProperties.SCIM_BASE_URL));
-            var developmentMode = resource.asPrismObject().findProperty(ItemPath.create(connectorConfig, ScimRestConfigurationProperties.DEVELOPMENT_MODE));
-
-            var hasScimBaseUrl = scimBaseUrl != null && scimBaseUrl.getRealValue() != null
-                    && !((String) scimBaseUrl.getRealValue()).isBlank();
-            var hasDevelopmentMode = developmentMode != null && Boolean.TRUE.equals(developmentMode.getRealValue());
-
-            return hasScimBaseUrl && hasDevelopmentMode;
-        } catch (Exception e) {
-            LOGGER.warn("Could not check configuration on testing resource {}: {}", testingResourceOid, e.getMessage());
-            return false;
-        }
+    @Override
+    protected List<String> devDocumentationObjectClasses() {
+        var objectClasses = new ArrayList<>(super.devDocumentationObjectClasses());
+        objectClasses.add(CONNDEV_SCIM_SCHEMA);
+        objectClasses.add(CONNDEV_SCIM_RESOURCE);
+        return objectClasses;
     }
 }

--- a/model/smart-impl/src/main/java/com/evolveum/midpoint/smart/impl/conndev/activity/RefreshSchemaActivityHandler.java
+++ b/model/smart-impl/src/main/java/com/evolveum/midpoint/smart/impl/conndev/activity/RefreshSchemaActivityHandler.java
@@ -6,12 +6,11 @@ import com.evolveum.midpoint.repo.common.activity.run.ActivityRunInstantiationCo
 import com.evolveum.midpoint.repo.common.activity.run.ActivityRunResult;
 import com.evolveum.midpoint.repo.common.activity.run.LocalActivityRun;
 import com.evolveum.midpoint.schema.result.OperationResult;
-import com.evolveum.midpoint.smart.impl.conndev.ScimBackend;
 import com.evolveum.midpoint.smart.impl.conndev.ConnectorDevelopmentBackend;
 import com.evolveum.midpoint.util.exception.CommonException;
 import com.evolveum.midpoint.util.exception.ConfigurationException;
-import com.evolveum.midpoint.xml.ns._public.common.common_3.ConnDevRefreshScimSchemaWorkDefinitionType;
-import com.evolveum.midpoint.xml.ns._public.common.common_3.ConnDevRefreshScimSchemaWorkStateType;
+import com.evolveum.midpoint.xml.ns._public.common.common_3.ConnDevRefreshSchemaWorkDefinitionType;
+import com.evolveum.midpoint.xml.ns._public.common.common_3.ConnDevRefreshSchemaWorkStateType;
 import com.evolveum.midpoint.xml.ns._public.common.common_3.FocusTypeSuggestionWorkStateType;
 import com.evolveum.midpoint.xml.ns._public.common.common_3.WorkDefinitionsType;
 
@@ -19,35 +18,35 @@ import org.jetbrains.annotations.NotNull;
 import org.springframework.stereotype.Component;
 
 @Component
-public class RefreshScimSchemaActivityHandler
-        extends AbstractConnDevActivityHandler<RefreshScimSchemaActivityHandler.WorkDefinition, RefreshScimSchemaActivityHandler> {
+public class RefreshSchemaActivityHandler
+        extends AbstractConnDevActivityHandler<RefreshSchemaActivityHandler.WorkDefinition, RefreshSchemaActivityHandler> {
 
-    public RefreshScimSchemaActivityHandler() {
+    public RefreshSchemaActivityHandler() {
         super(
-                ConnDevRefreshScimSchemaWorkDefinitionType.COMPLEX_TYPE,
-                WorkDefinitionsType.F_REFRESH_SCIM_SCHEMA,
-                ConnDevRefreshScimSchemaWorkStateType.COMPLEX_TYPE,
-                RefreshScimSchemaActivityHandler.WorkDefinition.class,
-                RefreshScimSchemaActivityHandler.WorkDefinition::new);
+                ConnDevRefreshSchemaWorkDefinitionType.COMPLEX_TYPE,
+                WorkDefinitionsType.F_REFRESH_SCHEMA,
+                ConnDevRefreshSchemaWorkStateType.COMPLEX_TYPE,
+                RefreshSchemaActivityHandler.WorkDefinition.class,
+                RefreshSchemaActivityHandler.WorkDefinition::new);
     }
 
     @Override
-    public AbstractActivityRun<WorkDefinition, RefreshScimSchemaActivityHandler, ?> createActivityRun(
-            @NotNull ActivityRunInstantiationContext<WorkDefinition, RefreshScimSchemaActivityHandler> context,
+    public AbstractActivityRun<WorkDefinition, RefreshSchemaActivityHandler, ?> createActivityRun(
+            @NotNull ActivityRunInstantiationContext<WorkDefinition, RefreshSchemaActivityHandler> context,
             @NotNull OperationResult result) {
         return new MyActivityRun(context);
     }
 
-    public static class WorkDefinition extends AbstractWorkDefinition<ConnDevRefreshScimSchemaWorkDefinitionType> {
+    public static class WorkDefinition extends AbstractWorkDefinition<ConnDevRefreshSchemaWorkDefinitionType> {
         public WorkDefinition(WorkDefinitionFactory.@NotNull WorkDefinitionInfo info) throws ConfigurationException {
             super(info);
         }
     }
 
     public static class MyActivityRun
-            extends LocalActivityRun<WorkDefinition, RefreshScimSchemaActivityHandler, FocusTypeSuggestionWorkStateType> {
+            extends LocalActivityRun<WorkDefinition, RefreshSchemaActivityHandler, FocusTypeSuggestionWorkStateType> {
 
-        MyActivityRun(ActivityRunInstantiationContext<WorkDefinition, RefreshScimSchemaActivityHandler> context) {
+        MyActivityRun(ActivityRunInstantiationContext<WorkDefinition, RefreshSchemaActivityHandler> context) {
             super(context);
             setInstanceReady();
         }
@@ -56,9 +55,7 @@ public class RefreshScimSchemaActivityHandler
         protected @NotNull ActivityRunResult runLocally(OperationResult result) throws CommonException {
             var task = getRunningTask();
             var backend = ConnectorDevelopmentBackend.backendFor(getWorkDefinition().connectorDevelopmentOid, task, result);
-            if (backend instanceof ScimBackend scimBackend) {
-                scimBackend.refreshScimDocumentation();
-            }
+            backend.refreshConnDevDocumentation();
             return ActivityRunResult.success();
         }
     }


### PR DESCRIPTION
conndev-based connectors now export their internal schema in development mode as shared `conndev_ObjectClass` objects (precomputed schema mapping), plus raw exports for SCIM (`conndev_ScimSchema`/`conndev_ScimResource`). midPoint reads these shadows from the testing resource during the (now connector-agnostic) schema refresh and forwards them to the generation service as documentation — faithfully, via a structural prism unwrap with no fixed DTOs, so connector specifics and future fields pass through unchanged. Uploads are idempotent (stable UUIDs, `application/com.evolveum.conndev+json`).

  Also adapts discovery to the new digester metadata format (endpoint in `restAvailability`/`scimAvailability`, integration type derived from `apiType`).