### PR TITLE
Connector generation wizard: fix documentation discovery restart, duplicate jobs and error reporting

### DIFF
--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/component/wizard/scimrest/WaitingConnectorStepPanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/component/wizard/scimrest/WaitingConnectorStepPanel.java
@@ -59,6 +59,7 @@ public abstract class WaitingConnectorStepPanel extends AbstractWizardStepPanel<
     private LoadableModel<SmartGeneratingDto> statusModel;
     private LoadableModel<String> tokenModel;
     private boolean isReloaded = false;
+    private String restartedTaskToken;
 
     public WaitingConnectorStepPanel(WizardPanelHelper<? extends Containerable, ConnectorDevelopmentDetailsModel> helper) {
         super(helper);
@@ -80,7 +81,7 @@ public abstract class WaitingConnectorStepPanel extends AbstractWizardStepPanel<
             @Override
             protected String load() {
                 if (isReloaded) {
-                    return null;
+                    return restartedTaskToken;
                 }
 
                 try {
@@ -130,6 +131,20 @@ public abstract class WaitingConnectorStepPanel extends AbstractWizardStepPanel<
         tokenModel.reset();
     }
 
+    /**
+     * Resets the panel so that a new background task is submitted instead of reusing
+     * the result of the previous one.
+     */
+    public void restartTask() {
+        restartedTaskToken = null;
+        resetToken();
+        if (getStatusModel() != null) {
+            getStatusModel().detach();
+        }
+        markAsReloaded();
+        addOrReplace(createWaitingPanel());
+    }
+
     private void createStatusModel() {
         statusModel = new LoadableModel<>() {
             @Override
@@ -140,6 +155,9 @@ public abstract class WaitingConnectorStepPanel extends AbstractWizardStepPanel<
 
                 if (StringUtils.isEmpty(tokenModel.getObject())) {
                     tokenModel.setObject(getNewTaskToken(task, result, isReloaded));
+                    if (isReloaded) {
+                        restartedTaskToken = tokenModel.getObject();
+                    }
                 }
                 Optional.ofNullable(getKeyForStoringToken()).ifPresent(key -> getHelper().putVariable(key, tokenModel.getObject()));
 
@@ -296,6 +314,7 @@ public abstract class WaitingConnectorStepPanel extends AbstractWizardStepPanel<
         getDetailsModel().reloadPrismObjectModel(
                 WebModelServiceUtils.loadObject(ConnectorDevelopmentType.class, oid, getPageBase(), task, task.getResult()));
         isReloaded = false;
+        restartedTaskToken = null;
         return super.onNextPerformed(target);
     }
 

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/component/wizard/scimrest/WaitingScriptConnectorStepPanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/component/wizard/scimrest/WaitingScriptConnectorStepPanel.java
@@ -28,12 +28,7 @@ public abstract class WaitingScriptConnectorStepPanel extends WaitingConnectorSt
     }
 
     public void resetScript(PageBase pageBase) {
-        resetToken();
-        if (getStatusModel() != null){
-            getStatusModel().detach();
-        }
-        markAsReloaded();
-        addOrReplace(createWaitingPanel());
+        restartTask();
     }
 
     @Override

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/component/wizard/scimrest/basic/ApplicationIdentificationConnectorStepPanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/component/wizard/scimrest/basic/ApplicationIdentificationConnectorStepPanel.java
@@ -6,16 +6,21 @@
  */
 package com.evolveum.midpoint.gui.impl.page.admin.connector.development.component.wizard.scimrest.basic;
 
+import java.util.List;
+
 import org.apache.wicket.ajax.AjaxRequestTarget;
 import org.apache.wicket.behavior.AttributeAppender;
 import org.apache.wicket.model.IModel;
 
+import com.evolveum.midpoint.gui.api.component.wizard.WizardStep;
 import com.evolveum.midpoint.gui.api.factory.wrapper.WrapperContext;
+import com.evolveum.midpoint.gui.api.prism.ItemStatus;
 import com.evolveum.midpoint.gui.api.prism.wrapper.ItemVisibilityHandler;
 import com.evolveum.midpoint.gui.api.prism.wrapper.ItemWrapper;
 import com.evolveum.midpoint.gui.api.prism.wrapper.PrismContainerWrapper;
 import com.evolveum.midpoint.gui.impl.component.wizard.AbstractFormWizardStepPanel;
 import com.evolveum.midpoint.gui.impl.component.wizard.WizardPanelHelper;
+import com.evolveum.midpoint.gui.impl.component.wizard.withnavigation.WizardModelWithParentSteps;
 import com.evolveum.midpoint.gui.impl.page.admin.connector.development.ConnectorDevelopmentDetailsModel;
 import com.evolveum.midpoint.gui.impl.prism.panel.ItemPanelSettings;
 import com.evolveum.midpoint.gui.impl.prism.panel.ItemPanelSettingsBuilder;
@@ -23,7 +28,9 @@ import com.evolveum.midpoint.gui.impl.prism.panel.vertical.form.VerticalFormPane
 import com.evolveum.midpoint.gui.impl.prism.panel.vertical.form.VerticalFormPrismContainerPanel;
 import com.evolveum.midpoint.gui.impl.prism.wrapper.PrismPropertyValueWrapper;
 import com.evolveum.midpoint.prism.Containerable;
+import com.evolveum.midpoint.prism.path.ItemName;
 import com.evolveum.midpoint.schema.result.OperationResult;
+import com.evolveum.midpoint.util.QNameUtil;
 import com.evolveum.midpoint.util.exception.SchemaException;
 import com.evolveum.midpoint.web.application.PanelDisplay;
 import com.evolveum.midpoint.web.application.PanelInstance;
@@ -181,10 +188,12 @@ public class ApplicationIdentificationConnectorStepPanel extends AbstractFormWiz
 
     @Override
     public boolean onNextPerformed(AjaxRequestTarget target) {
+        boolean applicationInfoChanged = isApplicationInfoChanged();
         try {
             PrismPropertyValueWrapper<Object> value = PrismPropertyWrapperModel.fromContainerWrapper(getDetailsModel().getObjectWrapperModel(), ConnectorDevelopmentType.F_NAME)
                     .getObject().getValue();
-            if (value.getRealValue() == null) {
+            if (value.getRealValue() == null
+                    || getDetailsModel().getObjectWrapper().getStatus() == ItemStatus.ADDED) {
                 value.setRealValue(
                         PrismPropertyWrapperModel.fromContainerWrapper((IModel<PrismContainerWrapper<ConnDevApplicationInfoType>>) getContainerFormModel(), ConnDevApplicationInfoType.F_APPLICATION_NAME)
                                 .getObject().getValue().getRealValue()
@@ -196,11 +205,56 @@ public class ApplicationIdentificationConnectorStepPanel extends AbstractFormWiz
         OperationResult result = getHelper().onSaveObjectPerformed(target);
         getDetailsModel().getConnectorDevelopmentOperation();
         if (result != null && !result.isError()) {
+            if (applicationInfoChanged) {
+                restartDocumentationDiscovery();
+            }
             super.onNextPerformed(target);
         } else {
             target.add(getFeedback());
         }
         return false;
+    }
+
+    /**
+     * Returns true if the user changed the application information used by the documentation
+     * discovery (name, version, integration type), so the already discovered documentation
+     * may belong to a different application. Changes of other items (e.g. description)
+     * don't influence the discovery.
+     */
+    private boolean isApplicationInfoChanged() {
+        if (getDetailsModel().getObjectWrapper().getStatus() == ItemStatus.ADDED) {
+            // Initial creation, there is no previous discovery to restart.
+            return false;
+        }
+        List<ItemName> discoveryRelevantItems = List.of(
+                ConnDevApplicationInfoType.F_APPLICATION_NAME,
+                ConnDevApplicationInfoType.F_VERSION,
+                ConnDevApplicationInfoType.F_INTEGRATION_TYPE);
+        try {
+            PrismContainerWrapper<ConnDevApplicationInfoType> container =
+                    ((IModel<PrismContainerWrapper<ConnDevApplicationInfoType>>) getContainerFormModel()).getObject();
+            var deltas = container.getDelta();
+            return deltas != null && deltas.stream().anyMatch(
+                    delta -> discoveryRelevantItems.stream().anyMatch(
+                            item -> QNameUtil.match(item, delta.getElementName())));
+        } catch (SchemaException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * Resets the documentation waiting step, so the documentation discovery is executed
+     * again instead of reusing the result of the previous discovery task.
+     */
+    private void restartDocumentationDiscovery() {
+        if (getWizard() instanceof WizardModelWithParentSteps parentWizardModel) {
+            for (WizardStep step : parentWizardModel.getActiveChildrenSteps()) {
+                if (step instanceof WaitingForDocumentationConnectorStepPanel waitingPanel) {
+                    waitingPanel.restartTask();
+                    return;
+                }
+            }
+        }
     }
 
     @Override

--- a/model/smart-impl/src/main/java/com/evolveum/midpoint/smart/impl/conndev/RestBackend.java
+++ b/model/smart-impl/src/main/java/com/evolveum/midpoint/smart/impl/conndev/RestBackend.java
@@ -67,7 +67,7 @@ public class RestBackend extends ConnectorDevelopmentBackend {
                 // FIXME: Add dynamic
                 return ret;
             });
-        } catch (Exception e) {
+        } catch (IOException e) {
             throw new SystemException("Couldn't discover basic application information", e);
         }
     }
@@ -139,7 +139,7 @@ public class RestBackend extends ConnectorDevelopmentBackend {
                 }
                 return ret;
             });
-        } catch (Exception e) {
+        } catch (IOException e) {
             throw new SystemException("Couldn't discover authorization information", e);
         }
     }
@@ -178,7 +178,7 @@ public class RestBackend extends ConnectorDevelopmentBackend {
                 }
                 return ret;
             });
