### PR TITLE
Run object class detail discovery as parallel tasks via multi-waiting wizard step

### DIFF
--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/component/wizard/collapse/OperationResultCollapsedItem.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/component/wizard/collapse/OperationResultCollapsedItem.java
@@ -9,8 +9,10 @@ package com.evolveum.midpoint.gui.impl.component.wizard.collapse;
 import com.evolveum.midpoint.gui.api.page.PageBase;
 import com.evolveum.midpoint.gui.impl.component.wizard.withnavigation.WizardModelWithParentSteps;
 import com.evolveum.midpoint.schema.result.OperationResult;
+import com.evolveum.midpoint.web.component.util.SerializableConsumer;
 
 import org.apache.wicket.Component;
+import org.apache.wicket.ajax.AjaxRequestTarget;
 import org.apache.wicket.model.IModel;
 import org.apache.wicket.model.Model;
 
@@ -37,8 +39,12 @@ public class OperationResultCollapsedItem extends CollapsedItem {
     }
 
     public void addOperationResult(String panelId, String fixPanelId, OperationResult result) {
+        addOperationResult(panelId, fixPanelId, result, null);
+    }
+
+    public void addOperationResult(String panelId, String fixPanelId, OperationResult result, SerializableConsumer<AjaxRequestTarget> fixAction) {
         removeOperationResult(panelId);
-        OperationResultWrapper resultWrapper = new OperationResultWrapper(result, fixPanelId);
+        OperationResultWrapper resultWrapper = new OperationResultWrapper(result, fixPanelId, fixAction);
         results.put(panelId, resultWrapper);
     }
 

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/component/wizard/collapse/OperationResultCollapsedItemPanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/component/wizard/collapse/OperationResultCollapsedItemPanel.java
@@ -135,12 +135,18 @@ public class OperationResultCollapsedItemPanel extends BasePanel<OperationResult
                         createStringResource("OperationResultCollapsedItemPanel.fixButton")) {
                     @Override
                     public void onClick(AjaxRequestTarget target) {
+                        if (resultWrapper.getFixAction() != null) {
+                            resultWrapper.getFixAction().accept(target);
+                            target.add(OperationResultCollapsedItemPanel.this);
+                            return;
+                        }
                         wizardModel.setActiveStepById(resultWrapper.getFixPanelId());
                         wizardModel.fireActiveStepChanged();
                         target.add(wizardModel.getPanel());
                     }
                 };
-                fixButton.add(new VisibleBehaviour(() -> !Strings.CS.equals(wizardModel.getActiveStep().getStepId(), resultWrapper.getFixPanelId())));
+                fixButton.add(new VisibleBehaviour(() -> resultWrapper.getFixAction() != null
+                        || !Strings.CS.equals(wizardModel.getActiveStep().getStepId(), resultWrapper.getFixPanelId())));
                 fixButton.setOutputMarkupId(true);
                 fixButton.showTitleAsLabel(true);
                 return fixButton;

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/component/wizard/collapse/OperationResultWrapper.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/component/wizard/collapse/OperationResultWrapper.java
@@ -7,6 +7,9 @@
 package com.evolveum.midpoint.gui.impl.component.wizard.collapse;
 
 import com.evolveum.midpoint.schema.result.OperationResult;
+import com.evolveum.midpoint.web.component.util.SerializableConsumer;
+
+import org.apache.wicket.ajax.AjaxRequestTarget;
 
 import java.io.Serializable;
 
