### PR TITLE
Connector Generator: Send current script and test errors to codegen for script repair

### DIFF
--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/component/wizard/withnavigation/WizardModelWithParentSteps.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/component/wizard/withnavigation/WizardModelWithParentSteps.java
@@ -13,6 +13,7 @@ import com.evolveum.midpoint.gui.api.component.wizard.WizardStep;
 import com.evolveum.midpoint.gui.impl.component.wizard.collapse.CollapsedItem;
 
 import com.evolveum.midpoint.gui.impl.component.wizard.collapse.OperationResultCollapsedItem;
+import com.evolveum.midpoint.gui.impl.component.wizard.collapse.OperationResultWrapper;
 import com.evolveum.midpoint.schema.result.OperationResult;
 
 import org.apache.commons.lang3.StringUtils;
@@ -87,6 +88,16 @@ public abstract class WizardModelWithParentSteps extends WizardModel {
         }
         return operationResultCollapsedItem.getResults().stream()
                 .anyMatch(operationResultWrapper -> Strings.CS.equals(stepId, operationResultWrapper.getFixPanelId()));
+    }
+
+    public List<OperationResult> getOperationResultsForFixStep(String stepId) {
+        if (StringUtils.isEmpty(stepId)) {
+            return List.of();
+        }
+        return operationResultCollapsedItem.getResults().stream()
+                .filter(operationResultWrapper -> Strings.CS.equals(stepId, operationResultWrapper.getFixPanelId()))
+                .map(OperationResultWrapper::getResult)
+                .toList();
     }
 
     public abstract boolean isShowedSummary();

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/component/wizard/ConnectorDevelopmentWizardUtil.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/component/wizard/ConnectorDevelopmentWizardUtil.java
@@ -565,6 +565,24 @@ public class ConnectorDevelopmentWizardUtil {
         }
     }
 
