### PR TITLE
Invalidate cached connector instances after saving connector artifact

### DIFF
--- a/model/smart-impl/src/main/java/com/evolveum/midpoint/smart/impl/conndev/ConnectorDevelopmentBackend.java
+++ b/model/smart-impl/src/main/java/com/evolveum/midpoint/smart/impl/conndev/ConnectorDevelopmentBackend.java
@@ -207,6 +207,19 @@ public abstract class ConnectorDevelopmentBackend {
         beans.modelService.executeChanges(List.of(delta), null, task, result);
         reload();
         recomputeConnectorManifest();
+        invalidateConnector();
+    }
+
+    /**
+     * Disposes cached connector instances so that the next operation re-initializes the connector
+     * with the freshly saved scripts. Without this, provisioning keeps using the connector instance
+     * that compiled the scripts during its init.
+     */
+    private void invalidateConnector() {
+        var connectorRef = development.getConnector().getConnectorRef();
+        if (connectorRef != null && connectorRef.getOid() != null) {
+            beans.cacheDispatcher.dispatchInvalidation(ConnectorType.class, connectorRef.getOid(), false, null);
+        }
     }
 
     private void copyRelationToConnectorInfo(String objectClass) throws CommonException {

--- a/model/smart-impl/src/main/java/com/evolveum/midpoint/smart/impl/conndev/activity/ConnDevBeans.java
+++ b/model/smart-impl/src/main/java/com/evolveum/midpoint/smart/impl/conndev/activity/ConnDevBeans.java
@@ -6,6 +6,7 @@ import com.evolveum.midpoint.model.api.ModelService;
 import com.evolveum.midpoint.provisioning.api.ProvisioningService;
 import com.evolveum.midpoint.provisioning.ucf.api.ConnectorInstallationService;
 
+import com.evolveum.midpoint.repo.api.CacheDispatcher;
 import com.evolveum.midpoint.repo.api.RepositoryService;
 
 import com.evolveum.midpoint.repo.common.SystemObjectCache;
@@ -45,6 +46,7 @@ public class ConnDevBeans {
 
     @Autowired public ModelService modelService;
     @Autowired public RepositoryService repositoryService;
+    @Autowired public CacheDispatcher cacheDispatcher;
     @Autowired public ConnectorInstallationService connectorService;
     @Autowired public ProvisioningService provisioningService;
     @Autowired public SystemObjectCache systemObjectCache;


### PR DESCRIPTION
Provisioning caches configured connector instances and the scimrest connector compiles all Groovy scripts during init, so a corrected script saved via the wizard was never picked up - the test execution kept failing with the error from the previous script version. Dispatch ConnectorType cache invalidation after saveArtifact so the next operation re-initializes the connector with fresh scripts.