### PR TITLE
Connector Development: Validate connector development scripts before saving them

### DIFF
--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/component/wizard/collapse/OperationResultCollapsedItem.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/component/wizard/collapse/OperationResultCollapsedItem.java
@@ -43,8 +43,15 @@ public class OperationResultCollapsedItem extends CollapsedItem<WizardModelWithP
     }
 
     public void addOperationResult(String panelId, String fixPanelId, OperationResult result, SerializableConsumer<AjaxRequestTarget> fixAction) {
+        addOperationResult(panelId, fixPanelId, result, fixAction, null, null);
+    }
+
+    /** @see OperationResultWrapper#OperationResultWrapper(OperationResult, String, SerializableConsumer, String, String) */
+    public void addOperationResult(
+            String panelId, String fixPanelId, OperationResult result, SerializableConsumer<AjaxRequestTarget> fixAction,
+            String fixButtonLabelKey, String fixButtonIcon) {
         removeOperationResult(panelId);
-        OperationResultWrapper resultWrapper = new OperationResultWrapper(result, fixPanelId, fixAction);
+        OperationResultWrapper resultWrapper = new OperationResultWrapper(result, fixPanelId, fixAction, fixButtonLabelKey, fixButtonIcon);
         results.put(panelId, resultWrapper);
     }
 
@@ -52,6 +59,11 @@ public class OperationResultCollapsedItem extends CollapsedItem<WizardModelWithP
         if (results.containsKey(panelId)) {
             results.remove(panelId);
         }