+    public static List<String> collectErrorMessages(Collection<OperationResult> results) {
+        List<String> messages = new ArrayList<>();
+        results.forEach(result -> collectErrorMessages(result, messages));
+        return messages;
+    }
+
+    private static void collectErrorMessages(OperationResult result, List<String> messages) {
+        if (result == null) {
+            return;
+        }
+        if (result.isError() && StringUtils.isNotEmpty(result.getMessage()) && !messages.contains(result.getMessage())) {
+            messages.add(result.getMessage());
+        }
+        for (OperationResult subresult : result.getSubresults()) {
+            collectErrorMessages(subresult, messages);
+        }
+    }
+
     public static void enableConnectorLogCapture(Task task) {
         task.setExecutionMode(TaskExecutionMode.SIMULATED_SHADOWS_DEVELOPMENT);
         task.addTracingRequest(TracingRootType.CONNECTOR_OPERATION);

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/component/wizard/scimrest/ScriptConnectorStepPanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/component/wizard/scimrest/ScriptConnectorStepPanel.java
@@ -249,6 +249,10 @@ public abstract class ScriptConnectorStepPanel extends AbstractWizardStepPanel<C
 
     private void onRefreshPerformed(AjaxRequestTarget target) {
         if (getWizard() instanceof WizardModelWithParentSteps parentWizardModel) {
+            ConnDevArtifactType currentArtifact = valueModel.getObject();
+            String currentScript = currentArtifact != null ? currentArtifact.getContent() : null;
+            List<String> errorMessages = ConnectorDevelopmentWizardUtil.collectErrorMessages(
+                    parentWizardModel.getOperationResultsForFixStep(getStepId()));
             List<WizardStep> steps = parentWizardModel.getActiveChildrenSteps();
             int activeStepIndex = parentWizardModel.getActiveStepIndex();
             String idOfFound = null;
@@ -260,7 +264,7 @@ public abstract class ScriptConnectorStepPanel extends AbstractWizardStepPanel<C
                 WizardStep step = steps.get(i);
                 if (step instanceof WaitingScriptConnectorStepPanel waitingPanel) {
                     idOfFound = step.getStepId();
-                    waitingPanel.resetScript(getPageBase());
+                    waitingPanel.resetScript(getPageBase(), currentScript, errorMessages);
                     if (i == 0) {
                         setActiveStepById(target, parentWizardModel, idOfFound);
                     }

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/component/wizard/scimrest/WaitingScriptConnectorStepPanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/component/wizard/scimrest/WaitingScriptConnectorStepPanel.java
@@ -17,18 +17,36 @@ import com.evolveum.midpoint.smart.api.conndev.ConnectorDevelopmentArtifacts;
 import com.evolveum.midpoint.xml.ns._public.common.common_3.ConnDevObjectClassInfoType;
 import com.evolveum.midpoint.xml.ns._public.common.common_3.WorkDefinitionsType;
 
+import java.util.List;
+
 /**
  * @author lskublik
  */
 public abstract class WaitingScriptConnectorStepPanel extends WaitingConnectorStepPanel {
 
+    private String repairScript;
+    private List<String> repairErrors = List.of();
 
     public WaitingScriptConnectorStepPanel(WizardPanelHelper<? extends Containerable, ConnectorDevelopmentDetailsModel> helper) {
         super(helper);
     }
 
     public void resetScript(PageBase pageBase) {
+        resetScript(pageBase, null, List.of());
+    }
+
+    public void resetScript(PageBase pageBase, String currentScript, List<String> errorMessages) {
+        repairScript = currentScript;
+        repairErrors = errorMessages != null ? errorMessages : List.of();
         restartTask();
+    }
+
+    protected String getRepairScript() {
+        return repairScript;
+    }
+
+    protected List<String> getRepairErrors() {
+        return repairErrors;
     }
 
     @Override

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/component/wizard/scimrest/objectclass/create/WaitingCreateConnectorStepPanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/component/wizard/scimrest/objectclass/create/WaitingCreateConnectorStepPanel.java
@@ -49,7 +49,7 @@ public class WaitingCreateConnectorStepPanel extends WaitingObjectClassScriptCon
         var realValue = getObjectClassModel().getObject().getRealValue();
 
         return getDetailsModel().getConnectorDevelopmentOperation().submitGenerateCreateScript(
-                realValue.getName(), realValue.getEndpoint(), regenerate, task, result);
+                realValue.getName(), realValue.getEndpoint(), regenerate, getRepairScript(), getRepairErrors(), task, result);
     }
 
     @Override

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/component/wizard/scimrest/objectclass/delete/WaitingDeleteConnectorStepPanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/component/wizard/scimrest/objectclass/delete/WaitingDeleteConnectorStepPanel.java
@@ -49,7 +49,7 @@ public class WaitingDeleteConnectorStepPanel extends WaitingObjectClassScriptCon
         var realValue = getObjectClassModel().getObject().getRealValue();
 
         return getDetailsModel().getConnectorDevelopmentOperation().submitGenerateDeleteScript(
-                realValue.getName(), realValue.getEndpoint(), regenerate, task, result);
+                realValue.getName(), realValue.getEndpoint(), regenerate, getRepairScript(), getRepairErrors(), task, result);
     }
 
     @Override

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/component/wizard/scimrest/objectclass/search/SearchByIdObjectConnectorStepPanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/component/wizard/scimrest/objectclass/search/SearchByIdObjectConnectorStepPanel.java
@@ -155,7 +155,7 @@ public class SearchByIdObjectConnectorStepPanel extends ScriptConfirmationPanel 
                 if (getWizard() instanceof WizardModelWithParentSteps wizardModel) {
                     ConnectorDevelopmentWizardUtil.collectConnectorResults(result, (connIdResult) -> {
                         ConnectorDevelopmentWizardUtil.appendLogsAsContext(connIdResult);
-                        wizardModel.addOperationResult(getStepId(), "cdw-search-all-script", connIdResult);
+                        wizardModel.addOperationResult(getStepId(), "cdw-search-by-id-script", connIdResult);
 
                     });
 

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/component/wizard/scimrest/objectclass/search/WaitingSearchAllConnectorStepPanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/component/wizard/scimrest/objectclass/search/WaitingSearchAllConnectorStepPanel.java
@@ -52,7 +52,7 @@ public class WaitingSearchAllConnectorStepPanel extends WaitingObjectClassScript
         var realValue = getObjectClassModel().getObject().getRealValue();
 
         return getDetailsModel().getConnectorDevelopmentOperation().submitGenerateSearchScript(
-                realValue.getName(), realValue.getEndpoint(), regenerate, task, result);
+                realValue.getName(), realValue.getEndpoint(), regenerate, getRepairScript(), getRepairErrors(), task, result);
     }
 
     @Override

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/component/wizard/scimrest/objectclass/search/WaitingSearchByIdConnectorStepPanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/component/wizard/scimrest/objectclass/search/WaitingSearchByIdConnectorStepPanel.java
@@ -50,7 +50,7 @@ public class WaitingSearchByIdConnectorStepPanel extends WaitingObjectClassScrip
         var realValue = getObjectClassModel().getObject().getRealValue();
 
         return getDetailsModel().getConnectorDevelopmentOperation().submitGenerateSearchByIdScript(
-                realValue.getName(), realValue.getEndpoint(), regenerate, task, result);
+                realValue.getName(), realValue.getEndpoint(), regenerate, getRepairScript(), getRepairErrors(), task, result);
     }
 
     @Override

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/component/wizard/scimrest/objectclass/search/WaitingSearchFilterConnectorStepPanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/component/wizard/scimrest/objectclass/search/WaitingSearchFilterConnectorStepPanel.java
@@ -50,7 +50,7 @@ public class WaitingSearchFilterConnectorStepPanel extends WaitingObjectClassScr
         var realValue = getObjectClassModel().getObject().getRealValue();
 
         return getDetailsModel().getConnectorDevelopmentOperation().submitGenerateSearchFilterScript(
-                realValue.getName(), realValue.getEndpoint(), regenerate, task, result);
+                realValue.getName(), realValue.getEndpoint(), regenerate, getRepairScript(), getRepairErrors(), task, result);
     }
 
     @Override

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/component/wizard/scimrest/objectclass/update/WaitingUpdateConnectorStepPanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/component/wizard/scimrest/objectclass/update/WaitingUpdateConnectorStepPanel.java
@@ -49,7 +49,7 @@ public class WaitingUpdateConnectorStepPanel extends WaitingObjectClassScriptCon
         var realValue = getObjectClassModel().getObject().getRealValue();
 
         return getDetailsModel().getConnectorDevelopmentOperation().submitGenerateUpdateScript(
-                realValue.getName(), realValue.getEndpoint(), regenerate, task, result);
+                realValue.getName(), realValue.getEndpoint(), regenerate, getRepairScript(), getRepairErrors(), task, result);
     }
 
     @Override

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/component/wizard/scimrest/relation/WaitingRelationshipScriptConnectorStepPanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/component/wizard/scimrest/relation/WaitingRelationshipScriptConnectorStepPanel.java
@@ -69,7 +69,7 @@ public class WaitingRelationshipScriptConnectorStepPanel extends WaitingScriptCo
     @Override
     protected String getNewTaskToken(Task task, OperationResult result, boolean regenerate) {
         return getDetailsModel().getConnectorDevelopmentOperation().submitGenerateRelationScript(
-                valueModel.getObject().getRealValue(), regenerate, task, result);
+                valueModel.getObject().getRealValue(), regenerate, getRepairScript(), getRepairErrors(), task, result);
     }
 
     @Override

