### PR TITLE
Smart integration: sync dev-shadow documentation with the midpilot

### DIFF
--- a/model/smart-impl/src/main/java/com/evolveum/midpoint/smart/impl/conndev/ConnectorDevelopmentBackend.java
+++ b/model/smart-impl/src/main/java/com/evolveum/midpoint/smart/impl/conndev/ConnectorDevelopmentBackend.java
@@ -64,6 +64,15 @@ public abstract class ConnectorDevelopmentBackend {
     }
 
     /**
+     * A dev-shadow document built from a {@code conndev_*} shadow: its stable {@code uuid}/{@code uri}
+     * (derived from the discovered name), content type, and the unwrapped schema-mapping {@code content}.
+     * Kept purely in memory (not a file-backed {@link ProcessedDocumentation}) because the content is only
+     * a transient upload body — the stored {@link ProcessedDocumentation} is materialized from what the
+     * generation service returns (see {@link #synchronizeDocumentation}).
+     */
+    protected record DevShadowDocument(String uuid, String uri, String contentType, String content) {}
+
+    /**
      * Returns a supplier that operations must poll to implement cooperative cancellation.
      *
      * Because operations run in threads that cannot be forcibly killed, each operation is
@@ -648,8 +657,14 @@ public abstract class ConnectorDevelopmentBackend {
         }
 
         var objectClasses = devDocumentationObjectClasses();
-        var newDocs = objectClasses.stream()
+        var shadowDocs = objectClasses.stream()
                 .flatMap(objectClass -> loadShadowsAsDocumentation(testingResourceOid, objectClass).stream())
+                .toList();
+
+        // Push the freshly built dev-shadow documentation to the generation service and pull the
+        // processed result back (see synchronizeDocumentation). Offline/base does nothing and keeps
+        // the docs as built; REST/SCIM overrides it to POST each doc and pull the processed items.
+        var newDocs = synchronizeDocumentation(shadowDocs).stream()
                 .map(ProcessedDocumentation::toBean)
                 .toList();
 
@@ -667,6 +682,15 @@ public abstract class ConnectorDevelopmentBackend {
         beans.modelService.executeChanges(List.of(delta), null, task, result);
         reload();
     }
+
+    /**
+     * Pushes the freshly built dev-shadow documentation to the generation service, waits for it to be
+     * processed, and pulls the processed result back as file-backed {@link ProcessedDocumentation}. The
+     * service is the source of truth: a {@link ProcessedDocumentation} only ever comes into being from
+     * what the service returns for a processed upload. Backends without a generation service (offline) do
+     * not support this.
+     */
+    protected abstract List<ProcessedDocumentation> synchronizeDocumentation(List<DevShadowDocument> documentation) throws CommonException;
 
     /**
      * Development object classes whose objects are forwarded as documentation: the shared
@@ -690,13 +714,14 @@ public abstract class ConnectorDevelopmentBackend {
 
     /**
      * Loads shadows of a given {@code conndev_*} object class from a testing resource and forwards each
-     * as a {@link ProcessedDocumentation}, faithfully: the shadow content is only structurally unwrapped
-     * from prism serialization ({@link ConnDevShadowUnwrapper}), never interpreted — the connector owns
-     * the schema-mapping content (single source), midPoint reads only the name (for uri/uuid).
-     * Connector-agnostic core: any connector exposing {@code conndev_ObjectClass} (SCIM, SQL, ...) works
-     * unchanged, including future fields.
+     * as a {@link DevShadowDocument}, faithfully: the shadow content is only structurally unwrapped from
+     * prism serialization ({@link ConnDevShadowUnwrapper}), never interpreted — the connector owns the
+     * schema-mapping content (single source), midPoint reads only the name (for uri/uuid). The result is
+     * an in-memory carrier; it becomes a persisted {@link ProcessedDocumentation} only in
+     * {@link #synchronizeDocumentation}. Connector-agnostic core: any connector exposing
+     * {@code conndev_ObjectClass} (SCIM, SQL, ...) works unchanged, including future fields.
      */