@@ -14,11 +17,17 @@ public class OperationResultWrapper implements Serializable {
 
     private final OperationResult result;
     private final String fixPanelId;
+    private final SerializableConsumer<AjaxRequestTarget> fixAction;
     private boolean expanded = false;
 
     public OperationResultWrapper(OperationResult result, String fixPanelId) {
+        this(result, fixPanelId, null);
+    }
+
+    public OperationResultWrapper(OperationResult result, String fixPanelId, SerializableConsumer<AjaxRequestTarget> fixAction) {
         this.result = result;
         this.fixPanelId = fixPanelId;
+        this.fixAction = fixAction;
     }
 
     public OperationResult getResult() {
@@ -35,5 +44,9 @@ public class OperationResultWrapper implements Serializable {
 
     public String getFixPanelId() {
         return fixPanelId;
+    }
+
+    public SerializableConsumer<AjaxRequestTarget> getFixAction() {
+        return fixAction;
     }
 }

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/component/wizard/withnavigation/WizardModelWithParentSteps.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/component/wizard/withnavigation/WizardModelWithParentSteps.java
@@ -14,10 +14,12 @@ import com.evolveum.midpoint.gui.impl.component.wizard.collapse.CollapsedItem;
 
 import com.evolveum.midpoint.gui.impl.component.wizard.collapse.OperationResultCollapsedItem;
 import com.evolveum.midpoint.schema.result.OperationResult;
+import com.evolveum.midpoint.web.component.util.SerializableConsumer;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Strings;
 import org.apache.wicket.Page;
+import org.apache.wicket.ajax.AjaxRequestTarget;
 import org.apache.wicket.model.IModel;
 import org.apache.wicket.model.Model;
 import org.jetbrains.annotations.NotNull;
@@ -75,6 +77,10 @@ public abstract class WizardModelWithParentSteps extends WizardModel {
 
     public void addOperationResult(String panelId, String fixPanelId, OperationResult result) {
         operationResultCollapsedItem.addOperationResult(panelId, fixPanelId, result);
+    }
+
+    public void addOperationResult(String panelId, OperationResult result, SerializableConsumer<AjaxRequestTarget> fixAction) {
+        operationResultCollapsedItem.addOperationResult(panelId, null, result, fixAction);
     }
 
     public void removeOperationResult(String panelId) {

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/component/wizard/withnavigation/WizardWithNavigationPanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/component/wizard/withnavigation/WizardWithNavigationPanel.java
@@ -176,6 +176,7 @@ public class WizardWithNavigationPanel<AH extends AssignmentHolderType, ADM exte
 
         CollapsedInfoPanel collapsedInfoPanel = new CollapsedInfoPanel(ID_COLLAPSED_INFO_PANEL, getController());
         collapsedInfoPanel.setOutputMarkupId(true);
+        collapsedInfoPanel.setOutputMarkupPlaceholderTag(true);
         form.add(collapsedInfoPanel);
     }
 

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/component/wizard/ConnectorDevelopmentController.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/component/wizard/ConnectorDevelopmentController.java
@@ -14,6 +14,7 @@ import com.evolveum.midpoint.gui.impl.component.wizard.withnavigation.AbstractWi
 import com.evolveum.midpoint.gui.impl.component.wizard.withnavigation.AbstractWizardPartItem;
 
 import com.evolveum.midpoint.gui.impl.page.admin.connector.development.ConnectorDevelopmentDetailsModel;
+import com.evolveum.midpoint.gui.impl.page.admin.connector.development.component.wizard.scimrest.MultiWaitingConnectorStepPanel;
 import com.evolveum.midpoint.gui.impl.page.admin.connector.development.component.wizard.scimrest.basic.BasicInformationConnectorStepPanel;
 import com.evolveum.midpoint.gui.impl.page.admin.connector.development.component.wizard.scimrest.basic.DocumentationConnectorStepPanel;
 import com.evolveum.midpoint.gui.impl.page.admin.connector.development.component.wizard.scimrest.connection.ConnectionConnectorStepPanel;
@@ -61,6 +62,15 @@ public class ConnectorDevelopmentController extends AbstractWizardController<Con
 
     public ConnectorDevelopmentController(WizardPanelHelper<? extends Containerable, ConnectorDevelopmentDetailsModel> helper) {
         super(helper);
+    }
+
+    @Override
+    public boolean isCollapsedItemsVisible() {
+        // on multi-waiting steps the problems panel is shown from the beginning, even when there are no problems yet
+        if (getActiveStep() instanceof MultiWaitingConnectorStepPanel) {
+            return true;
+        }
+        return super.isCollapsedItemsVisible();
     }
 
     public void initNewObjectClass(AjaxRequestTarget target) {

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/component/wizard/ConnectorDevelopmentWizardUtil.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/component/wizard/ConnectorDevelopmentWizardUtil.java
@@ -87,15 +87,7 @@ public class ConnectorDevelopmentWizardUtil {
                 .searchObjects(TaskType.class, query, null, operationTask, operationTask.getResult());
 
         if (objectClassName != null) {
-            tasks.removeIf(task ->
-                    task.asObjectable().getActivity() == null
-                            || task.asObjectable().getActivity().getWork() == null
-                            || task.asObjectable().getActivity().getWork().getGenerateConnectorArtifact() == null
-                            || task.asObjectable().getActivity().getWork().getGenerateConnectorArtifact().getArtifact() == null
-                            || !Strings.CS.equals(
-                            task.asObjectable().getActivity().getWork().getGenerateConnectorArtifact().getArtifact().getObjectClass(),
-                            objectClassName)
-            );
+            tasks.removeIf(task -> !Strings.CS.equals(getTaskObjectClass(task.asObjectable()), objectClassName));
         }
 
         if (scriptType != null) {
@@ -114,6 +106,24 @@ public class ConnectorDevelopmentWizardUtil {
         }
 
         return tasks.get(0);
+    }
+
+    /** Resolves the object class the task works on, for the work definition types that are object class specific. */
+    private static String getTaskObjectClass(TaskType task) {
+        if (task.getActivity() == null || task.getActivity().getWork() == null) {
+            return null;
+        }
+        var work = task.getActivity().getWork();
+        if (work.getGenerateConnectorArtifact() != null && work.getGenerateConnectorArtifact().getArtifact() != null) {
+            return work.getGenerateConnectorArtifact().getArtifact().getObjectClass();
+        }
+        if (work.getDiscoverObjectClassAttributes() != null) {
+            return work.getDiscoverObjectClassAttributes().getObjectClass();
+        }
+        if (work.getDiscoverObjectClassEndpoints() != null) {
+            return work.getDiscoverObjectClassEndpoints().getObjectClass();
+        }
+        return null;
     }
 
     public static String getTaskToken(

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/component/wizard/scimrest/MultiWaitingConnectorStepPanel.html
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/component/wizard/scimrest/MultiWaitingConnectorStepPanel.html
@@ -1,0 +1,42 @@
+<!--
+  ~ Copyright (C) 2010-2025 Evolveum and contributors
+  ~
+  ~ This work is dual-licensed under the Apache License 2.0
+  ~ and European Union Public License. See LICENSE file for details.
+  -->
+
+<!DOCTYPE html>
+<html xmlns:wicket="http://wicket.apache.org">
+<wicket:extend>
+    <!-- feedback is unused in this step, but the components are created by AbstractWizardStepPanel and need markup -->
+    <div wicket:id="feedbackContainer">
+        <div wicket:id="feedback"/>
+    </div>
+    <div class="d-flex flex-column align-items-center justify-content-center w-100 gap-4" style="min-height: 60vh;">
+        <i wicket:id="titleIcon"></i>
+        <div class="d-flex flex-column align-items-center gap-2h w-100">
+            <h2 wicket:id="titleLabel" class="gen-step-title mb-0 text-center"></h2>
+            <div wicket:id="subtitleLabel" class="text-muted text-center w-50"></div>
+        </div>
+        <div class="d-flex justify-content-center w-100">
+            <div class="bg-white border rounded" style="width: 500px; max-width: 90%; padding: 20px;" wicket:id="taskContainer">
+                <div class="d-flex flex-column gap-3" wicket:id="taskRepeater">
+                    <div class="d-flex align-items-center gap-2h">
+                        <i wicket:id="taskIcon"></i>
+                        <span wicket:id="taskLabel" class="text-nowrap"></span>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <div wicket:id="elapsedTime"></div>
+        <div class="d-flex flex-row">
+            <a wicket:id="stopButton" class="btn btn-link text-decoration-none p-3 font-weight-semibold">
+                <i class="fa fa-stop mr-2"></i> Stop
+            </a>
+            <a wicket:id="retryButton" class="btn btn-link text-decoration-none p-3 font-weight-semibold ml-2">
+                <i class="fa fa-redo mr-2"></i> Retry
+            </a>
+        </div>
+    </div>
+</wicket:extend>
+</html>

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/component/wizard/scimrest/MultiWaitingConnectorStepPanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/component/wizard/scimrest/MultiWaitingConnectorStepPanel.java
@@ -1,0 +1,588 @@
+/*
+ * Copyright (C) 2010-2025 Evolveum and contributors
+ *
+ * This work is dual-licensed under the Apache License 2.0
+ * and European Union Public License. See LICENSE file for details.
+ */
+package com.evolveum.midpoint.gui.impl.page.admin.connector.development.component.wizard.scimrest;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Objects;
+
+import javax.xml.datatype.XMLGregorianCalendar;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.wicket.Component;
+import org.apache.wicket.AttributeModifier;
+import org.apache.wicket.ajax.AjaxRequestTarget;
+import org.apache.wicket.ajax.markup.html.AjaxLink;
+import org.apache.wicket.behavior.AttributeAppender;
+import org.apache.wicket.markup.html.WebMarkupContainer;
+import org.apache.wicket.markup.html.basic.Label;
+import org.apache.wicket.markup.html.list.ListItem;
+import org.apache.wicket.markup.html.list.ListView;
+import org.apache.wicket.model.IModel;
+import org.apache.wicket.model.Model;
+
+import com.evolveum.midpoint.gui.api.component.wizard.WizardModel;
+import com.evolveum.midpoint.gui.api.model.LoadableModel;
+import com.evolveum.midpoint.gui.api.util.WebModelServiceUtils;
+import com.evolveum.midpoint.gui.impl.component.wizard.AbstractWizardStepPanel;
+import com.evolveum.midpoint.gui.impl.component.wizard.WizardPanelHelper;
+import com.evolveum.midpoint.gui.impl.component.wizard.withnavigation.WizardModelWithParentSteps;
+import com.evolveum.midpoint.gui.impl.page.admin.connector.development.ConnectorDevelopmentDetailsModel;
+import com.evolveum.midpoint.gui.impl.page.admin.connector.development.component.wizard.ConnectorDevelopmentWizardUtil;
+import com.evolveum.midpoint.gui.impl.page.admin.resource.component.wizard.schemaHandling.objectType.smart.component.TimerProgressPanel;
+import com.evolveum.midpoint.gui.impl.page.admin.resource.component.wizard.schemaHandling.objectType.smart.dto.SmartGeneratingDto;
+import com.evolveum.midpoint.prism.Containerable;
+import com.evolveum.midpoint.prism.PrismObject;
+import com.evolveum.midpoint.prism.path.ItemName;
+import com.evolveum.midpoint.schema.result.OperationResult;
+import com.evolveum.midpoint.smart.api.info.StatusInfo;
+import com.evolveum.midpoint.task.api.Task;
+import com.evolveum.midpoint.util.exception.CommonException;
+import com.evolveum.midpoint.util.exception.ObjectNotFoundException;
+import com.evolveum.midpoint.util.exception.SchemaException;
+import com.evolveum.midpoint.util.logging.Trace;
+import com.evolveum.midpoint.util.logging.TraceManager;
+import com.evolveum.midpoint.web.component.util.VisibleBehaviour;
+import com.evolveum.midpoint.web.component.util.VisibleEnableBehaviour;
+import com.evolveum.midpoint.web.security.MidPointApplication;
+import com.evolveum.midpoint.web.util.TaskOperationUtils;
+import com.evolveum.midpoint.xml.ns._public.common.common_3.ConnectorDevelopmentType;
+import com.evolveum.midpoint.xml.ns._public.common.common_3.OperationResultStatusType;
+import com.evolveum.midpoint.xml.ns._public.common.common_3.TaskExecutionStateType;
+import com.evolveum.midpoint.xml.ns._public.common.common_3.TaskType;
+
+/**
+ * @author lskublik
+ */
+public abstract class MultiWaitingConnectorStepPanel extends AbstractWizardStepPanel<ConnectorDevelopmentDetailsModel> {
+
+    private static final Trace LOGGER = TraceManager.getTrace(MultiWaitingConnectorStepPanel.class);
+
+    private static final String CLASS_DOT = MultiWaitingConnectorStepPanel.class.getName() + ".";
+    private static final String OP_DETERMINE_STATUS = CLASS_DOT + "determineStatus";
+    private static final String OP_LOAD_CONNECTOR = CLASS_DOT + "loadConnector";
+    private static final String OP_RESTART_ACTIVITY = CLASS_DOT + "restartActivity";
+
+    private static final String ID_TITLE_ICON = "titleIcon";
+    private static final String ID_TITLE_LABEL = "titleLabel";
+    private static final String ID_SUBTITLE_LABEL = "subtitleLabel";
+    private static final String ID_TASK_CONTAINER = "taskContainer";
+    private static final String ID_TASK_REPEATER = "taskRepeater";
+    private static final String ID_TASK_ICON = "taskIcon";
+    private static final String ID_TASK_LABEL = "taskLabel";
+    private static final String ID_STOP_BUTTON = "stopButton";
+    private static final String ID_RETRY_BUTTON = "retryButton";
+    private static final String ID_ELAPSED_TIME = "elapsedTime";
+
+    private LoadableModel<List<TaskStatusDto>> statusesModel;
+    private WebMarkupContainer taskListContainer;
+    private WebMarkupContainer titleIconContainer;
+    private org.apache.wicket.ajax.AbstractAjaxTimerBehavior refreshTimer;
+    private boolean isReloaded = false;
+
+    public MultiWaitingConnectorStepPanel(WizardPanelHelper<? extends Containerable, ConnectorDevelopmentDetailsModel> helper) {
+        super(helper);
+    }
+
+    protected final void markAsReloaded() {
+        isReloaded = true;
+    }
+
+    protected final boolean isReloaded() {
+        return isReloaded;
+    }
+
+    @Override
+    public void init(WizardModel wizard) {
+        super.init(wizard);
+
+        statusesModel = new LoadableModel<>() {
+            @Override
+            protected List<TaskStatusDto> load() {
+                String oid = getDetailsModel().getObjectWrapper().getOid();
+
+                Task task = getDetailsModel().getPageAssignmentHolder().createSimpleTask(OP_DETERMINE_STATUS);
+                OperationResult result = task.getResult();
+
+                List<ItemName> activityTypes = getActivityTypes();
+                List<String> tokens = new ArrayList<>();
+                boolean anyMissing = false;
+
+                for (ItemName activityType : activityTypes) {
+                    try {
+                        String token = ConnectorDevelopmentWizardUtil.getTaskToken(
+                                activityType,
+                                getObjectClassName(),
+                                null,
+                                oid,
+                                getDetailsModel().getPageAssignmentHolder());
+                        if (StringUtils.isEmpty(token)) {
+                            anyMissing = true;
+                        }
+                        tokens.add(token);
+                    } catch (CommonException e) {
+                        LOGGER.error("Couldn't search tasks for " + activityType);
+                        tokens.add(null);
+                        anyMissing = true;
+                    }
+                }
+
+                if (anyMissing && !isReloaded) {
+                    if (oid == null) {
+                        List<TaskStatusDto> dtos = new ArrayList<>();
+                        for (int i = 0; i < activityTypes.size(); i++) {
+                            dtos.add(createDto(activityTypes.get(i), tokens.get(i), task, result));
+                        }
+                        return dtos;
+                    }
+                    String objectClassName = null;
+                    try {
+                        objectClassName = getObjectClassName();
+                    } catch (Exception ignored) {}
+                    if (objectClassRequired() && StringUtils.isEmpty(objectClassName)) {
+                        List<TaskStatusDto> dtos = new ArrayList<>();
+                        for (int i = 0; i < activityTypes.size(); i++) {
+                            dtos.add(createDto(activityTypes.get(i), tokens.get(i), task, result));
+                        }
+                        return dtos;
+                    }
+                    triggerOperation(task, result);
+                    markAsReloaded();
+                    // Refresh tokens after submission
+                    tokens.clear();
+                    for (ItemName activityType : activityTypes) {
+                        try {
+                            String refreshed = ConnectorDevelopmentWizardUtil.getTaskToken(
+                                    activityType,
+                                    getObjectClassName(),
+                                    null,
+                                    oid,
+                                    getDetailsModel().getPageAssignmentHolder());
+                            tokens.add(refreshed);
+                        } catch (CommonException e) {
+                            LOGGER.error("Couldn't refresh token for " + activityType, e);
+                            tokens.add(null);
+                        }
+                    }
+                }
+
+                List<TaskStatusDto> dtos = new ArrayList<>();
+                for (int i = 0; i < activityTypes.size(); i++) {
+                    dtos.add(createDto(activityTypes.get(i), tokens.get(i), task, result));
+                }
+                return dtos;
+            }
+        };
+    }
+
+    protected abstract List<ItemName> getActivityTypes();
+
+    protected abstract StatusInfo<?> obtainResult(ItemName activityType, String token, Task task, OperationResult result) throws SchemaException, ObjectNotFoundException;
+
+    protected abstract String triggerOperation(Task task, OperationResult result);
+
+    protected String getObjectClassName() {
+        return null;
+    }
+
+    protected abstract boolean objectClassRequired();
+
+    private TaskStatusDto createDto(ItemName activityType, String token, Task opTask, OperationResult opResult) {
+        if (StringUtils.isEmpty(token)) {
+            return new TaskStatusDto(activityType, getTaskTitleModel(activityType), null, null);
+        }
+
+        LoadableModel<StatusInfo<?>> statusInfoModel = new LoadableModel<>() {
+            @Override
+            protected StatusInfo<?> load() {
+                try {
+                    MidPointApplication app = MidPointApplication.get();
+                    Task task = app.createSimpleTask(OP_DETERMINE_STATUS);
+                    OperationResult result = task.getResult();
+                    return obtainResult(activityType, token, task, result);
+                } catch (SchemaException|ObjectNotFoundException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        };
+
+        PrismObject<TaskType> taskTypePrismObject = WebModelServiceUtils.loadObject(TaskType.class, token, getDetailsModel().getPageAssignmentHolder(), opTask, opResult);
+        return new TaskStatusDto(activityType, getTaskTitleModel(activityType), statusInfoModel, () -> taskTypePrismObject);
+    }
+
+    protected IModel<String> getTaskTitleModel(ItemName activityType) {
+        return Model.of(activityType.getLocalPart());
+    }
+
+    protected IModel<String> getSubtitle() {
+        return Model.of("");
+    }
+
+    @Override
+    protected void onInitialize() {
+        super.onInitialize();
+        initLayout();
+        refreshTimer = new org.apache.wicket.ajax.AbstractAjaxTimerBehavior(java.time.Duration.ofSeconds(2)) {
+            @Override
+            protected void onTimer(AjaxRequestTarget target) {
+                statusesModel.reset();
+                List<TaskStatusDto> dtos = statusesModel.getObject();
+                target.add(taskListContainer);
+                target.add(titleIconContainer);
+                if (dtos.stream().anyMatch(SmartGeneratingDto::isFailed)) {
+                    reportFailedTasksToRightPanel(dtos, target);
+                }
+                target.add(get(ID_STOP_BUTTON));
+                target.add(get(ID_RETRY_BUTTON));
+                target.add(get(ID_ELAPSED_TIME));
+                boolean allDone = !dtos.isEmpty() && dtos.stream().allMatch(dto -> dto.isFinished() || dto.isFailed());
+                if (allDone) {
+                    stop(target);
+                    if (dtos.stream().noneMatch(dto -> dto.isFailed() || dto.isSuspended())) {
+                        MultiWaitingConnectorStepPanel.this.onNextPerformed(target);
+                    }
+                }
+            }
+        };
+        add(refreshTimer);
+    }
+
+    @Override
+    protected IModel<String> getTextModel() {
+        return getTitle();
+    }
+
+    private void initLayout() {
+        getSubtextLabel().add(VisibleEnableBehaviour.ALWAYS_INVISIBLE);
+        getFeedback().add(VisibleEnableBehaviour.ALWAYS_INVISIBLE);
+        // parent's title label renders above the child markup, we show our own title below the spinner instead
+        getTextLabel().add(VisibleEnableBehaviour.ALWAYS_INVISIBLE);
+
+        titleIconContainer = new WebMarkupContainer(ID_TITLE_ICON);
+        titleIconContainer.setOutputMarkupId(true);
+        titleIconContainer.add(AttributeModifier.replace("class", () -> resolveTitleIconClass()));
+        add(titleIconContainer);
+
+        add(new Label(ID_TITLE_LABEL, getTitle()));
+
+        IModel<String> subtitleModel = getSubtitle();
+        Label subtitleLabel = new Label(ID_SUBTITLE_LABEL, subtitleModel);
+        subtitleLabel.add(new VisibleBehaviour(() -> StringUtils.isNotBlank(subtitleModel.getObject())));
+        add(subtitleLabel);
+
+        taskListContainer = new WebMarkupContainer(ID_TASK_CONTAINER);
+        taskListContainer.setOutputMarkupId(true);
+        add(taskListContainer);
+
+        ListView<TaskStatusDto> taskList = new ListView<>(ID_TASK_REPEATER, statusesModel) {
+            @Override
+            protected void populateItem(ListItem<TaskStatusDto> item) {
+                WebMarkupContainer icon = new WebMarkupContainer(ID_TASK_ICON);
+                icon.add(AttributeModifier.replace("class", () -> resolveIconClass(item.getModelObject())));
+                item.add(icon);
+                Label label = new Label(ID_TASK_LABEL, item.getModelObject().getTitleModel());
+                // finished rows are grey, the running one keeps the default (toned) color
+                label.add(AttributeAppender.append("class",
+                        () -> item.getModelObject().isFinished() || item.getModelObject().isFailed() ? "text-muted" : ""));
+                item.add(label);
+            }
+        };
+        taskList.setReuseItems(false);
+        taskListContainer.add(taskList);
+
+        TimerProgressPanel elapsedTime = new TimerProgressPanel(ID_ELAPSED_TIME,
+                () -> getEarliestStartTime(),
+                () -> getLatestEndTime());
+        add(elapsedTime);
+
+        AjaxLink<Void> stopButton = new AjaxLink<>(ID_STOP_BUTTON) {
+            @Override
+            public void onClick(AjaxRequestTarget target) {
+                stopRunningTasks(target);
+            }
+        };
+        stopButton.setOutputMarkupPlaceholderTag(true);
+        stopButton.add(new VisibleBehaviour(this::anyTaskRunning));
+        add(stopButton);
+
+        AjaxLink<Void> retryButton = new AjaxLink<>(ID_RETRY_BUTTON) {
+            @Override
+            public void onClick(AjaxRequestTarget target) {
+                retryNotSuccessfulTasks(target);
+            }
+        };
+        retryButton.setOutputMarkupPlaceholderTag(true);
+        retryButton.add(new VisibleBehaviour(() -> !anyTaskRunning() && anyTaskNotSuccessful()));
+        add(retryButton);
+    }
+
+    private XMLGregorianCalendar getEarliestStartTime() {
+        return statusesModel.getObject().stream()
+                .map(SmartGeneratingDto::getSuggestedObjectsStartTime)
+                .filter(Objects::nonNull)
+                .min(Comparator.comparingLong(calendar -> calendar.toGregorianCalendar().getTimeInMillis()))
+                .orElse(null);
+    }
+
+    private XMLGregorianCalendar getLatestEndTime() {
+        List<TaskStatusDto> dtos = statusesModel.getObject();
+        boolean allDone = !dtos.isEmpty() && dtos.stream().allMatch(dto -> dto.isFinished() || dto.isFailed());
+        if (!allDone) {
+            return null;
+        }
+        return dtos.stream()
+                .map(SmartGeneratingDto::getSuggestedObjectsEndTime)
+                .filter(Objects::nonNull)
+                .max(Comparator.comparingLong(calendar -> calendar.toGregorianCalendar().getTimeInMillis()))
+                .orElse(null);
+    }
+
+    private boolean anyTaskRunning() {
+        return statusesModel.getObject().stream()
+                .anyMatch(dto -> !dto.isFinished() && !dto.isFailed());
+    }
+
+    private boolean anyTaskNotSuccessful() {
+        return statusesModel.getObject().stream()
+                .anyMatch(dto -> dto.isFailed() || dto.isSuspended());
+    }
+
+    private void retryNotSuccessfulTasks(AjaxRequestTarget target) {
+        List<ItemName> activitiesToRetry = statusesModel.getObject().stream()
+                .filter(dto -> dto.isFailed() || dto.isSuspended())
+                .map(TaskStatusDto::getActivityType)
+                .toList();
+        if (activitiesToRetry.isEmpty()) {
+            return;
+        }
+
+        Task task = getDetailsModel().getPageAssignmentHolder().createSimpleTask(OP_RESTART_ACTIVITY);
+        OperationResult result = task.getResult();
+        for (ItemName activityType : activitiesToRetry) {
+            restartActivity(activityType, task, result);
+            if (getWizard() instanceof WizardModelWithParentSteps wizardModel) {
+                wizardModel.removeOperationResult(getStepId() + "." + activityType.getLocalPart());
+            }
+        }
+
+        refreshAfterRestart(target);
+    }
+
+    private void stopRunningTasks(AjaxRequestTarget target) {
+        List<TaskType> runningTasks = statusesModel.getObject().stream()
+                .map(TaskStatusDto::getTaskObject)
+                .filter(Objects::nonNull)
+                .filter(taskBean -> taskBean.getExecutionState() != TaskExecutionStateType.CLOSED
+                        && taskBean.getExecutionState() != TaskExecutionStateType.SUSPENDED)
+                .toList();
+        if (!runningTasks.isEmpty()) {
+            TaskOperationUtils.suspendTasks(runningTasks, getPageBase());
+        }
+        statusesModel.reset();
+        target.add(taskListContainer);
+        target.add(titleIconContainer);
+        target.add(get(ID_STOP_BUTTON));
+        target.add(get(ID_RETRY_BUTTON));
+        target.add(get(ID_ELAPSED_TIME));
+    }
+
+    private String resolveTitleIconClass() {
+        if (statusesModel == null || !statusesModel.isLoaded()) {
+            return "fa fa-spinner fa-spin fa-2x text-primary";
+        }
+        List<TaskStatusDto> dtos = statusesModel.getObject();
+        if (dtos.stream().anyMatch(SmartGeneratingDto::isFailed)) {
+            return "fa fa-exclamation-triangle fa-2x text-danger";
+        }
+        if (dtos.stream().anyMatch(SmartGeneratingDto::isSuspended)) {
+            return "fa fa-pause-circle fa-2x text-info";
+        }
+        if (dtos.stream().allMatch(SmartGeneratingDto::isFinished)) {
+            return "fa fa-check fa-2x text-success";
+        }
+        return "fa fa-spinner fa-spin fa-2x text-primary";
+    }
+
+    @Override
+    public String appendCssToWizard() {
+        return "col-12";
+    }
+
+    @Override
+    protected boolean isSubmitVisible() {
+        return false;
+    }
+
+    @Override
+    protected IModel<String> getNextLabelModel() {
+        return null;
+    }
+
+    @Override
+    public boolean isCompleted() {
+        List<TaskStatusDto> dtos = statusesModel.getObject();
+        if (dtos == null || dtos.isEmpty()) {
+            return false;
+        }
+
+        for (TaskStatusDto dto : dtos) {
+            String token = dto.getToken();
+            if (StringUtils.isEmpty(token)) {
+                return false;
+            }
+
+            Task operationTask = getDetailsModel().getPageAssignmentHolder().createSimpleTask("create_task_instance");
+            try {
+                Task task = getDetailsModel().getPageAssignmentHolder().getTaskManager().getTask(
+                        token, null, operationTask.getResult());
+                if (task == null || task.getExecutionState() != TaskExecutionStateType.CLOSED || task.getResultStatus() != OperationResultStatusType.SUCCESS) {
+                    return false;
+                }
+            } catch (CommonException e) {
+                LOGGER.error("Couldn't create Task instance");
+                return false;
+            }
+        }
+        return true;
+    }
+
+    @Override
+    public boolean onNextPerformed(AjaxRequestTarget target) {
+        String oid = getDetailsModel().getObjectWrapper().getOid();
+        Task task = getPageBase().createSimpleTask(OP_LOAD_CONNECTOR);
+
+        getDetailsModel().reset();
+        getDetailsModel().reloadPrismObjectModel(
+                WebModelServiceUtils.loadObject(ConnectorDevelopmentType.class, oid, getPageBase(), task, task.getResult()));
+        isReloaded = false;
+        return super.onNextPerformed(target);
+    }
+
+    @Override
+    public VisibleEnableBehaviour getNextBehaviour() {
+        return VisibleEnableBehaviour.ALWAYS_INVISIBLE;
+    }
+
+    @Override
+    public VisibleEnableBehaviour getBackBehaviour() {
+        return VisibleEnableBehaviour.ALWAYS_INVISIBLE;
+    }
+
+    @Override
+    protected boolean isSubmitEnable() {
+        return false;
+    }
+
+    @Override
+    public IModel<Boolean> isStepVisible() {
+        return () -> {
+            if (statusesModel == null || !statusesModel.isLoaded()) {
+                boolean completed = isCompleted();
+                return !completed;
+            }
+            boolean anyNotFinished = statusesModel.getObject().stream()
+                    .anyMatch(dto -> !dto.isFinished() || dto.isSuspended());
+            return anyNotFinished;
+        };
+    }
+
+    private void reportFailedTasksToRightPanel(List<TaskStatusDto> dtos, AjaxRequestTarget target) {
+        if (!(getWizard() instanceof WizardModelWithParentSteps wizardModel)) {
+            return;
+        }
+
+        for (ItemName activityType : getActivityTypes()) {
+            wizardModel.removeOperationResult(getStepId() + "." + activityType.getLocalPart());
+        }
+
+        for (TaskStatusDto dto : dtos) {
+            if (!dto.isFailed()) {
+                continue;
+            }
+            String taskTitle = dto.getTitleModel() != null ? dto.getTitleModel().getObject() : "Unknown task";
+            String localizedMsg = (dto.getStatusInfo() != null && dto.getStatusInfo().getObject() != null)
+                    ? dto.getStatusInfo().getObject().getLocalizedMessage()
+                    : null;
+            String message = (localizedMsg != null && !localizedMsg.isBlank()) ? localizedMsg : taskTitle + " failed";
+
+            OperationResult taskResult = new OperationResult(taskTitle);
+            taskResult.recordFatalError(message);
+            ItemName activityType = dto.getActivityType();
+            wizardModel.addOperationResult(
+                    getStepId() + "." + activityType.getLocalPart(),
+                    taskResult,
+                    fixTarget -> restartFailedActivity(activityType, fixTarget));
+        }
+
+        Component collapsedInfoPanel = getWizard().getPanel().get("mainForm:collapsedInfoPanel");
+        if (collapsedInfoPanel != null) {
+            target.add(collapsedInfoPanel);
+        }
+    }
+
+    private void restartFailedActivity(ItemName activityType, AjaxRequestTarget target) {
+        Task task = getDetailsModel().getPageAssignmentHolder().createSimpleTask(OP_RESTART_ACTIVITY);
+        OperationResult result = task.getResult();
+        restartActivity(activityType, task, result);
+
+        if (getWizard() instanceof WizardModelWithParentSteps wizardModel) {
+            wizardModel.removeOperationResult(getStepId() + "." + activityType.getLocalPart());
+        }
+
+        refreshAfterRestart(target);
+    }
+
+    private void refreshAfterRestart(AjaxRequestTarget target) {
+        statusesModel.reset();
+        if (refreshTimer != null && refreshTimer.isStopped()) {
+            refreshTimer.restart(target);
+        }
+        target.add(taskListContainer);
+        target.add(titleIconContainer);
+        target.add(get(ID_STOP_BUTTON));
+        target.add(get(ID_RETRY_BUTTON));
+        target.add(get(ID_ELAPSED_TIME));
+
+        Component collapsedInfoPanel = getWizard().getPanel().get("mainForm:collapsedInfoPanel");
+        if (collapsedInfoPanel != null) {
+            target.add(collapsedInfoPanel);
+        }
+    }
+
+    /** Resubmits the task for the given activity. Used by the 'Fix it' button when the previous run failed. */
+    protected abstract String restartActivity(ItemName activityType, Task task, OperationResult result);
+
+    private static String resolveIconClass(TaskStatusDto dto) {
+        if (dto.getStatusInfo() == null || dto.getStatusInfo().getObject() == null) {
+            return "fa fa-spinner fa-spin text-secondary";
+        }
+        if (dto.isFailed()) return "fa fa-exclamation-triangle text-danger";
+        if (dto.isSuspended()) return "fa fa-pause-circle text-info";
+        if (dto.isFinished()) return "fa fa-check text-success";
+        return "fa fa-spinner fa-spin";
+    }
+
+    private static class TaskStatusDto extends SmartGeneratingDto {
+        private final ItemName activityType;
+        private final IModel<String> titleModel;
+
+        public TaskStatusDto(ItemName activityType, IModel<String> titleModel, LoadableModel<StatusInfo<?>> statusInfo, IModel<PrismObject<TaskType>> taskModel) {
+            super(statusInfo, taskModel);
+            this.activityType = activityType;
+            this.titleModel = titleModel;
+        }
+
+        public IModel<String> getTitleModel() {
+            return titleModel;
+        }
+
+        public ItemName getActivityType() {
+            return activityType;
+        }
+    }
+}

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/component/wizard/scimrest/objectclass/schema/WaitingObjectClassDetailsConnectorStepPanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/component/wizard/scimrest/objectclass/schema/WaitingObjectClassDetailsConnectorStepPanel.java
@@ -8,7 +8,9 @@ package com.evolveum.midpoint.gui.impl.page.admin.connector.development.componen
 
 import com.evolveum.midpoint.gui.api.prism.wrapper.PrismContainerValueWrapper;
 import com.evolveum.midpoint.gui.impl.page.admin.connector.development.component.wizard.ConnectorDevelopmentWizardUtil;
+import com.evolveum.midpoint.gui.impl.page.admin.connector.development.component.wizard.scimrest.MultiWaitingConnectorStepPanel;
 import com.evolveum.midpoint.prism.path.ItemName;
+import com.evolveum.midpoint.smart.api.conndev.ConnectorDevelopmentOperation;
 import com.evolveum.midpoint.xml.ns._public.common.common_3.ConnDevObjectClassInfoType;
 import com.evolveum.midpoint.xml.ns._public.common.common_3.ConnectorDevelopmentType;
 import com.evolveum.midpoint.xml.ns._public.common.common_3.OperationTypeType;
@@ -18,7 +20,6 @@ import org.apache.wicket.model.IModel;
 
 import com.evolveum.midpoint.gui.impl.component.wizard.WizardPanelHelper;
 import com.evolveum.midpoint.gui.impl.page.admin.connector.development.ConnectorDevelopmentDetailsModel;
-import com.evolveum.midpoint.gui.impl.page.admin.connector.development.component.wizard.scimrest.WaitingConnectorStepPanel;
 import com.evolveum.midpoint.prism.Containerable;
 import com.evolveum.midpoint.schema.result.OperationResult;
 import com.evolveum.midpoint.smart.api.info.StatusInfo;
@@ -29,7 +30,11 @@ import com.evolveum.midpoint.web.application.PanelDisplay;
 import com.evolveum.midpoint.web.application.PanelInstance;
 import com.evolveum.midpoint.web.application.PanelType;
 
+import java.util.List;
+
 /**
+ * Waits for two parallel tasks discovering object class details: attributes and endpoints.
+ *
  * @author lskublik
  */
 @PanelType(name = "cdw-connector-waiting-object-class-details")
@@ -38,7 +43,7 @@ import com.evolveum.midpoint.web.application.PanelType;
         applicableForOperation = OperationTypeType.WIZARD,
         display = @PanelDisplay(label = "PageConnectorDevelopment.wizard.step.connectorWaitingObjectClassDetails", icon = "fa fa-wrench"),
         containerPath = "empty")
-public class WaitingObjectClassDetailsConnectorStepPanel extends WaitingConnectorStepPanel {
+public class WaitingObjectClassDetailsConnectorStepPanel extends MultiWaitingConnectorStepPanel {
 
     private static final String PANEL_TYPE = "cdw-connector-waiting-object-class-details";
     private final IModel<PrismContainerValueWrapper<ConnDevObjectClassInfoType>> valueModel;
@@ -51,19 +56,63 @@ public class WaitingObjectClassDetailsConnectorStepPanel extends WaitingConnecto
     }
 
     @Override
-    protected StatusInfo<?> obtainResult(String token, Task task, OperationResult result) throws SchemaException, ObjectNotFoundException {
-        return getDetailsModel().getServiceLocator().getConnectorService().getDiscoverObjectClassAttributesStatus(token, task, result);
+    protected List<ItemName> getActivityTypes() {
+        return List.of(
+                WorkDefinitionsType.F_DISCOVER_OBJECT_CLASS_ATTRIBUTES,
+                WorkDefinitionsType.F_DISCOVER_OBJECT_CLASS_ENDPOINTS);
     }
 
     @Override
-    protected String getNewTaskToken(Task task, OperationResult result, boolean regenerate) {
-        return getDetailsModel().getConnectorDevelopmentOperation().submitDiscoverObjectClassDetails(
-                valueModel.getObject().getRealValue().getName(), task, result);
+    protected StatusInfo<?> obtainResult(ItemName activityType, String token, Task task, OperationResult result)
+            throws SchemaException, ObjectNotFoundException {
+        var service = getDetailsModel().getServiceLocator().getConnectorService();
+        if (WorkDefinitionsType.F_DISCOVER_OBJECT_CLASS_ENDPOINTS.equals(activityType)) {
+            return service.getDiscoverObjectClassEndpointsStatus(token, task, result);
+        }
+        return service.getDiscoverObjectClassAttributesStatus(token, task, result);
+    }
+
+    @Override
+    protected String triggerOperation(Task task, OperationResult result) {
+        ConnectorDevelopmentOperation op = getDetailsModel().getConnectorDevelopmentOperation();
+        if (op == null) {
+            return null;
+        }
+        String objectClass = getObjectClassName();
+        op.submitDiscoverObjectClassAttributes(objectClass, task, result);
+        op.submitDiscoverObjectClassEndpoints(objectClass, task, result);
+        return null;
+    }
+
+    @Override
+    protected String restartActivity(ItemName activityType, Task task, OperationResult result) {
+        ConnectorDevelopmentOperation op = getDetailsModel().getConnectorDevelopmentOperation();
+        if (op == null) {
+            return null;
+        }
+        String objectClass = getObjectClassName();
+        if (WorkDefinitionsType.F_DISCOVER_OBJECT_CLASS_ENDPOINTS.equals(activityType)) {
+            return op.submitDiscoverObjectClassEndpoints(objectClass, task, result);
+        }
+        return op.submitDiscoverObjectClassAttributes(objectClass, task, result);
+    }
+
+    @Override
+    protected IModel<String> getTaskTitleModel(ItemName activityType) {
+        if (WorkDefinitionsType.F_DISCOVER_OBJECT_CLASS_ENDPOINTS.equals(activityType)) {
+            return createStringResource("WaitingObjectClassDetailsConnectorStepPanel.discoverObjectClassEndpoints");
+        }
+        return createStringResource("WaitingObjectClassDetailsConnectorStepPanel.discoverObjectClassAttributes");
     }
 
     @Override
     protected boolean objectClassRequired() {
         return true;
+    }
+
+    @Override
+    protected String getObjectClassName() {
+        return valueModel.getObject().getRealValue().getName();
     }
 
     @Override
@@ -77,23 +126,8 @@ public class WaitingObjectClassDetailsConnectorStepPanel extends WaitingConnecto
     }
 
     @Override
-    protected IModel<String> getTextModel() {
-        return createStringResource("PageConnectorDevelopment.wizard.step.connectorWaitingObjectClassDetails.text");
-    }
-
-    @Override
-    protected IModel<String> getSubTextModel() {
+    protected IModel<String> getSubtitle() {
         return createStringResource("PageConnectorDevelopment.wizard.step.connectorWaitingObjectClassDetails.subText");
-    }
-
-    @Override
-    protected ItemName getActivityType() {
-        return WorkDefinitionsType.F_DISCOVER_OBJECT_CLASS_ATTRIBUTES;
-    }
-
-    @Override
-    protected String getObjectClassName() {
-        return valueModel.getObject().getRealValue().getName();
     }
 
     @Override

--- a/model/smart-impl/src/main/java/com/evolveum/midpoint/smart/impl/conndev/activity/DiscoverObjectClassAttributesActivityHandler.java
+++ b/model/smart-impl/src/main/java/com/evolveum/midpoint/smart/impl/conndev/activity/DiscoverObjectClassAttributesActivityHandler.java
@@ -15,9 +15,7 @@ import com.evolveum.midpoint.schema.result.OperationResult;
 import com.evolveum.midpoint.smart.impl.conndev.ConnectorDevelopmentBackend;
 import com.evolveum.midpoint.util.exception.CommonException;
 
-import com.evolveum.midpoint.prism.path.ItemName;
 
-import java.util.Set;
 import com.evolveum.midpoint.util.exception.ConfigurationException;
 import com.evolveum.midpoint.util.logging.Trace;
 import com.evolveum.midpoint.util.logging.TraceManager;
@@ -50,11 +48,6 @@ public class DiscoverObjectClassAttributesActivityHandler
         handlerRegistry.unregister(
                 ConnDevDiscoverObjectClassAttributesDefinitionType.COMPLEX_TYPE,
                 DiscoverObjectClassAttributesActivityHandler.WorkDefinition.class);
-    }
-
-    @Override
-    public @NotNull Set<ItemName> getSiblingActivityTypes() {
-        return Set.of(WorkDefinitionsType.F_DISCOVER_OBJECT_CLASS_ENDPOINTS);
     }
 
     @Override
@@ -92,21 +85,16 @@ public class DiscoverObjectClassAttributesActivityHandler
             String connectorDevelopmentOid = getWorkDefinition().connectorDevelopmentOid;
 
             LOGGER.info("Discovering attributes for object class '{}' in task {}", objectClass, getRunningTask().getName());
-            try {
-                var backend = ConnectorDevelopmentBackend.backendFor(connectorDevelopmentOid, getRunningTask(), result);
-                backend.ensureDocumentationIsProcessed();
-                backend.ensureObjectClass(objectClass);
+            var backend = ConnectorDevelopmentBackend.backendFor(connectorDevelopmentOid, getRunningTask(), result);
+            backend.ensureDocumentationIsProcessed();
+            backend.ensureObjectClass(objectClass);
 
-                var skipCache = Boolean.TRUE.equals(getWorkDefinition().typedDefinition.getSkipCache());
-                var attributes = backend.discoverObjectClassAttributes(objectClass, skipCache);
-                backend.updateConnectorObjectClassAttributes(objectClass, attributes);
-            } catch (CommonException | RuntimeException e) {
-                getActivityHandler().suspendSiblings(connectorDevelopmentOid, this, result);
-                throw e;
-            }
+            var skipCache = Boolean.TRUE.equals(getWorkDefinition().typedDefinition.getSkipCache());
+            var attributes = backend.discoverObjectClassAttributes(objectClass, skipCache);
+            backend.updateConnectorObjectClassAttributes(objectClass, attributes);
             LOGGER.info("Successfully discovered attributes for object class '{}'", objectClass);
 
-            return getActivityHandler().waitForSiblingByPolling(connectorDevelopmentOid, this, result);
+            return ActivityRunResult.success();
         }
     }
 }

--- a/model/smart-impl/src/main/java/com/evolveum/midpoint/smart/impl/conndev/activity/DiscoverObjectClassEndpointsActivityHandler.java
+++ b/model/smart-impl/src/main/java/com/evolveum/midpoint/smart/impl/conndev/activity/DiscoverObjectClassEndpointsActivityHandler.java
@@ -15,9 +15,7 @@ import com.evolveum.midpoint.schema.result.OperationResult;
 import com.evolveum.midpoint.smart.impl.conndev.ConnectorDevelopmentBackend;
 import com.evolveum.midpoint.util.exception.CommonException;
 
-import com.evolveum.midpoint.prism.path.ItemName;
 
-import java.util.Set;
 import com.evolveum.midpoint.util.exception.ConfigurationException;
 import com.evolveum.midpoint.util.logging.Trace;
 import com.evolveum.midpoint.util.logging.TraceManager;
@@ -50,11 +48,6 @@ public class DiscoverObjectClassEndpointsActivityHandler
         handlerRegistry.unregister(
                 ConnDevDiscoverObjectClassEndpointsDefinitionType.COMPLEX_TYPE,
                 DiscoverObjectClassEndpointsActivityHandler.WorkDefinition.class);
-    }
-
-    @Override
-    public @NotNull Set<ItemName> getSiblingActivityTypes() {
-        return Set.of(WorkDefinitionsType.F_DISCOVER_OBJECT_CLASS_ATTRIBUTES);
     }
 
     @Override
@@ -92,21 +85,16 @@ public class DiscoverObjectClassEndpointsActivityHandler
             String connectorDevelopmentOid = getWorkDefinition().connectorDevelopmentOid;
 
             LOGGER.info("Discovering endpoints for object class '{}' in task {}", objectClass, getRunningTask().getName());
-            try {
-                var backend = ConnectorDevelopmentBackend.backendFor(connectorDevelopmentOid, getRunningTask(), result);
-                backend.ensureDocumentationIsProcessed();
-                backend.ensureObjectClass(objectClass);
+            var backend = ConnectorDevelopmentBackend.backendFor(connectorDevelopmentOid, getRunningTask(), result);
+            backend.ensureDocumentationIsProcessed();
+            backend.ensureObjectClass(objectClass);
 
-                var skipCache = Boolean.TRUE.equals(getWorkDefinition().typedDefinition.getSkipCache());
-                var endpoints = backend.discoverObjectClassEndpoints(objectClass, skipCache);
-                backend.updateApplicationObjectClassEndpoints(objectClass, endpoints);
-            } catch (CommonException | RuntimeException e) {
-                getActivityHandler().suspendSiblings(connectorDevelopmentOid, this, result);
-                throw e;
-            }
+            var skipCache = Boolean.TRUE.equals(getWorkDefinition().typedDefinition.getSkipCache());
+            var endpoints = backend.discoverObjectClassEndpoints(objectClass, skipCache);
+            backend.updateApplicationObjectClassEndpoints(objectClass, endpoints);
             LOGGER.info("Successfully discovered endpoints for object class '{}'", objectClass);
 
-            return getActivityHandler().waitForSiblingByPolling(connectorDevelopmentOid, this, result);
+            return ActivityRunResult.success();
         }
     }
 }


### PR DESCRIPTION
MultiWaitingConnectorStepPanel waits for several independent activities at once; WaitingObjectClassDetailsConnectorStepPanel builds on it to run attribute and endpoint discovery in parallel. Failures are surfaced in the problems panel with a per-task fix (restart) action instead of the backend sibling suspension, which is removed from the discover activity handlers.