+    }
+
+    /** Removes every entry whose panelId starts with {@code prefix} (e.g. {@code "<stepId>."}). */
+    public void removeOperationResultsByPrefix(String prefix) {
+        results.keySet().removeIf(panelId -> panelId.startsWith(prefix));
     }
 
     @Override

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/component/wizard/collapse/OperationResultCollapsedItemPanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/component/wizard/collapse/OperationResultCollapsedItemPanel.java
@@ -131,8 +131,10 @@ public class OperationResultCollapsedItemPanel extends BasePanel<OperationResult
 
             private @NotNull AjaxIconButton getFixButton(OperationResultWrapper resultWrapper) {
                 AjaxIconButton fixButton = new AjaxIconButton(ID_FIX_BUTTON,
-                        () -> "fa fa-wrench",
-                        createStringResource("OperationResultCollapsedItemPanel.fixButton")) {
+                        () -> resultWrapper.getFixButtonIcon() != null ? resultWrapper.getFixButtonIcon() : "fa fa-wrench",
+                        resultWrapper.getFixButtonLabelKey() != null
+                                ? createStringResource(resultWrapper.getFixButtonLabelKey())
+                                : createStringResource("OperationResultCollapsedItemPanel.fixButton")) {
                     @Override
                     public void onClick(AjaxRequestTarget target) {
                         if (resultWrapper.getFixAction() != null) {

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/component/wizard/collapse/OperationResultWrapper.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/component/wizard/collapse/OperationResultWrapper.java
@@ -18,6 +18,8 @@ public class OperationResultWrapper implements Serializable {
     private final OperationResult result;
     private final String fixPanelId;
     private final SerializableConsumer<AjaxRequestTarget> fixAction;
+    private final String fixButtonLabelKey;
+    private final String fixButtonIcon;
     private boolean expanded = false;
 
     public OperationResultWrapper(OperationResult result, String fixPanelId) {
@@ -25,9 +27,27 @@ public class OperationResultWrapper implements Serializable {
     }
 
     public OperationResultWrapper(OperationResult result, String fixPanelId, SerializableConsumer<AjaxRequestTarget> fixAction) {
+        this(result, fixPanelId, fixAction, null, null);
+    }
+
+    /**
+     * @param result             the validation/operation failure this drawer entry reports
+     * @param fixPanelId         wizard step to navigate to on fix-button click, used only when
+     *                           {@code fixAction} is null
+     * @param fixAction          runs instead of step navigation on fix-button click, if set
+     * @param fixButtonLabelKey  overrides the button's default "Fix it" localization key - lets a
+     *                           caller repurpose the single fix button for a different action (e.g.
+     *                           "Disable operation") instead of adding a second button next to it
+     * @param fixButtonIcon      overrides the button's default "fa fa-wrench" icon class
+     */
+    public OperationResultWrapper(
+            OperationResult result, String fixPanelId, SerializableConsumer<AjaxRequestTarget> fixAction,
+            String fixButtonLabelKey, String fixButtonIcon) {
         this.result = result;
         this.fixPanelId = fixPanelId;
         this.fixAction = fixAction;
+        this.fixButtonLabelKey = fixButtonLabelKey;
+        this.fixButtonIcon = fixButtonIcon;
     }
 
     public OperationResult getResult() {
@@ -48,5 +68,13 @@ public class OperationResultWrapper implements Serializable {
 
     public SerializableConsumer<AjaxRequestTarget> getFixAction() {
         return fixAction;
+    }
+
+    public String getFixButtonLabelKey() {
+        return fixButtonLabelKey;
+    }
+
+    public String getFixButtonIcon() {
+        return fixButtonIcon;
     }
 }

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/component/wizard/withnavigation/WizardModelWithParentSteps.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/component/wizard/withnavigation/WizardModelWithParentSteps.java
@@ -85,8 +85,24 @@ public abstract class WizardModelWithParentSteps extends WizardModel implements 
         operationResultCollapsedItem.addOperationResult(panelId, null, result, fixAction);
     }
 
+    /**
+     * Adds an entry whose fix button is repurposed for a different action than step navigation
+     * (e.g. disabling a broken sibling script's manifest entry instead of "fixing" it), with its
+     * own label/icon instead of the default "Fix it" - see {@link OperationResultWrapper}.
+     */
+    public void addOperationResult(
+            String panelId, OperationResult result, SerializableConsumer<AjaxRequestTarget> fixAction,
+            String fixButtonLabelKey, String fixButtonIcon) {
+        operationResultCollapsedItem.addOperationResult(panelId, null, result, fixAction, fixButtonLabelKey, fixButtonIcon);
+    }
+
     public void removeOperationResult(String panelId) {
         operationResultCollapsedItem.removeOperationResult(panelId);
+    }
+
+    /** Removes every drawer entry whose panelId starts with {@code prefix} (e.g. {@code "<stepId>."}). */
+    public void removeOperationResultsByPrefix(String prefix) {
+        operationResultCollapsedItem.removeOperationResultsByPrefix(prefix);
     }
 
     public boolean isStepWithError(String stepId) {

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/component/wizard/ConnectorDevelopmentWizardUtil.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/component/wizard/ConnectorDevelopmentWizardUtil.java
@@ -25,6 +25,7 @@ import com.evolveum.midpoint.schema.SearchResultList;
 import com.evolveum.midpoint.schema.TaskExecutionMode;
 import com.evolveum.midpoint.schema.constants.SchemaConstants;
 import com.evolveum.midpoint.schema.result.OperationResult;
+import com.evolveum.midpoint.smart.api.conndev.ConnDevArtifactValidationResult;
 import com.evolveum.midpoint.smart.api.conndev.ConnectorDevelopmentArtifacts;
 import com.evolveum.midpoint.smart.api.conndev.SupportedAuthorization;
 import com.evolveum.midpoint.task.api.Task;
@@ -149,6 +150,16 @@ public class ConnectorDevelopmentWizardUtil {
         }
 
         return taskBean.getOid();
+    }
+
+    public static String scriptValidationErrorMessage(
+            ConnDevArtifactValidationResult validation, String fileName, PageAdminLTE page) {
+        if (validation.line() != null) {
+            return page.createStringResource("ScriptConnectorStepPanel.validation.failedAtLine",
+                    validation.phase(), validation.message(), fileName, validation.line()).getString();
+        }
+        return page.createStringResource("ScriptConnectorStepPanel.validation.failed",
+                validation.phase(), validation.message(), fileName).getString();
     }
 
     public static <C extends PrismContainerWrapper<?>> boolean existContainerValue(C container, ItemPath path) {

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/component/wizard/ConnectorDevelopmentWizardUtil.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/component/wizard/ConnectorDevelopmentWizardUtil.java
@@ -10,6 +10,8 @@ import com.evolveum.midpoint.gui.api.page.PageAdminLTE;
 import com.evolveum.midpoint.gui.api.prism.wrapper.*;
 import com.evolveum.midpoint.gui.api.util.WebComponentUtil;
 import com.evolveum.midpoint.gui.api.util.WebPrismUtil;
+import com.evolveum.midpoint.gui.impl.component.wizard.AbstractWizardStepPanel;
+import com.evolveum.midpoint.gui.impl.component.wizard.withnavigation.WizardModelWithParentSteps;
 import com.evolveum.midpoint.gui.impl.page.admin.ObjectDetailsModels;
 import com.evolveum.midpoint.gui.impl.page.admin.connector.development.ConnectorDevelopmentDetailsModel;
 import com.evolveum.midpoint.prism.PrismContainerValue;
@@ -25,6 +27,7 @@ import com.evolveum.midpoint.schema.SearchResultList;
 import com.evolveum.midpoint.schema.TaskExecutionMode;
 import com.evolveum.midpoint.schema.constants.SchemaConstants;
 import com.evolveum.midpoint.schema.result.OperationResult;
+import com.evolveum.midpoint.smart.api.conndev.ConnDevArtifactValidationResult;
 import com.evolveum.midpoint.smart.api.conndev.ConnectorDevelopmentArtifacts;
 import com.evolveum.midpoint.smart.api.conndev.SupportedAuthorization;
 import com.evolveum.midpoint.task.api.Task;
@@ -37,6 +40,8 @@ import com.evolveum.midpoint.xml.ns._public.common.common_3.*;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Strings;
+import org.apache.wicket.Component;
+import org.apache.wicket.ajax.AjaxRequestTarget;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -159,6 +164,77 @@ public class ConnectorDevelopmentWizardUtil {
         }
 
         return taskBean.getOid();
+    }
+
+    /**
+     * The single line shown in the step's feedback alert: always just a short summary (affected
+     * file count), regardless of how many errors there are - the concrete detail always goes to
+     * the sidebar instead, see {@link #scriptValidationOperationResult}.
+     */
+    public static String scriptValidationErrorMessage(
+            ConnDevArtifactValidationResult validation, String fileName, PageAdminLTE page) {
+        long affectedFiles = validation.errors().stream()
+                .map(error -> error.source() != null ? error.source() : fileName)
+                .distinct().count();
+        return page.createStringResource("ScriptConnectorStepPanel.validation.summary",
+                affectedFiles).getString();
+    }
+
+    /**
+     * Per-error detail for the wizard's right-side drawer (see {@code WizardModelWithParentSteps
+     * #addOperationResult}) - the feedback alert only ever shows the one-line summary above, so
+     * this is where the user finds the concrete error(s), even when there's just one.
+     */
+    public static OperationResult scriptValidationOperationResult(
+            ConnDevArtifactValidationResult validation, String fileName) {
+        var result = new OperationResult("Script validation: " + fileName);
+        for (var error : validation.errors()) {
+            String source = error.source() != null ? error.source() : fileName;
+            var sub = result.createSubresult(source + (error.phase() != null ? " (" + error.phase() + ")" : ""));
+            String message = error.line() != null
+                    ? source + ":" + error.line() + " - " + error.message()
+                    : source + " - " + error.message();
+            sub.recordFatalError(message);
+        }
+        result.computeStatus();
+        return result;
+    }
+
+    /** Drops any sidebar entry left over from a previous, now-superseded validation of {@code panelId}. */
+    public static void clearScriptValidationErrors(AbstractWizardStepPanel<?> step, String panelId) {
+        if (step.getWizard() instanceof WizardModelWithParentSteps wizardModel) {
+            wizardModel.removeOperationResult(panelId);
+        }
+    }
+
+    /**
+     * Pushes the concrete validation error(s) to the wizard's right-side drawer and refreshes it -
+     * the feedback alert only ever shows the one-line summary from {@link
+     * #scriptValidationErrorMessage}, so this is where the user finds the detail.
+     */
+    public static void reportScriptValidationErrors(
+            AbstractWizardStepPanel<?> step, String panelId,
+            ConnDevArtifactValidationResult validation, String fileName, AjaxRequestTarget target) {
+        if (!(step.getWizard() instanceof WizardModelWithParentSteps wizardModel)) {
+            return;
+        }
+        wizardModel.addOperationResult(panelId, scriptValidationOperationResult(validation, fileName));
+        refreshDrawerPanel(step, target);
+    }
+
+    /**
+     * Adds the wizard's right-side drawer ({@code mainForm:drawerInfoPanel}) to {@code target} so
+     * its content re-renders on this AJAX response - callers must invoke this after any change to
+     * the drawer's underlying model (e.g. via {@link WizardModelWithParentSteps#addOperationResult}
+     * or {@link WizardModelWithParentSteps#removeOperationResult}), since that change alone doesn't
+     * push anything to the browser. A no-op if the drawer isn't part of this wizard's component
+     * tree (e.g. not yet rendered).
+     */
+    public static void refreshDrawerPanel(AbstractWizardStepPanel<?> step, AjaxRequestTarget target) {
+        Component drawerInfoPanel = step.getWizard().getPanel().get("mainForm:drawerInfoPanel");
+        if (drawerInfoPanel != null) {
+            target.add(drawerInfoPanel);
+        }
     }
 
     public static <C extends PrismContainerWrapper<?>> boolean existContainerValue(C container, ItemPath path) {

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/component/wizard/ConnectorDevelopmentWizardUtil.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/component/wizard/ConnectorDevelopmentWizardUtil.java
@@ -30,9 +30,11 @@ import com.evolveum.midpoint.schema.result.OperationResult;
 import com.evolveum.midpoint.smart.api.conndev.ConnDevArtifactValidationResult;
 import com.evolveum.midpoint.smart.api.conndev.ConnectorDevelopmentArtifacts;
 import com.evolveum.midpoint.smart.api.conndev.SupportedAuthorization;
+import com.evolveum.midpoint.smart.api.conndev.ConnectorDevelopmentOperation;
 import com.evolveum.midpoint.task.api.Task;
 import com.evolveum.midpoint.util.exception.CommonException;
 import com.evolveum.midpoint.util.exception.SchemaException;
+import com.evolveum.midpoint.web.component.util.SerializableConsumer;
 import com.evolveum.midpoint.util.logging.Trace;
 import com.evolveum.midpoint.util.logging.TraceManager;
 import com.evolveum.midpoint.web.component.prism.ValueStatus;
@@ -47,11 +49,14 @@ import org.jetbrains.annotations.Nullable;
 
 import com.evolveum.midpoint.xml.ns._public.common.common_3.LogSegmentType;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Consumer;
+import java.util.stream.Collectors;
 
 public class ConnectorDevelopmentWizardUtil {
 
@@ -169,7 +174,7 @@ public class ConnectorDevelopmentWizardUtil {
     /**
      * The single line shown in the step's feedback alert: always just a short summary (affected
      * file count), regardless of how many errors there are - the concrete detail always goes to
-     * the sidebar instead, see {@link #scriptValidationOperationResult}.
+     * the sidebar instead, see {@link #reportScriptValidationErrors}.
      */
     public static String scriptValidationErrorMessage(
             ConnDevArtifactValidationResult validation, String fileName, PageAdminLTE page) {
@@ -181,15 +186,13 @@ public class ConnectorDevelopmentWizardUtil {
     }
 
     /**
-     * Per-error detail for the wizard's right-side drawer (see {@code WizardModelWithParentSteps
-     * #addOperationResult}) - the feedback alert only ever shows the one-line summary above, so
-     * this is where the user finds the concrete error(s), even when there's just one.
+     * Builds the per-error detail shown for one drawer entry, scoped to a single source file (the
+     * artifact under edit, or one broken sibling) - see {@link #reportScriptValidationErrors}.
      */
-    public static OperationResult scriptValidationOperationResult(
-            ConnDevArtifactValidationResult validation, String fileName) {
-        var result = new OperationResult("Script validation: " + fileName);
-        for (var error : validation.errors()) {
-            String source = error.source() != null ? error.source() : fileName;
+    private static OperationResult buildValidationOperationResult(
+            List<ConnDevArtifactValidationResult.Error> errors, String source) {
+        var result = new OperationResult("Script validation: " + source);
+        for (var error : errors) {
             var sub = result.createSubresult(source + (error.phase() != null ? " (" + error.phase() + ")" : ""));
             String message = error.line() != null
                     ? source + ":" + error.line() + " - " + error.message()
@@ -200,26 +203,77 @@ public class ConnectorDevelopmentWizardUtil {
         return result;
     }
 
-    /** Drops any sidebar entry left over from a previous, now-superseded validation of {@code panelId}. */
-    public static void clearScriptValidationErrors(AbstractWizardStepPanel<?> step, String panelId) {
+    /**
+     * Drops every sidebar entry left over from a previous, now-superseded validation attempt for
+     * this artifact - {@code stepId} is the same prefix passed to {@link
+     * #reportScriptValidationErrors}, since one validation attempt can fan out into several
+     * entries (one per broken sibling file), not just one.
+     */
+    public static void clearScriptValidationErrors(AbstractWizardStepPanel<?> step, String stepId) {
         if (step.getWizard() instanceof WizardModelWithParentSteps wizardModel) {
-            wizardModel.removeOperationResult(panelId);
+            wizardModel.removeOperationResultsByPrefix(stepId + ".");
         }
     }
 
     /**
      * Pushes the concrete validation error(s) to the wizard's right-side drawer and refreshes it -
      * the feedback alert only ever shows the one-line summary from {@link
-     * #scriptValidationErrorMessage}, so this is where the user finds the detail.
+     * #scriptValidationErrorMessage}. One entry is added per distinct affected file rather than a
+     * single combined entry, so a broken sibling script gets its own fix button independently of
+     * any others. The artifact under edit itself (its own errors have no {@code source}, so its
+     * entry uses {@code fileName} as a stand-in) gets the button's default "Fix it"/navigate-back
+     * behavior, pointed at this very step - which correctly hides it while the step is active. A
+     * broken sibling instead repurposes the same button as "Disable operation" (see {@link
+     * ConnectorDevelopmentOperation#disableArtifact}), since there's nowhere to navigate to fix a
+     * script other than editing its already-deployed content, which disabling bypasses.
      */
     public static void reportScriptValidationErrors(
-            AbstractWizardStepPanel<?> step, String panelId,
+            AbstractWizardStepPanel<ConnectorDevelopmentDetailsModel> step, String stepId,
             ConnDevArtifactValidationResult validation, String fileName, AjaxRequestTarget target) {
         if (!(step.getWizard() instanceof WizardModelWithParentSteps wizardModel)) {
             return;
         }
-        wizardModel.addOperationResult(panelId, scriptValidationOperationResult(validation, fileName));
+        var bySource = validation.errors().stream()
+                .collect(Collectors.groupingBy(
+                        error -> error.source() != null ? error.source() : fileName,
+                        LinkedHashMap::new, Collectors.toList()));
+        for (var entry : bySource.entrySet()) {
+            String source = entry.getKey();
+            String panelId = stepId + "." + source;
+            var result = buildValidationOperationResult(entry.getValue(), source);
+            if (source.equals(fileName)) {
+                wizardModel.addOperationResult(panelId, step.getStepId(), result);
+            } else {
+                wizardModel.addOperationResult(panelId, result, disableAction(step, panelId, source),
+                        "OperationResultCollapsedItemPanel.disableButton", "fa fa-ban");
+            }
+        }
         refreshDrawerPanel(step, target);
+    }
+
+    /**
+     * Builds the fix button's click handler for a broken sibling script's drawer entry, repurposed
+     * as "Disable operation" (see {@link #reportScriptValidationErrors}): marks it disabled in the
+     * manifest (see {@link ConnectorDevelopmentOperation#disableArtifact}), then removes just this
+     * one entry and refreshes the drawer - the original save attempt that surfaced the breakage is
+     * not retried automatically.
+     */
+    private static SerializableConsumer<AjaxRequestTarget> disableAction(
+            AbstractWizardStepPanel<ConnectorDevelopmentDetailsModel> step, String panelId, String source) {
+        return clickTarget -> {
+            Task task = step.getPageBase().createSimpleTask(ConnectorDevelopmentWizardUtil.class.getName() + ".disableArtifact");
+            try {
+                step.getDetailsModel().getConnectorDevelopmentOperation().disableArtifact(source, task, task.getResult());
+            } catch (IOException | CommonException | RuntimeException e) {
+                step.getPageBase().error("Couldn't disable " + source + ": " + e.getMessage());
+                clickTarget.add(step.getWizard().getPanel());
+                return;
+            }
+            if (step.getWizard() instanceof WizardModelWithParentSteps wizardModel) {
+                wizardModel.removeOperationResult(panelId);
+            }
+            refreshDrawerPanel(step, clickTarget);
+        };
     }
 
     /**

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/component/wizard/scimrest/ScriptConnectorStepPanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/component/wizard/scimrest/ScriptConnectorStepPanel.java
@@ -30,6 +30,7 @@ import com.evolveum.midpoint.gui.impl.page.admin.connector.development.Connector
 import com.evolveum.midpoint.gui.impl.page.admin.connector.development.component.wizard.ConnectorDevelopmentWizardUtil;
 import com.evolveum.midpoint.prism.Containerable;
 import com.evolveum.midpoint.schema.result.OperationResult;
+import com.evolveum.midpoint.smart.api.conndev.ConnDevArtifactValidationResult;
 import com.evolveum.midpoint.smart.api.conndev.ConnectorDevelopmentArtifacts;
 import com.evolveum.midpoint.smart.api.info.StatusInfo;
 import com.evolveum.midpoint.task.api.Task;
@@ -205,6 +206,14 @@ public abstract class ScriptConnectorStepPanel extends AbstractWizardStepPanel<C
         try {
             ConnDevArtifactType script = valueModel.getObject().clone();
             WebPrismUtil.cleanupEmptyContainerValue(script.asPrismContainerValue());
+            ConnDevArtifactValidationResult validation = getDetailsModel().getConnectorDevelopmentOperation()
+                    .validateArtifact(script, task, task.getResult());
+            if (!validation.ok()) {
+                getPageBase().error(ConnectorDevelopmentWizardUtil.scriptValidationErrorMessage(
+                        validation, script.getFilename(), getPageBase()));
+                target.add(getFeedback());
+                return false;
+            }
             saveScript(script, task, task.getResult());
             getDetailsModel().reloadPrismObjectByOid();
             if (task.getResult() == null || task.getResult().isError()) {

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/component/wizard/scimrest/ScriptConnectorStepPanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/component/wizard/scimrest/ScriptConnectorStepPanel.java
@@ -30,6 +30,7 @@ import com.evolveum.midpoint.gui.impl.page.admin.connector.development.Connector
 import com.evolveum.midpoint.gui.impl.page.admin.connector.development.component.wizard.ConnectorDevelopmentWizardUtil;
 import com.evolveum.midpoint.prism.Containerable;
 import com.evolveum.midpoint.schema.result.OperationResult;
+import com.evolveum.midpoint.smart.api.conndev.ConnDevArtifactValidationResult;
 import com.evolveum.midpoint.smart.api.conndev.ConnectorDevelopmentArtifacts;
 import com.evolveum.midpoint.smart.api.info.StatusInfo;
 import com.evolveum.midpoint.task.api.Task;
@@ -202,9 +203,21 @@ public abstract class ScriptConnectorStepPanel extends AbstractWizardStepPanel<C
     @Override
     public boolean onNextPerformed(AjaxRequestTarget target) {
         Task task = getPageBase().createSimpleTask(OP_SAVE_SCRIPT);
+        ConnectorDevelopmentWizardUtil.clearScriptValidationErrors(this, getStepId());
+        ConnectorDevelopmentWizardUtil.refreshDrawerPanel(this, target);
         try {
             ConnDevArtifactType script = valueModel.getObject().clone();
             WebPrismUtil.cleanupEmptyContainerValue(script.asPrismContainerValue());
+            ConnDevArtifactValidationResult validation = getDetailsModel().getConnectorDevelopmentOperation()
+                    .validateArtifact(script, task, task.getResult());
+            if (!validation.ok()) {
+                getPageBase().error(ConnectorDevelopmentWizardUtil.scriptValidationErrorMessage(
+                        validation, script.getFilename(), getPageBase()));
+                target.add(getFeedback());
+                ConnectorDevelopmentWizardUtil.reportScriptValidationErrors(
+                        this, getStepId(), validation, script.getFilename(), target);
+                return false;
+            }
             saveScript(script, task, task.getResult());
             getDetailsModel().reloadPrismObjectByOid();
             if (task.getResult() == null || task.getResult().isError()) {

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/component/wizard/scimrest/ScriptsConnectorStepPanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/component/wizard/scimrest/ScriptsConnectorStepPanel.java
@@ -37,6 +37,7 @@ import com.evolveum.midpoint.gui.impl.page.admin.connector.development.Connector
 import com.evolveum.midpoint.gui.impl.page.admin.connector.development.component.wizard.ConnectorDevelopmentWizardUtil;
 import com.evolveum.midpoint.prism.Containerable;
 import com.evolveum.midpoint.schema.result.OperationResult;
+import com.evolveum.midpoint.smart.api.conndev.ConnDevArtifactValidationResult;
 import com.evolveum.midpoint.smart.api.conndev.ConnectorDevelopmentArtifacts;
 import com.evolveum.midpoint.smart.api.info.StatusInfo;
 import com.evolveum.midpoint.task.api.Task;
@@ -242,6 +243,14 @@ public abstract class ScriptsConnectorStepPanel extends AbstractWizardStepPanel<
             try {
                 ConnDevArtifactType script = scriptArtifact.clone();
                 WebPrismUtil.cleanupEmptyContainerValue(script.asPrismContainerValue());
+                ConnDevArtifactValidationResult validation = getDetailsModel().getConnectorDevelopmentOperation()
+                        .validateArtifact(script, task, task.getResult());
+                if (!validation.ok()) {
+                    getPageBase().error(ConnectorDevelopmentWizardUtil.scriptValidationErrorMessage(
+                            validation, script.getFilename(), getPageBase()));
+                    target.add(getFeedback());
+                    return false;
+                }
                 saveScript(script, task, task.getResult());
                 getDetailsModel().reloadPrismObjectByOid();
                 if (task.getResult() == null || task.getResult().isError()) {

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/component/wizard/scimrest/ScriptsConnectorStepPanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/component/wizard/scimrest/ScriptsConnectorStepPanel.java
@@ -37,6 +37,7 @@ import com.evolveum.midpoint.gui.impl.page.admin.connector.development.Connector
 import com.evolveum.midpoint.gui.impl.page.admin.connector.development.component.wizard.ConnectorDevelopmentWizardUtil;
 import com.evolveum.midpoint.prism.Containerable;
 import com.evolveum.midpoint.schema.result.OperationResult;
+import com.evolveum.midpoint.smart.api.conndev.ConnDevArtifactValidationResult;
 import com.evolveum.midpoint.smart.api.conndev.ConnectorDevelopmentArtifacts;
 import com.evolveum.midpoint.smart.api.info.StatusInfo;
 import com.evolveum.midpoint.task.api.Task;
@@ -238,10 +239,29 @@ public abstract class ScriptsConnectorStepPanel extends AbstractWizardStepPanel<
     @Override
     public boolean onNextPerformed(AjaxRequestTarget target) {
         for (ConnDevArtifactType scriptArtifact : valueModel.getObject()) {
+            ConnectorDevelopmentWizardUtil.clearScriptValidationErrors(
+                    this, getStepId() + "." + scriptArtifact.getFilename());
+        }
+        ConnectorDevelopmentWizardUtil.refreshDrawerPanel(this, target);
+        for (ConnDevArtifactType scriptArtifact : valueModel.getObject()) {
             Task task = getPageBase().createSimpleTask(OP_SAVE_SCRIPT);
             try {
                 ConnDevArtifactType script = scriptArtifact.clone();
                 WebPrismUtil.cleanupEmptyContainerValue(script.asPrismContainerValue());
+                ConnDevArtifactValidationResult validation = getDetailsModel().getConnectorDevelopmentOperation()
+                        .validateArtifact(script, task, task.getResult());
+                if (!validation.ok()) {
+                    getPageBase().error(ConnectorDevelopmentWizardUtil.scriptValidationErrorMessage(
+                            validation, script.getFilename(), getPageBase()));
+                    target.add(getFeedback());
+                    ConnectorDevelopmentWizardUtil.reportScriptValidationErrors(
+                            this, getStepId() + "." + script.getFilename(), validation, script.getFilename(), target);
+                    return false;
+                }
+                // Saved immediately (not after the whole batch validates) so that a later script
+                // in the same batch — e.g. a ConnId mapping referencing a schema attribute — is
+                // validated against this one as an already-deployed sibling, not just against
+                // whatever was on disk before this submit.
                 saveScript(script, task, task.getResult());
                 getDetailsModel().reloadPrismObjectByOid();
                 if (task.getResult() == null || task.getResult().isError()) {

--- a/infra/schema/src/main/resources/xml/ns/public/common/common-connector-dev-3.xsd
+++ b/infra/schema/src/main/resources/xml/ns/public/common/common-connector-dev-3.xsd
@@ -415,6 +415,7 @@
             <xsd:element name="filename" type="xsd:string"/>
             <xsd:element name="content" type="xsd:string"/>
             <xsd:element name="confirm" type="xsd:boolean"/>
+            <xsd:element name="disabled" type="xsd:boolean" minOccurs="0"/>
         </xsd:sequence>
     </xsd:complexType>
 

--- a/model/smart-api/src/main/java/com/evolveum/midpoint/smart/api/conndev/ConnDevArtifactValidationResult.java
+++ b/model/smart-api/src/main/java/com/evolveum/midpoint/smart/api/conndev/ConnDevArtifactValidationResult.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) 2010-2026 Evolveum and contributors
+ *
+ * This work is dual-licensed under the Apache License 2.0
+ * and European Union Public License. See LICENSE file for details.
+ */
+package com.evolveum.midpoint.smart.api.conndev;
+
+import java.io.Serializable;
+
+/**
+ * Result of the connector script validation executed by the connector itself
+ * (development mode only). For failed validation, {@code phase} distinguishes
+ * where the script failed: {@code compile}, {@code evaluate} or {@code build}.
+ */
+public record ConnDevArtifactValidationResult(boolean ok, String phase, String message, Integer line, Integer column)
+        implements Serializable {
+
+    public static ConnDevArtifactValidationResult success() {
+        return new ConnDevArtifactValidationResult(true, null, null, null, null);
+    }
+
+    public static ConnDevArtifactValidationResult error(String phase, String message, Integer line, Integer column) {
+        return new ConnDevArtifactValidationResult(false, phase, message, line, column);
+    }
+}

--- a/model/smart-api/src/main/java/com/evolveum/midpoint/smart/api/conndev/ConnDevArtifactValidationResult.java
+++ b/model/smart-api/src/main/java/com/evolveum/midpoint/smart/api/conndev/ConnDevArtifactValidationResult.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2010-2026 Evolveum and contributors
+ *
+ * This work is dual-licensed under the Apache License 2.0
+ * and European Union Public License. See LICENSE file for details.
+ */
+package com.evolveum.midpoint.smart.api.conndev;
+
+import java.io.Serializable;
+import java.util.List;
+
+/**
+ * Result of the connector script validation executed by the connector itself
+ * (development mode only). For a failed validation, {@code errors} holds one
+ * entry per script that failed — usually just the one being validated, but a
+ * schema candidate that itself builds cleanly can still break an
+ * already-deployed operation script referencing it, in which case there is
+ * more than one entry, each identifying its own {@code source}.
+ */
+public record ConnDevArtifactValidationResult(boolean ok, List<Error> errors) implements Serializable {
+
+    /**
+     * A single validation failure. {@code phase} distinguishes where it
+     * occurred: {@code compile}, {@code evaluate}, {@code build} or
+     * {@code initialization}. {@code source} is the file the failure
+     * occurred in, if different from the artifact being validated (e.g. a
+     * deployed operation script broken by a schema candidate).
+     */
+    public record Error(String phase, String message, Integer line, Integer column, String source) implements Serializable {
+    }
+
+    public static ConnDevArtifactValidationResult success() {
+        return new ConnDevArtifactValidationResult(true, List.of());
+    }
+
+    public static ConnDevArtifactValidationResult errors(List<Error> errors) {
+        return new ConnDevArtifactValidationResult(false, errors);
+    }
+}

--- a/model/smart-api/src/main/java/com/evolveum/midpoint/smart/api/conndev/ConnectorDevelopmentArtifacts.java
+++ b/model/smart-api/src/main/java/com/evolveum/midpoint/smart/api/conndev/ConnectorDevelopmentArtifacts.java
@@ -9,7 +9,9 @@ package com.evolveum.midpoint.smart.api.conndev;
 import com.evolveum.midpoint.prism.path.ItemName;
 import com.evolveum.midpoint.xml.ns._public.common.common_3.*;
 
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Objects;
 
 public class ConnectorDevelopmentArtifacts {
@@ -87,5 +89,39 @@ public class ConnectorDevelopmentArtifacts {
                 .findFirst();
 
         return classification.orElse(null);
+    }
+
+    /**
+     * Every script artifact declared anywhere on the connector - object class schema/search/
+     * create/update/delete scripts, relation schema scripts, the authentication script, and the
+     * test-connection operation - in a fixed, deterministic order, skipping unset slots. The
+     * single source both {@code ConnectorManifestWriter} and any filename-based artifact lookup
+     * (e.g. resolving a validation error's source file back to its artifact) should use, instead
+     * of separately re-enumerating the same fields.
+     */
+    public static List<ConnDevArtifactType> allArtifacts(ConnDevConnectorType connector) {
+        var artifacts = new ArrayList<ConnDevArtifactType>();
+        addIfPresent(artifacts, connector.getAuthenticationScript());
+        addIfPresent(artifacts, connector.getTestOperation());
+        for (var objClass : connector.getObjectClass()) {
+            addIfPresent(artifacts, objClass.getNativeSchemaScript());
+            addIfPresent(artifacts, objClass.getConnidSchemaScript());
+            addIfPresent(artifacts, objClass.getSearchAllOperation());
+            addIfPresent(artifacts, objClass.getSearchIdOperation());
+            addIfPresent(artifacts, objClass.getSearchFilterOperation());
+            addIfPresent(artifacts, objClass.getCreateScript());
+            addIfPresent(artifacts, objClass.getUpdateScript());
+            addIfPresent(artifacts, objClass.getDeleteScript());
+        }
+        for (var relation : connector.getRelation()) {
+            addIfPresent(artifacts, relation.getSchemaScript());
+        }
+        return artifacts;
+    }
+
+    private static void addIfPresent(List<ConnDevArtifactType> artifacts, ConnDevArtifactType artifact) {
+        if (artifact != null) {
+            artifacts.add(artifact);
+        }
     }
 }

--- a/model/smart-api/src/main/java/com/evolveum/midpoint/smart/api/conndev/ConnectorDevelopmentOperation.java
+++ b/model/smart-api/src/main/java/com/evolveum/midpoint/smart/api/conndev/ConnectorDevelopmentOperation.java
@@ -150,6 +150,8 @@ public interface ConnectorDevelopmentOperation {
 
     void saveArtifact(ConnDevArtifactType endpoint, Task task, OperationResult result) throws IOException, CommonException;
 
+    ConnDevArtifactValidationResult validateArtifact(ConnDevArtifactType artifact, Task task, OperationResult result);
+
 
     default void  saveNativeSchemaScript(ConnDevArtifactType artifact, Task task, OperationResult result) throws IOException, CommonException {
         saveArtifact(artifact, task, result);

--- a/model/smart-api/src/main/java/com/evolveum/midpoint/smart/api/conndev/ConnectorDevelopmentOperation.java
+++ b/model/smart-api/src/main/java/com/evolveum/midpoint/smart/api/conndev/ConnectorDevelopmentOperation.java
@@ -180,6 +180,14 @@ public interface ConnectorDevelopmentOperation {
 
     void saveArtifact(ConnDevArtifactType endpoint, Task task, OperationResult result) throws IOException, CommonException;
 
+    /**
+     * Marks an already-deployed script as disabled in the manifest, so the connector skips it both
+     * when initializing for real and when reloading siblings during script validation. Lets the
+     * wizard offer a "Disable operation" action for a sibling script a schema change breaks,
+     * without deleting the script's content.
+     */
+    void disableArtifact(String filename, Task task, OperationResult result) throws IOException, CommonException;
+
     ConnDevArtifactValidationResult validateArtifact(ConnDevArtifactType artifact, Task task, OperationResult result);
 
 

--- a/model/smart-api/src/main/java/com/evolveum/midpoint/smart/api/conndev/ConnectorDevelopmentOperation.java
+++ b/model/smart-api/src/main/java/com/evolveum/midpoint/smart/api/conndev/ConnectorDevelopmentOperation.java
@@ -180,6 +180,8 @@ public interface ConnectorDevelopmentOperation {
 
     void saveArtifact(ConnDevArtifactType endpoint, Task task, OperationResult result) throws IOException, CommonException;
 
+    ConnDevArtifactValidationResult validateArtifact(ConnDevArtifactType artifact, Task task, OperationResult result);
+
 
     default void  saveNativeSchemaScript(ConnDevArtifactType artifact, Task task, OperationResult result) throws IOException, CommonException {
         saveArtifact(artifact, task, result);

--- a/model/smart-impl/src/main/java/com/evolveum/midpoint/smart/impl/conndev/ConnectorDevelopmentBackend.java
+++ b/model/smart-impl/src/main/java/com/evolveum/midpoint/smart/impl/conndev/ConnectorDevelopmentBackend.java
@@ -11,14 +11,21 @@ import com.evolveum.midpoint.schema.GetOperationOptionsBuilder;
 import com.evolveum.midpoint.schema.constants.SchemaConstants;
 import com.evolveum.midpoint.schema.result.OperationResult;
 import com.evolveum.midpoint.schema.util.Resource;
+import com.evolveum.midpoint.smart.api.conndev.ConnDevArtifactValidationResult;
 import com.evolveum.midpoint.smart.api.conndev.ConnectorDevelopmentArtifacts;
 import com.evolveum.midpoint.smart.api.conndev.SupportedAuthorization;
 import com.evolveum.midpoint.smart.impl.conndev.activity.ConnDevBeans;
 import com.evolveum.midpoint.smart.impl.mappings.ConnDevJsonMapper;
 import com.evolveum.midpoint.task.api.RunningTask;
 import com.evolveum.midpoint.task.api.Task;
+import com.evolveum.midpoint.util.DOMUtil;
 import com.evolveum.midpoint.util.exception.*;
+import com.evolveum.midpoint.util.logging.Trace;
+import com.evolveum.midpoint.util.logging.TraceManager;
 import com.evolveum.midpoint.xml.ns._public.common.common_3.*;
+import com.evolveum.prism.xml.ns._public.types_3.RawType;
+
+import jakarta.xml.bind.JAXBElement;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -35,11 +42,14 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Properties;
 import java.util.UUID;
 import java.util.function.BooleanSupplier;
 
 public abstract class ConnectorDevelopmentBackend {
+
+    private static final Trace LOGGER = TraceManager.getTrace(ConnectorDevelopmentBackend.class);
 
     private static final JsonNodeFactory JSON_FACTORY = JsonNodeFactory.instance;
     private static final String CONNECTOR_MANIFEST = "connector.manifest.json";
@@ -227,6 +237,57 @@ public abstract class ConnectorDevelopmentBackend {
 
         editableConnector().saveFile(CONNECTOR_MANIFEST, manifest);
 
+    }
+
+    /**
+     * Validates the script by the connector itself (supported only in development mode) using
+     * the testing resource. When the validation cannot be executed (e.g. the testing resource
+     * does not exist yet or the deployed connector does not support it), the script is
+     * considered valid, so the wizard is not blocked.
+     */
+    public ConnDevArtifactValidationResult validateArtifact(ConnDevArtifactType artifact) {
+        if (artifact.getFilename() == null || !artifact.getFilename().endsWith(".groovy")) {
+            return ConnDevArtifactValidationResult.success();
+        }
+        var testing = developmentObject().getTesting();
+        if (testing == null || testing.getTestingResource() == null || testing.getTestingResource().getOid() == null) {
+            return ConnDevArtifactValidationResult.success();
+        }
+
+        var script = new ProvisioningScriptType()
+                .language("groovy")
+                .code(artifact.getContent())
+                .host(ProvisioningScriptHostType.RESOURCE);
+        script.getArgument().add(scriptArgument("operation", "validate"));
+        script.getArgument().add(scriptArgument("artifactKind",
+                ConnDevOperationType.SCHEMA.equals(artifact.getOperation()) ? "schema" : "operation"));
+
+        Object response;
+        try {
+            response = beans.provisioningService.executeScript(
+                    testing.getTestingResource().getOid(), script, task, result);
+        } catch (CommonException | RuntimeException e) {
+            LOGGER.warn("Couldn't validate script {}, proceeding without validation.", artifact.getFilename(), e);
+            return ConnDevArtifactValidationResult.success();
+        }
+
+        if (response instanceof Map<?, ?> map && "error".equals(map.get("status"))) {
+            return ConnDevArtifactValidationResult.error(
+                    map.get("phase") != null ? map.get("phase").toString() : null,
+                    map.get("message") != null ? map.get("message").toString() : null,
+                    map.get("line") instanceof Integer line ? line : null,
+                    map.get("column") instanceof Integer column ? column : null);
+        }
+        return ConnDevArtifactValidationResult.success();
+    }
+
+    private static ProvisioningScriptArgumentType scriptArgument(String name, String value) {
+        var argument = new ProvisioningScriptArgumentType();
+        argument.setName(name);
+        var node = PrismContext.get().xnodeFactory().primitive(value, DOMUtil.XSD_STRING);
+        argument.getExpressionEvaluator().add(
+                new JAXBElement<>(SchemaConstants.C_VALUE, RawType.class, new RawType(node.frozen())));
+        return argument;
     }
 
     private EditableConnector editableConnector() {

--- a/model/smart-impl/src/main/java/com/evolveum/midpoint/smart/impl/conndev/ConnectorDevelopmentBackend.java
+++ b/model/smart-impl/src/main/java/com/evolveum/midpoint/smart/impl/conndev/ConnectorDevelopmentBackend.java
@@ -11,14 +11,21 @@ import com.evolveum.midpoint.schema.GetOperationOptionsBuilder;
 import com.evolveum.midpoint.schema.constants.SchemaConstants;
 import com.evolveum.midpoint.schema.result.OperationResult;
 import com.evolveum.midpoint.schema.util.Resource;
+import com.evolveum.midpoint.smart.api.conndev.ConnDevArtifactValidationResult;
 import com.evolveum.midpoint.smart.api.conndev.ConnectorDevelopmentArtifacts;
 import com.evolveum.midpoint.smart.api.conndev.SupportedAuthorization;
 import com.evolveum.midpoint.smart.impl.conndev.activity.ConnDevBeans;
 import com.evolveum.midpoint.smart.impl.mappings.ConnDevJsonMapper;
 import com.evolveum.midpoint.task.api.RunningTask;
 import com.evolveum.midpoint.task.api.Task;
+import com.evolveum.midpoint.util.DOMUtil;
 import com.evolveum.midpoint.util.exception.*;
+import com.evolveum.midpoint.util.logging.Trace;
+import com.evolveum.midpoint.util.logging.TraceManager;
 import com.evolveum.midpoint.xml.ns._public.common.common_3.*;
+import com.evolveum.prism.xml.ns._public.types_3.RawType;
+
+import jakarta.xml.bind.JAXBElement;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -37,11 +44,14 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Properties;
 import java.util.UUID;
 import java.util.function.BooleanSupplier;
 
 public abstract class ConnectorDevelopmentBackend {
+
+    private static final Trace LOGGER = TraceManager.getTrace(ConnectorDevelopmentBackend.class);
 
     private static final JsonNodeFactory JSON_FACTORY = JsonNodeFactory.instance;
     private static final String CONNECTOR_MANIFEST = "connector.manifest.yaml";
@@ -247,6 +257,74 @@ public abstract class ConnectorDevelopmentBackend {
 
         editableConnector().saveFile(CONNECTOR_MANIFEST, manifest);
         editableConnector().deleteFileIfExists(CONNECTOR_MANIFEST_JSON_LEGACY);
+    }
+
+    /**
+     * Validates the script by the connector itself (supported only in development mode) using
+     * the testing resource. If the testing resource isn't configured yet, or the artifact isn't
+     * a groovy script, the script is considered valid (nothing to check against). Any failure to
+     * even run the check (testing resource unreachable, deployed connector broken, doesn't
+     * support script validation, ...) is reported as an error, blocking the save.
+     */
+    public ConnDevArtifactValidationResult validateArtifact(ConnDevArtifactType artifact) {
+        if (artifact.getFilename() == null || !artifact.getFilename().endsWith(".groovy")) {
+            return ConnDevArtifactValidationResult.success();
+        }
+        var testing = developmentObject().getTesting();
+        if (testing == null || testing.getTestingResource() == null || testing.getTestingResource().getOid() == null) {
+            return ConnDevArtifactValidationResult.success();
+        }
+        var testingResourceOid = testing.getTestingResource().getOid();
+
+        var script = new ProvisioningScriptType()
+                .language("groovy")
+                .code(artifact.getContent())
+                .host(ProvisioningScriptHostType.RESOURCE);
+        script.getArgument().add(scriptArgument("operation", "build"));
+        script.getArgument().add(scriptArgument("artifactKind",
+                ConnDevOperationType.SCHEMA.equals(artifact.getOperation()) ? "schema" : "operation"));
+        script.getArgument().add(scriptArgument("filename", "/" + artifact.getFilename()));
+
+        Object response;
+        try {
+            response = beans.provisioningService.executeScript(
+                    testingResourceOid, script, task, result);
+        } catch (CommonException | RuntimeException e) {
+            LOGGER.warn("Couldn't validate script {}.", artifact.getFilename(), e);
+            return ConnDevArtifactValidationResult.errors(List.of(
+                    new ConnDevArtifactValidationResult.Error(
+                            "initialization", e.getMessage(), null, null, null)));
+        }
+
+        if (!(response instanceof Map<?, ?> map) || !"error".equals(map.get("status"))) {
+            return ConnDevArtifactValidationResult.success();
+        }
+        if (map.get("errors") instanceof List<?> errorList) {
+            return ConnDevArtifactValidationResult.errors(
+                    errorList.stream()
+                            .filter(Map.class::isInstance)
+                            .map(entry -> validationError((Map<?, ?>) entry))
+                            .toList());
+        }
+        return ConnDevArtifactValidationResult.errors(List.of(validationError(map)));
+    }
+
+    private static ConnDevArtifactValidationResult.Error validationError(Map<?, ?> map) {
+        return new ConnDevArtifactValidationResult.Error(
+                map.get("phase") != null ? map.get("phase").toString() : null,
+                map.get("message") != null ? map.get("message").toString() : null,
+                map.get("line") instanceof Integer line ? line : null,
+                map.get("column") instanceof Integer column ? column : null,
+                map.get("source") != null ? map.get("source").toString() : null);
+    }
+
+    private static ProvisioningScriptArgumentType scriptArgument(String name, String value) {
+        var argument = new ProvisioningScriptArgumentType();
+        argument.setName(name);
+        var node = PrismContext.get().xnodeFactory().primitive(value, DOMUtil.XSD_STRING);
+        argument.getExpressionEvaluator().add(
+                new JAXBElement<>(SchemaConstants.C_VALUE, RawType.class, new RawType(node.frozen())));
+        return argument;
     }
 
     private EditableConnector editableConnector() {

--- a/model/smart-impl/src/main/java/com/evolveum/midpoint/smart/impl/conndev/ConnectorDevelopmentBackend.java
+++ b/model/smart-impl/src/main/java/com/evolveum/midpoint/smart/impl/conndev/ConnectorDevelopmentBackend.java
@@ -216,7 +216,10 @@ public abstract class ConnectorDevelopmentBackend {
         }
 
         saveConnectorFile(artifact.getFilename(), artifact.getContent());
-        var modelArtifact = artifact.clone().content(null);
+        // Saving through the script's own step is the user's declaration that it's fixed and back
+        // in use - clears a stale disabled:true left over from disabling it as a broken sibling
+        // (see disableArtifact()) after a schema change, rather than requiring a separate re-enable step.
+        var modelArtifact = artifact.clone().content(null).disabled(false);
 
         var delta = deltaBuilder
                 .item(itemPath).replace(modelArtifact)
@@ -225,6 +228,50 @@ public abstract class ConnectorDevelopmentBackend {
         reload();
         recomputeConnectorManifest();
         invalidateConnector();
+    }
+
+    /**
+     * Marks an already-deployed script as disabled in the manifest: the connector then skips it
+     * both when initializing for real and when reloading siblings during script validation (see
+     * conndev's manifest {@code disabled} flag). Lets the wizard offer a "Disable operation" action
+     * for a sibling script a schema change breaks, without deleting the script's content.
+     *
+     * @throws IllegalArgumentException if no deployed artifact has this filename
+     */
+    public void disableArtifact(String filename) throws IOException, CommonException {
+        var artifact = findArtifactByFilename(filename);
+        if (artifact == null) {
+            throw new IllegalArgumentException("No connector artifact found for filename " + filename);
+        }
+        var itemPath = ConnDevScriptIntentType.RELATION.equals(artifact.getIntent())
+                ? itemPathFor(artifact, ConnDevConnectorType.F_RELATION)
+                : itemPathFor(artifact, ConnDevConnectorType.F_OBJECT_CLASS);
+        if (itemPath == null) {
+            throw new IllegalArgumentException("No connector artifact found for filename " + filename);
+        }
+
+        var delta = PrismContext.get().deltaFor(ConnectorDevelopmentType.class)
+                .item(itemPath.append(ConnDevArtifactType.F_DISABLED)).replace(true)
+                .<ConnectorDevelopmentType>asObjectDelta(development.getOid());
+        beans.modelService.executeChanges(List.of(delta), null, task, result);
+        reload();
+        recomputeConnectorManifest();
+        invalidateConnector();
+    }
+
+    /**
+     * Finds the connector-scoped artifact whose filename matches {@code filename} (leading slash
+     * optional, since a validation error's {@code source} carries one but {@link
+     * ConnDevArtifactType#getFilename()} doesn't).
+     */
+    private ConnDevArtifactType findArtifactByFilename(String filename) {
+        if (filename == null) {
+            return null;
+        }
+        var normalized = filename.startsWith("/") ? filename.substring(1) : filename;
+        return ConnectorDevelopmentArtifacts.allArtifacts(development.getConnector()).stream()
+                .filter(a -> normalized.equals(a.getFilename()))
+                .findFirst().orElse(null);
     }
 
     /**

--- a/model/smart-impl/src/main/java/com/evolveum/midpoint/smart/impl/conndev/ConnectorDevelopmentServiceImpl.java
+++ b/model/smart-impl/src/main/java/com/evolveum/midpoint/smart/impl/conndev/ConnectorDevelopmentServiceImpl.java
@@ -17,6 +17,7 @@ import com.evolveum.midpoint.schema.GetOperationOptionsBuilder;
 import com.evolveum.midpoint.schema.SelectorOptions;
 import com.evolveum.midpoint.schema.processor.BareResourceSchema;
 import com.evolveum.midpoint.schema.result.OperationResult;
+import com.evolveum.midpoint.smart.api.conndev.ConnDevArtifactValidationResult;
 import com.evolveum.midpoint.smart.api.conndev.ConnectorDevelopmentArtifacts;
 import com.evolveum.midpoint.smart.api.conndev.ConnectorDevelopmentOperation;
 import com.evolveum.midpoint.smart.api.conndev.ConnectorDevelopmentService;
@@ -230,6 +231,12 @@ public class ConnectorDevelopmentServiceImpl implements ConnectorDevelopmentServ
             if (ConnDevOperationType.SCHEMA.equals(artifact.getOperation())) {
                 resetResourceSchema(task, result);
             }
+        }
+
+        @Override
+        public ConnDevArtifactValidationResult validateArtifact(ConnDevArtifactType artifact, Task task, OperationResult result) {
+            return ConnectorDevelopmentBackend.backendFor(stateObject, task, result)
+                    .validateArtifact(artifact);
         }
 
         public void comfirmApplicationInformation(Task task, OperationResult result) {

--- a/model/smart-impl/src/main/java/com/evolveum/midpoint/smart/impl/conndev/ConnectorDevelopmentServiceImpl.java
+++ b/model/smart-impl/src/main/java/com/evolveum/midpoint/smart/impl/conndev/ConnectorDevelopmentServiceImpl.java
@@ -252,6 +252,12 @@ public class ConnectorDevelopmentServiceImpl implements ConnectorDevelopmentServ
         }
 
         @Override
+        public void disableArtifact(String filename, Task task, OperationResult result) throws IOException, CommonException {
+            ConnectorDevelopmentBackend.backendFor(stateObject, task, result)
+                    .disableArtifact(filename);
+        }
+
+        @Override
         public ConnDevArtifactValidationResult validateArtifact(ConnDevArtifactType artifact, Task task, OperationResult result) {
             return ConnectorDevelopmentBackend.backendFor(stateObject, task, result)
                     .validateArtifact(artifact);

--- a/model/smart-impl/src/main/java/com/evolveum/midpoint/smart/impl/conndev/ConnectorDevelopmentServiceImpl.java
+++ b/model/smart-impl/src/main/java/com/evolveum/midpoint/smart/impl/conndev/ConnectorDevelopmentServiceImpl.java
@@ -19,6 +19,7 @@ import com.evolveum.midpoint.schema.GetOperationOptionsBuilder;
 import com.evolveum.midpoint.schema.SelectorOptions;
 import com.evolveum.midpoint.schema.processor.BareResourceSchema;
 import com.evolveum.midpoint.schema.result.OperationResult;
+import com.evolveum.midpoint.smart.api.conndev.ConnDevArtifactValidationResult;
 import com.evolveum.midpoint.smart.api.conndev.ConnectorDevelopmentArtifacts;
 import com.evolveum.midpoint.smart.api.conndev.ConnectorDevelopmentOperation;
 import com.evolveum.midpoint.smart.api.conndev.ConnectorDevelopmentService;
@@ -248,6 +249,12 @@ public class ConnectorDevelopmentServiceImpl implements ConnectorDevelopmentServ
             if (ConnDevOperationType.SCHEMA.equals(artifact.getOperation())) {
                 resetResourceSchema(task, result);
             }
+        }
+
+        @Override
+        public ConnDevArtifactValidationResult validateArtifact(ConnDevArtifactType artifact, Task task, OperationResult result) {
+            return ConnectorDevelopmentBackend.backendFor(stateObject, task, result)
+                    .validateArtifact(artifact);
         }
 
         public void comfirmApplicationInformation(Task task, OperationResult result) {

--- a/model/smart-impl/src/main/java/com/evolveum/midpoint/smart/impl/conndev/ConnectorManifestWriter.java
+++ b/model/smart-impl/src/main/java/com/evolveum/midpoint/smart/impl/conndev/ConnectorManifestWriter.java
@@ -1,5 +1,6 @@
 package com.evolveum.midpoint.smart.impl.conndev;
 
+import com.evolveum.midpoint.smart.api.conndev.ConnectorDevelopmentArtifacts;
 import com.evolveum.midpoint.xml.ns._public.common.common_3.*;
 
 import com.evolveum.prism.xml.ns._public.types_3.PolyStringType;
@@ -11,12 +12,17 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
 
 import java.io.UncheckedIOException;
+import java.util.Set;
 import java.util.function.Function;
 
 public class ConnectorManifestWriter {
 
     private static final JsonNodeFactory FACTORY = JsonNodeFactory.instance;
     private static final YAMLMapper YAML = new YAMLMapper();
+    private static final Set<ConnectorDevelopmentArtifacts.KnownArtifactType> SCHEMA_ARTIFACTS = Set.of(
+            ConnectorDevelopmentArtifacts.KnownArtifactType.NATIVE_SCHEMA_DEFINITION,
+            ConnectorDevelopmentArtifacts.KnownArtifactType.CONNID_SCHEMA_DEFINITION,
+            ConnectorDevelopmentArtifacts.KnownArtifactType.RELATIONSHIP_SCHEMA_DEFINITION);
     private final ObjectNode application;
     private final ObjectNode connector;
     private ObjectNode root;
@@ -40,22 +46,15 @@ public class ConnectorManifestWriter {
         var authorization = FACTORY.arrayNode();
         var operations = FACTORY.arrayNode();
 
-        writeScript(authorization, connector.getAuthenticationScript());
-        writeScript(operations, connector.getTestOperation());
-
-        for (var objClass : connector.getObjectClass()) {
-            writeScript(schemas, objClass.getNativeSchemaScript());
-            writeScript(schemas, objClass.getConnidSchemaScript());
-            writeScript(operations, objClass.getSearchAllOperation());
-            writeScript(operations, objClass.getSearchIdOperation());
-            writeScript(operations, objClass.getSearchFilterOperation());
-            writeScript(operations, objClass.getCreateScript());
-            writeScript(operations, objClass.getUpdateScript());
-            writeScript(operations, objClass.getDeleteScript());
-        }
-
-        for (var relation : connector.getRelation()) {
-            writeScript(schemas, relation.getSchemaScript());
+        for (var artifact : ConnectorDevelopmentArtifacts.allArtifacts(connector)) {
+            var classification = ConnectorDevelopmentArtifacts.classify(artifact);
+            if (classification == ConnectorDevelopmentArtifacts.KnownArtifactType.AUTHENTICATION_CUSTOMIZATION) {
+                writeScript(authorization, artifact);
+            } else if (classification != null && SCHEMA_ARTIFACTS.contains(classification)) {
+                writeScript(schemas, artifact);
+            } else {
+                writeScript(operations, artifact);
+            }
         }
 
         this.connector.set("schema", schemas);
@@ -75,6 +74,9 @@ public class ConnectorManifestWriter {
         writeTextProperty(json, "objectClass", artifact.getObjectClass());
         writeTextProperty(json, "operation", artifact.getOperation(), ConnDevOperationType::value);
         writeTextProperty(json, "intent", artifact.getIntent(), ConnDevScriptIntentType::value);
+        if (Boolean.TRUE.equals(artifact.isDisabled())) {
+            json.put("disabled", true);
+        }
         if (!json.isEmpty()) {
             array.add(json);
         }


### PR DESCRIPTION
The script wizard step validates the edited script by the connector itself (executeScript on the testing resource, development mode only) before writing it to the connector file. A validation error is shown on the step with the failed phase and location, and the script is not saved. When the validation cannot be executed (no testing resource yet, older deployed connector), the save proceeds as before. Non-groovy artifacts are not validated.