-    protected List<ProcessedDocumentation> loadShadowsAsDocumentation(String resourceOid, String objectClassLocalName) {
+    protected List<DevShadowDocument> loadShadowsAsDocumentation(String resourceOid, String objectClassLocalName) {
         try {
             var objectClass = new QName(SchemaConstants.NS_RI, objectClassLocalName);
             var query = PrismContext.get().queryFor(ShadowType.class)
@@ -718,7 +743,7 @@ public abstract class ConnectorDevelopmentBackend {
             var mapper = new ObjectMapper();
             var writer = mapper.writerWithDefaultPrettyPrinter();
             var unwrapper = new ConnDevShadowUnwrapper();
-            var docs = new ArrayList<ProcessedDocumentation>();
+            var docs = new ArrayList<DevShadowDocument>();
             for (var shadow : shadows) {
                 var attrs = shadow.findContainer(ShadowType.F_ATTRIBUTES);
                 if (attrs == null || attrs.isEmpty()) {
@@ -737,9 +762,7 @@ public abstract class ConnectorDevelopmentBackend {
                 var name = resolveDocName(shadow, document);
                 var uri = objectClassLocalName + "_" + name + ".json";
                 var uuid = UUID.nameUUIDFromBytes(uri.getBytes(StandardCharsets.UTF_8)).toString();
-                var doc = new ProcessedDocumentation(uuid, uri).contentType(CONNDEV_CONTENT_TYPE);
-                doc.write(content);
-                docs.add(doc);
+                docs.add(new DevShadowDocument(uuid, uri, CONNDEV_CONTENT_TYPE, content));
             }
             return docs;
         } catch (Exception e) {

--- a/model/smart-impl/src/main/java/com/evolveum/midpoint/smart/impl/conndev/OfflineBackend.java
+++ b/model/smart-impl/src/main/java/com/evolveum/midpoint/smart/impl/conndev/OfflineBackend.java
@@ -15,6 +15,12 @@ public class OfflineBackend extends ConnectorDevelopmentBackend {
         super(beans, connDev, task, result);
     }
 
+    @Override
+    protected List<ProcessedDocumentation> synchronizeDocumentation(List<DevShadowDocument> documentation) {
+        // The offline backend has no generation service to process documentation, so there is nothing to sync.
+        return List.of();
+    }
+
 
     @Override
     public ConnDevApplicationInfoType discoverBasicInformation(boolean skipCache) {

--- a/model/smart-impl/src/main/java/com/evolveum/midpoint/smart/impl/conndev/RestBackend.java
+++ b/model/smart-impl/src/main/java/com/evolveum/midpoint/smart/impl/conndev/RestBackend.java
@@ -13,17 +13,23 @@ import com.evolveum.midpoint.util.logging.TraceManager;
 import com.evolveum.midpoint.xml.ns._public.common.common_3.*;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
+import org.apache.hc.core5.http.ContentType;
+
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.*;
 
 public class RestBackend extends ConnectorDevelopmentBackend {
 
     private static final long SLEEP_TIME = 5 * 1000L;
     protected static final JsonNodeFactory JSON_FACTORY = JsonNodeFactory.instance;
+    private static final ObjectMapper MAPPER = new ObjectMapper();
 
 
     private static final Trace LOGGER = TraceManager.getTrace(ConnectorDevelopmentBackend.class);
@@ -308,14 +314,68 @@ public class RestBackend extends ConnectorDevelopmentBackend {
     }
 
     /**
-     * REST/SCIM backends additionally push the freshly saved documentation to the connector-generation
-     * service. The upload is idempotent (HEAD-guarded {@code putDocumentationIfMissing}), and with stable
-     * documentation UUIDs it uploads only genuinely new/changed docs.
+     * Pushes each freshly built dev-shadow documentation to the connector-generation service via
+     * {@code POST session/{sessionId}/documentation/{docId}} and pulls the processed result back into
+     * midPoint. The service processes each upload with the LLM (chunking it into {@code DocumentationItem}s)
+     * as an asynchronous job, and the jobs run in parallel, so all docs are submitted first and only then
+     * are the resulting jobs harvested (submit-all-then-wait) instead of blocking on each doc in turn.
      */
     @Override
-    public void refreshConnDevDocumentation() throws CommonException {
-        super.refreshConnDevDocumentation();
-        ensureDocumentationIsUploaded(client().synchronizationClient());
+    protected List<ProcessedDocumentation> synchronizeDocumentation(List<DevShadowDocument> documentation) {
+        if (documentation.isEmpty()) {
+            return List.of();
+        }
+
+        var sync = client().synchronizationClient();
+        try {
+            // Submit every upload first so the (parallel) processing jobs run concurrently on the service.
+            for (var doc : documentation) {
+                sync.postDocumentation(
+                        doc.uuid(),
+                        new ByteArrayInputStream(doc.content().getBytes(StandardCharsets.UTF_8)),
+                        ContentType.create(doc.contentType(), StandardCharsets.UTF_8),
+                        doc.uri());
+            }
+
+            // Harvest: wait for each upload to finish processing (HEAD 204), then pull the processed
+            // content back from the service and only now materialize it as a ProcessedDocumentation,
+            // keeping the original uri/uuid so the merge in the caller works.
+            var synced = new ArrayList<ProcessedDocumentation>();
+            for (var doc : documentation) {
+                sync.awaitDocumentation(doc.uuid(), SLEEP_TIME, canRun());
+                var content = extractDocumentationContent(sync.getDocumentation(doc.uuid()));
+                var processed = new ProcessedDocumentation(doc.uuid(), doc.uri()).contentType(doc.contentType());
+                processed.write(content);
+                synced.add(processed);
+            }
+            return synced;
+        } catch (IOException e) {
+            throw new SystemException("Couldn't synchronize documentation with the generation service", e);
+        }
+    }
+
+    /**
+     * Extracts the documentation content from a {@code GET documentation/{docId}} bundle. The bundle is
+     * {@code {docId, chunks:[{content, ...}]}}; a conndev schema is preserved as a single item, so there
+     * is normally one chunk whose {@code content} is the original schema JSON. Multiple chunks are joined
+     * (best effort); a bundle with no chunk content falls back to the raw bundle JSON.
+     */
+    private String extractDocumentationContent(String bundleJson) throws IOException {
+        var chunks = MAPPER.readTree(bundleJson).get("chunks");
+        if (chunks == null || !chunks.isArray() || chunks.isEmpty()) {
+            return bundleJson;
+        }
+        var contents = new StringBuilder();
+        for (var chunk : chunks) {
+            var content = chunk.get("content");
+            if (content != null && !content.isNull()) {
+                if (contents.length() > 0) {
+                    contents.append("\n");
+                }
+                contents.append(content.asText());
+            }
+        }
+        return contents.length() > 0 ? contents.toString() : bundleJson;
     }
 
 

--- a/model/smart-impl/src/main/java/com/evolveum/midpoint/smart/impl/conndev/ServiceClient.java
+++ b/model/smart-impl/src/main/java/com/evolveum/midpoint/smart/impl/conndev/ServiceClient.java
@@ -114,8 +114,8 @@ public class ServiceClient {
         return job;
     }
 
-    public RestorationClient synchronizationClient() {
-        return new RestorationClient();
+    public SynchronizationClient synchronizationClient() {
+        return new SynchronizationClient();
     }
 
 
@@ -337,6 +337,89 @@ public class ServiceClient {
                 return;
             }
             put(apiUri, entitySupplier);
+        }
+
+    }
+
+    /**
+     * Client for the documentation synchronization direction: upload dev documentation to the generation
+     * service, wait for it to be processed, and pull the processed result back. The service is the source
+     * of truth for processed documentation, so callers push with {@link #postDocumentation}, then, once
+     * {@link #awaitDocumentation} confirms processing, read the result with {@link #getDocumentation}.
+     */
+    public class SynchronizationClient {
+
+        private String documentationUri(String docId) {
+            return appendSession(apiBase + "session/{sessionId}/documentation/" + docId);
+        }
+
+        /**
+         * Uploads a single documentation file (multipart {@code documentation} part). The endpoint does
+         * not merely store it but hands it to the LLM, chunking it into {@code DocumentationItem}s (source
+         * {@code upload}, {@code doc_id == docId}) as an asynchronous job. Returns immediately; use
+         * {@link #awaitDocumentation} to wait for the job and {@link #getDocumentation} to pull the result.
+         */
+        public void postDocumentation(String docId, InputStream documentation, ContentType contentType, String filename) throws IOException {
+            ensureSessionExists();
+
+            final MultipartEntityBuilder builder = MultipartEntityBuilder.create();
+            builder.setMode(HttpMultipartMode.EXTENDED);
+            builder.addBinaryBody("documentation", documentation, contentType, filename);
+
+            var uri = documentationUri(docId);
+            var request = new HttpPost(uri);
+            request.setEntity(builder.build());
+            try (var response = client.execute(request)) {
+                if (response.getCode() < 200 || response.getCode() >= 300) {
+                    throw new IOException("Could not upload documentation " + docId + " to " + uri + ". Status code " + response.getCode());
+                }
+            }
+        }
+
+        /**
+         * Waits until an uploaded documentation has finished processing, by polling {@code HEAD
+         * documentation/{docId}}. Unlike the module job endpoints, the documentation endpoint has no
+         * {@code ?jobId=} status envelope; the HEAD status is the contract instead: {@code 204} once the
+         * chunks are persisted, {@code 202} while the upload job is still running, and {@code 404} when
+         * neither items nor a pending job exist (i.e. the upload failed).
+         */
+        public void awaitDocumentation(String docId, long sleepTime, BooleanSupplier canRun) throws IOException {
+            var uri = documentationUri(docId);
+            while (true) {
+                int code;
+                try (var response = client.execute(new HttpHead(uri))) {
+                    code = response.getCode();
+                }
+                if (code == HttpStatus.SC_NO_CONTENT || code == HttpStatus.SC_OK) {
+                    return;
+                }
+                if (code != HttpStatus.SC_ACCEPTED) {
+                    throw new IOException("Documentation " + docId + " was not processed. Status code " + code);
+                }
+                if (!canRun.getAsBoolean()) {
+                    throw new IOException("Cancelled while waiting for documentation " + docId + " to be processed");
+                }
+                try {
+                    Thread.sleep(sleepTime);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    throw new IOException("Interrupted while waiting for documentation " + docId, e);
+                }
+            }
+        }
+
+        /**
+         * Fetches a single processed documentation bundle ({@code docId} + its chunks) as raw JSON. Only
+         * call this once {@link #awaitDocumentation} has confirmed processing has finished.
+         */
+        public String getDocumentation(String docId) throws IOException {
+            var uri = documentationUri(docId);
+            try (var response = client.execute(new HttpGet(uri))) {
+                if (HttpStatus.SC_OK == response.getCode()) {
+                    return new String(response.getEntity().getContent().readAllBytes(), StandardCharsets.UTF_8);
+                }
+                throw new IOException("Could not fetch documentation " + docId + " from " + uri + ". Status code " + response.getCode());
+            }
         }
 
     }


### PR DESCRIPTION
On conndev schema refresh, upload each conndev shadow to the generation service for processing and pull the processed documentation back into midPoint. The service is the source of truth, so raw shadow content is no longer stored directly.

- loadShadowsAsDocumentation returns lightweight in-memory DevShadowDocument records; ProcessedDocumentation is materialized only from the pulled result
- ServiceClient.SynchronizationClient owns the documentation sync direction: multipart POST documentation/{docId}, HEAD-poll until processed, GET bundle
- uploads are submitted first and harvested afterwards so jobs run in parallel
- OfflineBackend has no generation service, so it synchronizes nothing