--- a/infra/schema/src/main/resources/xml/ns/public/common/common-tasks-3.xsd
+++ b/infra/schema/src/main/resources/xml/ns/public/common/common-tasks-3.xsd
@@ -11420,6 +11420,7 @@
                     <xsd:element name="artifact" type="tns:ConnDevArtifactType"/>
                     <xsd:element name="endpoint" type="tns:ConnDevHttpEndpointType" minOccurs="0" maxOccurs="unbounded"/>
                     <xsd:element name="relation" type="tns:ConnDevRelationInfoType" minOccurs="0" maxOccurs="unbounded"/>
+                    <xsd:element name="midpointError" type="xsd:string" minOccurs="0" maxOccurs="unbounded"/>
                 </xsd:sequence>
             </xsd:extension>
         </xsd:complexContent>

--- a/model/smart-api/src/main/java/com/evolveum/midpoint/smart/api/conndev/ConnectorDevelopmentOperation.java
+++ b/model/smart-api/src/main/java/com/evolveum/midpoint/smart/api/conndev/ConnectorDevelopmentOperation.java
@@ -65,7 +65,15 @@ public interface ConnectorDevelopmentOperation {
 
 
     default String submitGenerateEndpointBasedScript(ConnectorDevelopmentArtifacts.KnownArtifactType artifactDef, String objectClass, List<ConnDevHttpEndpointType> endpoints, boolean retry, Task task, OperationResult result) {
-        return submitGenerateArtifact(artifactDef.create(objectClass),
+        return submitGenerateEndpointBasedScript(artifactDef, objectClass, endpoints, retry, null, List.of(), task, result);
+    }
+
+    default String submitGenerateEndpointBasedScript(ConnectorDevelopmentArtifacts.KnownArtifactType artifactDef, String objectClass, List<ConnDevHttpEndpointType> endpoints, boolean retry, String currentScript, List<String> midpointErrors, Task task, OperationResult result) {
+        var artifact = artifactDef.create(objectClass);
+        if (currentScript != null) {
+            artifact.setContent(currentScript);
+        }
+        return submitGenerateArtifact(artifact,
                 definition -> {
                     if (endpoints != null && !endpoints.isEmpty()) {
                         for (var endpoint : endpoints) {
@@ -79,44 +87,64 @@ public interface ConnectorDevelopmentOperation {
                             );
                         }
                     }
+                    if (midpointErrors != null) {
+                        definition.getMidpointError().addAll(midpointErrors);
+                    }
                 }, retry, task, result);
 
     }
 
     default String submitGenerateSearchScript(String objectClass, List<ConnDevHttpEndpointType> endpoints, boolean retry, Task task, OperationResult result) {
-        return submitGenerateEndpointBasedScript(SEARCH_ALL_DEFINITION, objectClass, endpoints, retry, task, result);
+        return submitGenerateSearchScript(objectClass, endpoints, retry, null, List.of(), task, result);
     }
 
-    default String submitGenerateSearchByIdScript(String objectClass, List<ConnDevHttpEndpointType> endpoints, boolean retry, Task task, OperationResult result) {
-        return submitGenerateEndpointBasedScript(SEARCH_BY_ID_DEFINITION, objectClass, endpoints, retry, task, result);
+    default String submitGenerateSearchScript(String objectClass, List<ConnDevHttpEndpointType> endpoints, boolean retry, String currentScript, List<String> midpointErrors, Task task, OperationResult result) {
+        return submitGenerateEndpointBasedScript(SEARCH_ALL_DEFINITION, objectClass, endpoints, retry, currentScript, midpointErrors, task, result);
     }
 
-    default String submitGenerateSearchFilterScript(String objectClass, List<ConnDevHttpEndpointType> endpoints, boolean retry, Task task, OperationResult result) {
-        return submitGenerateEndpointBasedScript(SEARCH_FILTER_DEFINITION, objectClass, endpoints, retry, task, result);
+    default String submitGenerateSearchByIdScript(String objectClass, List<ConnDevHttpEndpointType> endpoints, boolean retry, String currentScript, List<String> midpointErrors, Task task, OperationResult result) {
+        return submitGenerateEndpointBasedScript(SEARCH_BY_ID_DEFINITION, objectClass, endpoints, retry, currentScript, midpointErrors, task, result);
+    }
+
+    default String submitGenerateSearchFilterScript(String objectClass, List<ConnDevHttpEndpointType> endpoints, boolean retry, String currentScript, List<String> midpointErrors, Task task, OperationResult result) {
+        return submitGenerateEndpointBasedScript(SEARCH_FILTER_DEFINITION, objectClass, endpoints, retry, currentScript, midpointErrors, task, result);
     }
 
 
     default String submitGenerateRelationScript(ConnDevRelationInfoType relation, boolean retry, Task task, OperationResult result) {
+        return submitGenerateRelationScript(relation, retry, null, List.of(), task, result);
+    }
+
+    default String submitGenerateRelationScript(ConnDevRelationInfoType relation, boolean retry, String currentScript, List<String> midpointErrors, Task task, OperationResult result) {
         var safeClone = new ConnDevRelationInfoType()
                 .name(relation.getName())
                 .subject(relation.getSubject())
                 .subjectAttribute(relation.getSubjectAttribute())
                 .object(relation.getObject())
                 .objectAttribute(relation.getObjectAttribute());
-        return submitGenerateArtifact(RELATIONSHIP_SCHEMA_DEFINITION.create(relation.getName()),
-                definition -> definition.relation(safeClone), retry,  task, result);
+        var artifact = RELATIONSHIP_SCHEMA_DEFINITION.create(relation.getName());
+        if (currentScript != null) {
+            artifact.setContent(currentScript);
+        }
+        return submitGenerateArtifact(artifact,
+                definition -> {
+                    definition.relation(safeClone);
+                    if (midpointErrors != null) {
+                        definition.getMidpointError().addAll(midpointErrors);
+                    }
+                }, retry,  task, result);
     }
 
-    default String submitGenerateCreateScript(String objectClass, List<ConnDevHttpEndpointType> endpoints, boolean retry, Task task, OperationResult result) {
-        return submitGenerateEndpointBasedScript(CREATE, objectClass, endpoints, retry, task, result);
+    default String submitGenerateCreateScript(String objectClass, List<ConnDevHttpEndpointType> endpoints, boolean retry, String currentScript, List<String> midpointErrors, Task task, OperationResult result) {
+        return submitGenerateEndpointBasedScript(CREATE, objectClass, endpoints, retry, currentScript, midpointErrors, task, result);
     }
 
-    default String submitGenerateUpdateScript(String objectClass, List<ConnDevHttpEndpointType> endpoints, boolean retry, Task task, OperationResult result) {
-        return submitGenerateEndpointBasedScript(UPDATE, objectClass, endpoints, retry, task, result);
+    default String submitGenerateUpdateScript(String objectClass, List<ConnDevHttpEndpointType> endpoints, boolean retry, String currentScript, List<String> midpointErrors, Task task, OperationResult result) {
+        return submitGenerateEndpointBasedScript(UPDATE, objectClass, endpoints, retry, currentScript, midpointErrors, task, result);
     }
 
-    default String submitGenerateDeleteScript(String objectClass, List<ConnDevHttpEndpointType> endpoints, boolean retry, Task task, OperationResult result) {
-        return submitGenerateEndpointBasedScript(DELETE, objectClass, endpoints, retry, task, result);
+    default String submitGenerateDeleteScript(String objectClass, List<ConnDevHttpEndpointType> endpoints, boolean retry, String currentScript, List<String> midpointErrors, Task task, OperationResult result) {
+        return submitGenerateEndpointBasedScript(DELETE, objectClass, endpoints, retry, currentScript, midpointErrors, task, result);
     }
 
     String submitGenerateArtifact(ConnDevArtifactType artifact, Consumer<ConnDevGenerateArtifactDefinitionType> customizer, boolean retry, Task task, OperationResult result);

--- a/model/smart-impl/src/main/java/com/evolveum/midpoint/smart/impl/conndev/RestBackend.java
+++ b/model/smart-impl/src/main/java/com/evolveum/midpoint/smart/impl/conndev/RestBackend.java
@@ -211,13 +211,7 @@ public class RestBackend extends ConnectorDevelopmentBackend {
             return null;
         }
 
-        var body = JSON_FACTORY.objectNode();
-
-        var artifact = input.getArtifact();
-        body.set("currentScript", JSON_FACTORY.textNode(
-                artifact != null && artifact.getContent() != null ? artifact.getContent() : ""));
-
-        body.set("midpointErrors", JSON_FACTORY.arrayNode());
+        var body = repairContextBody(input);
 
         var authArray = JSON_FACTORY.arrayNode();
         for (var auth : auths) {
@@ -246,22 +240,23 @@ public class RestBackend extends ConnectorDevelopmentBackend {
         var artifactSpec = input.getArtifact();
         var objectClass = artifactSpec.getObjectClass();
         var classification = ConnectorDevelopmentArtifacts.classify(artifactSpec);
+        var body = repairContextBody(input);
         var content = switch (classification) {
             case NATIVE_SCHEMA_DEFINITION -> generateObjectClassScript(artifactSpec,
-                    "native-schema", "native schema script", skipCache);
+                    "native-schema", "native schema script", body, skipCache);
             case CONNID_SCHEMA_DEFINITION -> generateObjectClassScript(artifactSpec,
-                    "connid", "ConnID mapping script", skipCache);
-            case SEARCH_ALL_DEFINITION -> generateSearchAll(artifactSpec, input.getEndpoint(), skipCache);
+                    "connid", "ConnID mapping script", body, skipCache);
+            case SEARCH_ALL_DEFINITION -> generateSearchAll(artifactSpec, input.getEndpoint(), body, skipCache);
             case SEARCH_BY_ID_DEFINITION -> generateObjectClassScript(artifactSpec,
                     "search/" + ConnDevJsonMapper.toServiceIntent(artifactSpec.getIntent()),
-                    "search by ID script", skipCache);
+                    "search by ID script", body, skipCache);
             case SEARCH_FILTER_DEFINITION -> generateObjectClassScript(artifactSpec,
                     "search/" + ConnDevJsonMapper.toServiceIntent(artifactSpec.getIntent()),
-                    "search filter script", skipCache);
-            case CREATE -> generateObjectClassScript(artifactSpec, "create", "Create script", skipCache);
-            case UPDATE ->  generateObjectClassScript(artifactSpec, "update", "Update script", skipCache);
-            case DELETE -> generateObjectClassScript(artifactSpec, "delete", "Delete script", skipCache);
-            case RELATIONSHIP_SCHEMA_DEFINITION -> generateRelation(artifactSpec, input.getRelation(), skipCache);
+                    "search filter script", body, skipCache);
+            case CREATE -> generateObjectClassScript(artifactSpec, "create", "Create script", body, skipCache);
+            case UPDATE ->  generateObjectClassScript(artifactSpec, "update", "Update script", body, skipCache);
+            case DELETE -> generateObjectClassScript(artifactSpec, "delete", "Delete script", body, skipCache);
+            case RELATIONSHIP_SCHEMA_DEFINITION -> generateRelation(artifactSpec, input.getRelation(), body, skipCache);
             default -> throw new IllegalStateException("Unexpected script type: " + classification);
         };
         content = content.replace("${objectClass}", objectClass);
@@ -269,8 +264,19 @@ public class RestBackend extends ConnectorDevelopmentBackend {
 
     }
 
-    private String generateRelation(ConnDevArtifactType artifactSpec, List<ConnDevRelationInfoType> relation, boolean skipCache) {
-        try(var job = client().postJob("codegen/{sessionId}/relations/" + artifactSpec.getObjectClass(), skipCache)) {
+    private ObjectNode repairContextBody(ConnDevGenerateArtifactDefinitionType input) {
+        var body = JSON_FACTORY.objectNode();
+        var artifact = input.getArtifact();
+        body.set("currentScript", JSON_FACTORY.textNode(
+                artifact != null && artifact.getContent() != null ? artifact.getContent() : ""));
+        var errors = JSON_FACTORY.arrayNode();
+        input.getMidpointError().forEach(errors::add);
+        body.set("midpointErrors", errors);
+        return body;
+    }
+
+    private String generateRelation(ConnDevArtifactType artifactSpec, List<ConnDevRelationInfoType> relation, ObjectNode body, boolean skipCache) {
+        try(var job = client().postJob("codegen/{sessionId}/relations/" + artifactSpec.getObjectClass(), body, skipCache)) {
             return job.waitAndProcess(SLEEP_TIME, canRun(), json -> json.get("code").asText());
         } catch (IOException e) {
             throw new SystemException("Couldn't generate relation for objectClass " + artifactSpec.getObjectClass(), e);
@@ -280,14 +286,14 @@ public class RestBackend extends ConnectorDevelopmentBackend {
 
 
 
-    private String generateSearchAll(ConnDevArtifactType artifactSpec, List<ConnDevHttpEndpointType> endpoints, boolean skipCache) {
+    private String generateSearchAll(ConnDevArtifactType artifactSpec, List<ConnDevHttpEndpointType> endpoints, ObjectNode body, boolean skipCache) {
         // TODO: In future when endpoints are editable ensure synchronization of endpoints
         return generateObjectClassScript(artifactSpec, "search/" + ConnDevJsonMapper.toServiceIntent(artifactSpec.getIntent()),
-                "search script", skipCache);
+                "search script", body, skipCache);
     }
 
-    private String generateObjectClassScript(ConnDevArtifactType artifactSpec, String endpointSuffix, String scriptDescription, boolean skipCache) {
-        try(var job = client().postJob("codegen/{sessionId}/classes/"+ artifactSpec.getObjectClass() + "/" + endpointSuffix, skipCache)) {
+    private String generateObjectClassScript(ConnDevArtifactType artifactSpec, String endpointSuffix, String scriptDescription, ObjectNode body, boolean skipCache) {
+        try(var job = client().postJob("codegen/{sessionId}/classes/"+ artifactSpec.getObjectClass() + "/" + endpointSuffix, body, skipCache)) {
             return job.waitAndProcess(SLEEP_TIME, canRun(), json -> json.get("code").asText());
         } catch (IOException e) {
             throw new SystemException("Couldn't generate " + scriptDescription + " for objectClass " + artifactSpec.getObjectClass(), e);


### PR DESCRIPTION
When regenerating a conndev script, the generate-artifact task now carries the user-edited script content (artifact/content) and errors collected from the wizard test steps (new midpointError item in the work definition). RestBackend forwards them to the generation service as currentScript/midpointErrors, activating its repair mode instead of generating from scratch. Also fixed search-by-id test results being filed under the search-all script step.