-        } catch (Exception e) {
+        } catch (IOException e) {
             throw new SystemException("Couldn't discover candidate links", e);
         }
     }
@@ -393,7 +393,7 @@ public class RestBackend extends ConnectorDevelopmentBackend {
                 }
                 return ret;
             });
-        } catch (Exception e) {
+        } catch (IOException e) {
             throw new SystemException("Couldn't discover object classes from documentation", e);
         }
     }
@@ -415,7 +415,7 @@ public class RestBackend extends ConnectorDevelopmentBackend {
                 }
                 return ret;
             });
-        } catch (Exception e) {
+        } catch (IOException e) {
             throw new SystemException("Couldn't discover connectivity endpoints", e);
         }
     }
@@ -431,7 +431,7 @@ public class RestBackend extends ConnectorDevelopmentBackend {
                 }
                 return ret;
             });
-        } catch (Exception e) {
+        } catch (IOException e) {
             throw new SystemException("Couldn't discover endpoints for object class " + objectClass, e);
         }
     }
@@ -448,7 +448,7 @@ public class RestBackend extends ConnectorDevelopmentBackend {
                 }
                 return ret;
             });
-        } catch (Exception e) {
+        } catch (IOException e) {
             throw new SystemException("Couldn't discover attributes for object class " + objectClass, e);
         }
     }
@@ -568,7 +568,7 @@ public class RestBackend extends ConnectorDevelopmentBackend {
                     return ret;
                 });
             }
-        } catch (Exception e) {
+        } catch (IOException e) {
             throw new SystemException("Couldn't discover relations between object classes", e);
         }
     }

--- a/model/smart-impl/src/main/java/com/evolveum/midpoint/smart/impl/conndev/activity/DiscoverDocumentationActivityHandler.java
+++ b/model/smart-impl/src/main/java/com/evolveum/midpoint/smart/impl/conndev/activity/DiscoverDocumentationActivityHandler.java
@@ -65,9 +65,6 @@ public class DiscoverDocumentationActivityHandler
             var backend = ConnectorDevelopmentBackend.backendFor(getWorkDefinition().connectorDevelopmentOid, task, result);
             var skipCache = Boolean.TRUE.equals(getWorkDefinition().typedDefinition.getSkipCache());
             var documentation = backend.discoverDocumentation(skipCache);
-            if (documentation.isEmpty()) {
-                documentation = backend.discoverDocumentation(skipCache);
-            }
 
             var ret = new ConnDevDiscoverDocumentationResultType();
             documentation.stream().map(ConnDevDocumentationSourceType::clone).forEach(ret::documentation);


### PR DESCRIPTION
- Changing the application name, version or integration type now restarts the documentation
  discovery. Previously the wizard reused the completed discovery task of the previous input,
  so there was no way to force a new search.
- Discovery runs exactly once: removed the blind retry on an empty result and the duplicate
  task submissions from the polling timer of the restarted waiting step.
- Discovery failures now show the errors reported by the connector generation service
  instead of a generic "Couldn't discover ..." message.
