### PR TITLE
Add connector export from connector development wizard

### DIFF
--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/ConnectorDevelopmentDetailsModel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/ConnectorDevelopmentDetailsModel.java
@@ -12,6 +12,7 @@ import com.evolveum.midpoint.gui.impl.page.admin.assignmentholder.AssignmentHold
 import com.evolveum.midpoint.prism.PrismObject;
 import com.evolveum.midpoint.schema.result.OperationResult;
 import com.evolveum.midpoint.smart.api.conndev.ConnectorDevelopmentOperation;
+import com.evolveum.midpoint.xml.ns._public.common.common_3.ConnDevExportConnectorResultType;
 import com.evolveum.midpoint.xml.ns._public.common.common_3.ConnectorDevelopmentType;
 
 import org.apache.wicket.model.LoadableDetachableModel;
@@ -19,6 +20,15 @@ import org.apache.wicket.model.LoadableDetachableModel;
 public class ConnectorDevelopmentDetailsModel extends AssignmentHolderDetailsModel<ConnectorDevelopmentType> {
 
     private LoadableDetachableModel<ConnectorDevelopmentOperation> developmentOperationModel;
+
+    /**
+     * Result of a connector export that finished while the wizard was still on the waiting step.
+     * The waiting step is replaced by the summary panel in the same AJAX response as the download
+     * behavior initiation, which would invalidate a behavior attached to the (now removed) waiting
+     * step. Stashing the result here lets the summary panel trigger the download itself, once it is
+     * part of the component tree.
+     */
+    private ConnDevExportConnectorResultType pendingExportResult;
 
     public ConnectorDevelopmentDetailsModel(LoadableDetachableModel<PrismObject<ConnectorDevelopmentType>> prismObjectModel, ModelServiceLocator serviceLocator) {
         super(prismObjectModel, serviceLocator);
@@ -47,5 +57,13 @@ public class ConnectorDevelopmentDetailsModel extends AssignmentHolderDetailsMod
 
     public ModelServiceLocator getServiceLocator() {
         return super.getModelServiceLocator();
+    }
+
+    public ConnDevExportConnectorResultType getPendingExportResult() {
+        return pendingExportResult;
+    }
+
+    public void setPendingExportResult(ConnDevExportConnectorResultType pendingExportResult) {
+        this.pendingExportResult = pendingExportResult;
     }
 }

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/component/wizard/ConnectorDevelopmentController.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/component/wizard/ConnectorDevelopmentController.java
@@ -56,6 +56,7 @@ public class ConnectorDevelopmentController extends AbstractWizardController<Con
         RELATIONSHIPS,
         INIT_RELATIONSHIP,
         RELATIONSHIP,
+        EXPORT_CONNECTOR,
         NEXT
     }
 
@@ -69,6 +70,10 @@ public class ConnectorDevelopmentController extends AbstractWizardController<Con
 
     public void initNewRelationship(AjaxRequestTarget target) {
         setPartItem(new InitRelationshipConnectorDevPartItem(getHelper()), target);
+    }
+
+    public void exportConnector(AjaxRequestTarget target) {
+        setPartItem(new ExportConnectorDevPartItem(getHelper()), target);
     }
 
     public void editBasicInformation(AjaxRequestTarget target) {

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/component/wizard/ExportConnectorDevPartItem.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/component/wizard/ExportConnectorDevPartItem.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2010-2025 Evolveum and contributors
+ *
+ * Licensed under the EUPL-1.2 or later.
+ */
+
+package com.evolveum.midpoint.gui.impl.page.admin.connector.development.component.wizard;
+
+import java.util.List;
+
+import com.evolveum.midpoint.gui.impl.component.wizard.WizardPanelHelper;
+import com.evolveum.midpoint.gui.impl.component.wizard.withnavigation.AbstractWizardPartItem;
+import com.evolveum.midpoint.gui.impl.component.wizard.withnavigation.WizardParentStep;
+import com.evolveum.midpoint.gui.impl.page.admin.connector.development.ConnectorDevelopmentDetailsModel;
+import com.evolveum.midpoint.gui.impl.page.admin.connector.development.component.wizard.ConnectorDevelopmentController.ConnectorDevelopmentStatusType;
+import com.evolveum.midpoint.gui.impl.page.admin.connector.development.component.wizard.scimrest.WaitingConnectorExportingStepPanel;
+import com.evolveum.midpoint.prism.Containerable;
+import com.evolveum.midpoint.xml.ns._public.common.common_3.ConnectorDevelopmentType;
+
+public class ExportConnectorDevPartItem extends AbstractWizardPartItem<ConnectorDevelopmentType, ConnectorDevelopmentDetailsModel> {
+
+    protected ExportConnectorDevPartItem(WizardPanelHelper<? extends Containerable, ConnectorDevelopmentDetailsModel> helper) {
+        super(helper);
+    }
+
+    @Override
+    public boolean isComplete() {
+        return false;
+    }
+
+    @Override
+    protected List<WizardParentStep> createWizardSteps() {
+        return List.of(new WaitingConnectorExportingStepPanel(getHelper()));
+    }
+
+    @Override
+    public Enum<?> getIdentifierForWizardStatus() {
+        return ConnectorDevelopmentStatusType.EXPORT_CONNECTOR;
+    }
+}

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/component/wizard/scimrest/NextStepsActionsPanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/component/wizard/scimrest/NextStepsActionsPanel.java
@@ -6,6 +6,10 @@
 
 package com.evolveum.midpoint.gui.impl.page.admin.connector.development.component.wizard.scimrest;
 
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.Serial;
+
 import com.evolveum.midpoint.gui.api.component.BasePanel;
 import com.evolveum.midpoint.gui.api.component.wizard.TileEnum;
 import com.evolveum.midpoint.gui.api.prism.wrapper.PrismReferenceWrapper;
@@ -19,15 +23,24 @@ import com.evolveum.midpoint.prism.PrismObject;
 import com.evolveum.midpoint.prism.Referencable;
 import com.evolveum.midpoint.prism.path.ItemPath;
 import com.evolveum.midpoint.schema.constants.SchemaConstants;
+import com.evolveum.midpoint.schema.result.OperationResult;
+import com.evolveum.midpoint.util.exception.CommonException;
 import com.evolveum.midpoint.util.exception.SchemaException;
+import com.evolveum.midpoint.util.logging.Trace;
+import com.evolveum.midpoint.util.logging.TraceManager;
+import com.evolveum.midpoint.web.component.AjaxDownloadBehaviorFromStream;
+import com.evolveum.midpoint.xml.ns._public.common.common_3.ConnDevExportConnectorResultType;
 import com.evolveum.midpoint.xml.ns._public.common.common_3.ConnDevTestingType;
 import com.evolveum.midpoint.xml.ns._public.common.common_3.ConnectorDevelopmentType;
 import com.evolveum.midpoint.xml.ns._public.common.common_3.ResourceType;
 
 import org.apache.wicket.ajax.AjaxRequestTarget;
+import org.apache.wicket.request.cycle.RequestCycle;
 import org.jetbrains.annotations.Nullable;
 
 public class NextStepsActionsPanel extends BasePanel {
+
+    private static final Trace LOGGER = TraceManager.getTrace(NextStepsActionsPanel.class);
 
     private static final String ID_CONNECTOR_ACTION = "connectorAction";
 
@@ -46,6 +59,62 @@ public class NextStepsActionsPanel extends BasePanel {
         initLayer();
     }
 
+    /**
+     * This panel is created once and reused for the whole lifetime of the wizard (it lives inside the
+     * cached summary step, see {@code AbstractWizardController#getSummaryPanel()}), so {@code onInitialize}
+     * only runs on its first render and is not a reliable place to react to a just-finished export.
+     * {@code onBeforeRender} runs on every render (including the AJAX response that switches back to this
+     * panel), which is what we need here.
+     *
+     * If a connector export finished while the wizard was still on the waiting step, the result was
+     * stashed on the details model (see {@link WaitingConnectorExportingStepPanel#onNextPerformed}),
+     * because a download behavior attached to that step would have been invalidated by the step being
+     * replaced by this panel in the same AJAX response. Now that this panel is (again) part of the
+     * component tree, it is safe to attach the behavior and start the download.
+     */
+    @Override
+    protected void onBeforeRender() {
+        triggerPendingExportDownload();
+        super.onBeforeRender();
+    }
+
+    private void triggerPendingExportDownload() {
+        ConnDevExportConnectorResultType exportResult = detailsModel.getPendingExportResult();
+        if (exportResult == null) {
+            return;
+        }
+        detailsModel.setPendingExportResult(null);
+
+        AjaxDownloadBehaviorFromStream downloadBehavior = new AjaxDownloadBehaviorFromStream() {
+
+            @Serial private static final long serialVersionUID = 1L;
+
+            @Override
+            protected InputStream getInputStream() {
+                try {
+                    return detailsModel.getServiceLocator().getConnectorService().getExportedConnectorFileStream(
+                            exportResult.getFileName(),
+                            exportResult.getNodeRef().getOid(),
+                            getPageBase().createSimpleTask("downloadExportedConnector"),
+                            new OperationResult("downloadExportedConnector"));
+                } catch (CommonException | IOException e) {
+                    LOGGER.error("Couldn't download exported connector file", e);
+                    return null;
+                }
+            }
+
+            @Override
+            public String getFileName() {
+                return exportResult.getFileName();
+            }
+        };
+        downloadBehavior.setContentType("application/java-archive");
+        add(downloadBehavior);
+
+        RequestCycle.get().find(AjaxRequestTarget.class)
+                .ifPresent(downloadBehavior::initiate);
+    }
+
     private void initLayer() {
         EnumTileChoicePanel<ConnectorAction> connectorActionPanel = new EnumTileChoicePanel<>(ID_CONNECTOR_ACTION, ConnectorAction.class) {
             @Override
@@ -58,6 +127,7 @@ public class NextStepsActionsPanel extends BasePanel {
                 switch (action) {
                     case NEW_OBJECT_CLASS -> createNewObjectClass(target);
                     case ADD_RELATIONSHIP -> createNewRelationship(target);
+                    case EXPORT_CONNECTOR -> exportConnector(target);
                     case CREATE_RESOURCE -> {
                         ResourceCreationPopup popup = new ResourceCreationPopup(getPageBase().getMainPopupBodyId()) {
                             @Override
@@ -99,12 +169,18 @@ public class NextStepsActionsPanel extends BasePanel {
         controller.initNewObjectClass(target);
     }
 
+    private void exportConnector(AjaxRequestTarget target) {
+        controller.exportConnector(target);
+    }
+
     public enum ConnectorAction implements TileEnum {
 
         CREATE_RESOURCE("fa fa-plus bg-teal-100 text-success",
                 "ConnectorAction.CREATE_RESOURCE.description"),
         UPLOAD("fa-solid fa-gears bg-cyan-100 text-info",
                 "ConnectorAction.UPLOAD.description"),
+        EXPORT_CONNECTOR("fa-solid fa-download bg-purple-100 text-purple",
+                "ConnectorAction.EXPORT_CONNECTOR.description"),
         NEW_OBJECT_CLASS("fa-solid fa-shapes bg-orange-100 text-warning",
                 "ConnectorAction.NEW_OBJECT_CLASS.description"),
         ADD_RELATIONSHIP("fa fa-code-compare bg-pink-100 text-pink",

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/component/wizard/scimrest/WaitingConnectorExportingStepPanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/component/wizard/scimrest/WaitingConnectorExportingStepPanel.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright (C) 2010-2025 Evolveum and contributors
+ *
+ * This work is dual-licensed under the Apache License 2.0
+ * and European Union Public License. See LICENSE file for details.
+ */
+package com.evolveum.midpoint.gui.impl.page.admin.connector.development.component.wizard.scimrest;
+
+import com.evolveum.midpoint.gui.impl.component.wizard.WizardPanelHelper;
+import com.evolveum.midpoint.gui.impl.component.wizard.withnavigation.WizardParentStep;
+import com.evolveum.midpoint.gui.impl.page.admin.connector.development.ConnectorDevelopmentDetailsModel;
+import com.evolveum.midpoint.prism.Containerable;
+import com.evolveum.midpoint.prism.path.ItemName;
+import com.evolveum.midpoint.schema.result.OperationResult;
+import com.evolveum.midpoint.smart.api.info.StatusInfo;
+import com.evolveum.midpoint.task.api.Task;
+import com.evolveum.midpoint.util.exception.ObjectNotFoundException;
+import com.evolveum.midpoint.util.exception.SchemaException;
+import com.evolveum.midpoint.web.application.PanelDisplay;
+import com.evolveum.midpoint.web.application.PanelInstance;
+import com.evolveum.midpoint.web.application.PanelType;
+import com.evolveum.midpoint.xml.ns._public.common.common_3.ConnDevExportConnectorResultType;
+import com.evolveum.midpoint.xml.ns._public.common.common_3.ConnectorDevelopmentType;
+import com.evolveum.midpoint.xml.ns._public.common.common_3.OperationTypeType;
+import com.evolveum.midpoint.xml.ns._public.common.common_3.WorkDefinitionsType;
+
+import org.apache.wicket.ajax.AjaxRequestTarget;
+import org.apache.wicket.model.IModel;
+import org.apache.wicket.model.Model;
+
+/**
+ * Waiting step for the "export connector" background activity. Shown as a single-step part item
+ * (see {@code ExportConnectorDevPartItem}). On completion the step stashes the export result in
+ * {@link ConnectorDevelopmentDetailsModel#setPendingExportResult}, so that the download can be
+ * triggered by the "next steps" summary panel once it replaces this step in the same AJAX response
+ * (a download behavior attached to this step would be invalidated by that replacement).
+ */
+@PanelType(name = "cdw-connector-waiting-exporting-connector")
+@PanelInstance(identifier = "cdw-connector-waiting-exporting-connector",
+        applicableForType = ConnectorDevelopmentType.class,
+        applicableForOperation = OperationTypeType.WIZARD,
+        display = @PanelDisplay(label = "PageConnectorDevelopment.wizard.step.connectorWaitingExportingConnector", icon = "fa fa-download"),
+        containerPath = "empty")
+public class WaitingConnectorExportingStepPanel extends WaitingConnectorStepPanel implements WizardParentStep {
+
+    private static final String PANEL_TYPE = "cdw-connector-waiting-exporting-connector";
+
+    public WaitingConnectorExportingStepPanel(WizardPanelHelper<? extends Containerable, ConnectorDevelopmentDetailsModel> helper) {
+        super(helper);
+    }
+
+    @Override
+    protected ItemName getActivityType() {
+        return WorkDefinitionsType.F_EXPORT_CONNECTOR;
+    }
+
+    @Override
+    protected StatusInfo<?> obtainResult(String token, Task task, OperationResult result) throws SchemaException, ObjectNotFoundException {
+        return getDetailsModel().getServiceLocator().getConnectorService().getExportConnectorStatus(token, task, result);
+    }
+
+    @Override
+    protected String getNewTaskToken(Task task, OperationResult result, boolean regenerate) {
+        return getDetailsModel().getConnectorDevelopmentOperation().submitExportConnector(task, result);
+    }
+
+    @Override
+    public String getStepId() {
+        return PANEL_TYPE;
+    }
+
+    @Override
+    public IModel<String> getTitle() {
+        return createStringResource("PageConnectorDevelopment.wizard.step.connectorWaitingExportingConnector");
+    }
+
+    @Override
+    protected IModel<String> getTextModel() {
+        return createStringResource("PageConnectorDevelopment.wizard.step.connectorWaitingExportingConnector.text");
+    }
+
+    @Override
+    protected IModel<String> getSubTextModel() {
+        return createStringResource("PageConnectorDevelopment.wizard.step.connectorWaitingExportingConnector.subText");
+    }
+
+    @Override
+    public boolean onNextPerformed(AjaxRequestTarget target) {
+        getDetailsModel().setPendingExportResult((ConnDevExportConnectorResultType) getResult());
+        return super.onNextPerformed(target);
+    }
+
+    @Override
+    protected Model<String> getIconModel() {
+        return Model.of("fa fa-download");
+    }
+
+    @Override
+    protected boolean objectClassRequired() {
+        return false;
+    }
+}

--- a/infra/schema/src/main/java/com/evolveum/midpoint/schema/util/task/work/WorkDefinitionUtil.java
+++ b/infra/schema/src/main/java/com/evolveum/midpoint/schema/util/task/work/WorkDefinitionUtil.java
@@ -79,6 +79,7 @@ public class WorkDefinitionUtil {
 
         addTypedParameters(values, definitions.getCreateConnector());
         addTypedParameters(values, definitions.getInstallConnector());
+        addTypedParameters(values, definitions.getExportConnector());
         addTypedParameters(values, definitions.getDiscoverDocumentation());
         addTypedParameters(values, definitions.getProcessDocumentation());
         addTypedParameters(values, definitions.getDiscoverGlobalInformation());

--- a/infra/schema/src/main/resources/xml/ns/public/common/common-tasks-3.xsd
+++ b/infra/schema/src/main/resources/xml/ns/public/common/common-tasks-3.xsd
@@ -2522,6 +2522,14 @@
                     </xsd:annotation>
                 </xsd:element>
 
+                <xsd:element name="exportConnector" type="tns:ConnDevExportConnectorWorkDefinitionType">
+                    <xsd:annotation>
+                        <xsd:appinfo>
+                            <a:since>4.11</a:since>
+                        </xsd:appinfo>
+                    </xsd:annotation>
+                </xsd:element>
+
                 <xsd:element name="discoverDocumentation" type="tns:ConnDevDiscoverDocumentationWorkDefinitionType">
                     <xsd:annotation>
                         <xsd:appinfo>
@@ -11171,6 +11179,66 @@
 
     <xsd:complexType name="ConnDevDownloadConnectorResultType">
         <xsd:sequence>
+            <xsd:element name="connectorRef" type="tns:ObjectReferenceType">
+                <xsd:annotation>
+                    <xas:appinfo>
+                        <a:objectReferenceTargetType>ConnectorType</a:objectReferenceTargetType>
+                    </xas:appinfo>
+                </xsd:annotation>
+            </xsd:element>
+        </xsd:sequence>
+    </xsd:complexType>
+
+    <!-- Export connector -->
+
+    <xsd:complexType name="ConnDevExportConnectorWorkDefinitionType">
+        <xsd:complexContent>
+            <xsd:extension base="tns:ConnDevBaseWorkDefinitionType">
+                <xsd:sequence>
+                    <xsd:element name="version" type="xsd:string" minOccurs="0">
+                        <xsd:annotation>
+                            <xsd:documentation>
+                                Explicit version for the exported connector bundle. If not specified,
+                                the current connector version is used as-is.
+                            </xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                </xsd:sequence>
+            </xsd:extension>
+        </xsd:complexContent>
+    </xsd:complexType>
+
+    <xsd:complexType name="ConnDevExportConnectorWorkStateType">
+        <xsd:complexContent>
+            <xsd:extension base="tns:AbstractActivityWorkStateType">
+                <xsd:sequence>
+                    <xsd:element name="result" type="tns:ConnDevExportConnectorResultType"/>
+                </xsd:sequence>
+            </xsd:extension>
+        </xsd:complexContent>
+    </xsd:complexType>
+
+    <xsd:complexType name="ConnDevExportConnectorResultType">
+        <xsd:sequence>
+            <xsd:element name="fileName" type="xsd:string">
+                <xsd:annotation>
+                    <xsd:documentation>
+                        Name of the exported connector bundle jar file, relative to the midPoint home
+                        "export" directory on the node identified by nodeRef.
+                    </xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="nodeRef" type="tns:ObjectReferenceType">
+                <xsd:annotation>
+                    <xsd:documentation>
+                        Node where the exported connector bundle jar file is stored.
+                    </xsd:documentation>
+                    <xas:appinfo>
+                        <a:objectReferenceTargetType>NodeType</a:objectReferenceTargetType>
+                    </xas:appinfo>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="version" type="xsd:string"/>
             <xsd:element name="connectorRef" type="tns:ObjectReferenceType">
                 <xsd:annotation>
                     <xas:appinfo>

--- a/model/smart-api/src/main/java/com/evolveum/midpoint/smart/api/conndev/ConnectorDevelopmentOperation.java
+++ b/model/smart-api/src/main/java/com/evolveum/midpoint/smart/api/conndev/ConnectorDevelopmentOperation.java
@@ -39,6 +39,8 @@ public interface ConnectorDevelopmentOperation {
 
     String submitCreateConnector(Task task, OperationResult result);
 
+    String submitExportConnector(Task task, OperationResult result);
+
     // Midpoint local (+ download framework)
 
     String submitDiscoverObjectClasses(Task task, OperationResult result);

--- a/model/smart-api/src/main/java/com/evolveum/midpoint/smart/api/conndev/ConnectorDevelopmentService.java
+++ b/model/smart-api/src/main/java/com/evolveum/midpoint/smart/api/conndev/ConnectorDevelopmentService.java
@@ -3,9 +3,13 @@ package com.evolveum.midpoint.smart.api.conndev;
 import com.evolveum.midpoint.schema.result.OperationResult;
 import com.evolveum.midpoint.smart.api.info.StatusInfo;
 import com.evolveum.midpoint.task.api.Task;
+import com.evolveum.midpoint.util.exception.CommonException;
 import com.evolveum.midpoint.util.exception.ObjectNotFoundException;
 import com.evolveum.midpoint.util.exception.SchemaException;
 import com.evolveum.midpoint.xml.ns._public.common.common_3.*;
+
+import java.io.IOException;
+import java.io.InputStream;
 
 public interface ConnectorDevelopmentService {
 
@@ -33,5 +37,15 @@ public interface ConnectorDevelopmentService {
     StatusInfo<ConnDevRefreshSchemaResultType> getRefreshSchemaStatus(String token, Task task, OperationResult result) throws SchemaException, ObjectNotFoundException;
 
     StatusInfo<ConnDevDiscoverConnectivityEndpointResultType> getDiscoverConnectivityEndpointStatus(String token, Task task, OperationResult result) throws SchemaException, ObjectNotFoundException;
+
+    StatusInfo<ConnDevExportConnectorResultType> getExportConnectorStatus(String token, Task task, OperationResult result) throws SchemaException, ObjectNotFoundException;
+
+    /**
+     * Cluster-aware download of an exported connector bundle jar, previously stored under
+     * {@code fileName} in the midPoint home "export" directory of the node identified by
+     * {@code nodeOid}. Falls back to a local file read if the file exists on this node.
+     */
+    InputStream getExportedConnectorFileStream(String fileName, String nodeOid, Task task, OperationResult result)
+            throws CommonException, IOException;
 
 }

--- a/model/smart-impl/src/main/java/com/evolveum/midpoint/smart/impl/conndev/ConnectorDevelopmentServiceImpl.java
+++ b/model/smart-impl/src/main/java/com/evolveum/midpoint/smart/impl/conndev/ConnectorDevelopmentServiceImpl.java
@@ -8,10 +8,12 @@ package com.evolveum.midpoint.smart.impl.conndev;
 
 import com.evolveum.midpoint.model.api.ActivitySubmissionOptions;
 import com.evolveum.midpoint.model.api.ModelInteractionService;
+import com.evolveum.midpoint.model.api.ModelPublicConstants;
 import com.evolveum.midpoint.model.api.ModelService;
 import com.evolveum.midpoint.model.api.util.ResourceUtils;
 import com.evolveum.midpoint.prism.PrismContainer;
 import com.evolveum.midpoint.prism.xml.XmlTypeConverter;
+import com.evolveum.midpoint.repo.common.reports.ReportSupportUtil;
 import com.evolveum.midpoint.schema.GetOperationOptions;
 import com.evolveum.midpoint.schema.GetOperationOptionsBuilder;
 import com.evolveum.midpoint.schema.SelectorOptions;
@@ -24,17 +26,25 @@ import com.evolveum.midpoint.smart.api.conndev.ConnectorDevelopmentService;
 import com.evolveum.midpoint.smart.api.info.StatusInfo;
 import com.evolveum.midpoint.smart.impl.StatusInfoImpl;
 import com.evolveum.midpoint.smart.impl.conndev.activity.ConnDevBeans;
+import com.evolveum.midpoint.task.api.ClusterExecutionHelper;
+import com.evolveum.midpoint.task.api.ClusterExecutionOptions;
 import com.evolveum.midpoint.task.api.Task;
 import com.evolveum.midpoint.task.api.TaskManager;
+import com.evolveum.midpoint.util.Holder;
 import com.evolveum.midpoint.util.exception.*;
 import com.evolveum.midpoint.xml.ns._public.common.common_3.*;
 
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import org.apache.commons.io.FileUtils;
 import org.jetbrains.annotations.NotNull;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import javax.xml.datatype.Duration;
+import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
 import java.util.Collection;
 import java.util.List;
 import java.util.function.Consumer;
@@ -48,6 +58,7 @@ public class ConnectorDevelopmentServiceImpl implements ConnectorDevelopmentServ
     @Autowired private ModelInteractionService modelInteractionService;
     @Autowired private TaskManager taskManager;
     @Autowired private ModelService modelService;
+    @Autowired private ClusterExecutionHelper clusterExecutionHelper;
 
     private static ConnectorDevelopmentServiceImpl instance;
 
@@ -78,6 +89,13 @@ public class ConnectorDevelopmentServiceImpl implements ConnectorDevelopmentServ
                     new WorkDefinitionsType().createConnector(new ConnDevCreateConnectorWorkDefinitionType()
                             .connectorDevelopmentRef(stateObject.getOid(), ConnectorDevelopmentType.COMPLEX_TYPE)
                             .baseTemplateUrl(connectorTemplateFor(stateObject.getConnector().getIntegrationType()))
+                    ), task, result);
+        }
+
+        public String submitExportConnector(Task task, OperationResult result) {
+            return submitTask("Exporting connector for " + connectorNameForTasks(),
+                    new WorkDefinitionsType().exportConnector(new ConnDevExportConnectorWorkDefinitionType()
+                            .connectorDevelopmentRef(stateObject.getOid(), ConnectorDevelopmentType.COMPLEX_TYPE)
                     ), task, result);
         }
 
@@ -400,5 +418,48 @@ public class ConnectorDevelopmentServiceImpl implements ConnectorDevelopmentServ
                 ConnDevCreateConnectorWorkStateType.F_RESULT,
                 ConnDevDiscoverConnectivityEndpointResultType.class
         );
+    }
+
+    @Override
+    public StatusInfo<ConnDevExportConnectorResultType> getExportConnectorStatus(String token, Task task, OperationResult result) throws SchemaException, ObjectNotFoundException {
+        return new StatusInfoImpl<>(
+                getTask(token, result),
+                ConnDevExportConnectorWorkStateType.F_RESULT,
+                ConnDevExportConnectorResultType.class
+        );
+    }
+
+    @Override
+    public InputStream getExportedConnectorFileStream(String fileName, String nodeOid, Task task, OperationResult result)
+            throws CommonException, IOException {
+        var localFile = new File(ReportSupportUtil.getExportDir(), fileName);
+        if (localFile.exists()) {
+            return FileUtils.openInputStream(localFile);
+        }
+
+        Holder<InputStream> inputStreamHolder = new Holder<>();
+        clusterExecutionHelper.executeWithFallback(nodeOid,
+                (client, node, result1) -> {
+                    client.path(ModelPublicConstants.CLUSTER_REPORT_FILE_PATH);
+                    client.query(ModelPublicConstants.CLUSTER_REPORT_FILE_FILENAME_PARAMETER, fileName);
+                    client.accept(MediaType.APPLICATION_OCTET_STREAM);
+                    var response = client.get();
+                    var statusInfo = response.getStatusInfo();
+                    if (statusInfo.getFamily() == Response.Status.Family.SUCCESSFUL) {
+                        Object entity = response.getEntity();
+                        if (entity == null || entity instanceof InputStream) {
+                            inputStreamHolder.setValue((InputStream) entity);
+                            // do NOT close the response; input stream will be closed later by the caller(s)
+                        } else {
+                            response.close();
+                        }
+                    } else {
+                        result1.recordFatalError("Could not retrieve exported connector file '" + fileName + "': Got "
+                                + statusInfo.getStatusCode() + ": " + statusInfo.getReasonPhrase());
+                        response.close();
+                    }
+                }, new ClusterExecutionOptions().tryNodesInTransition().skipDefaultAccept(), "get exported connector file", result);
+
+        return inputStreamHolder.getValue();
     }
 }

--- a/model/smart-impl/src/main/java/com/evolveum/midpoint/smart/impl/conndev/activity/ConnDevBeans.java
+++ b/model/smart-impl/src/main/java/com/evolveum/midpoint/smart/impl/conndev/activity/ConnDevBeans.java
@@ -4,6 +4,7 @@ import com.evolveum.midpoint.common.configuration.api.MidpointConfiguration;
 import com.evolveum.midpoint.model.api.ModelService;
 
 import com.evolveum.midpoint.provisioning.api.ProvisioningService;
+import com.evolveum.midpoint.provisioning.ucf.api.ConnectorExportService;
 import com.evolveum.midpoint.provisioning.ucf.api.ConnectorInstallationService;
 
 import com.evolveum.midpoint.repo.api.CacheDispatcher;
@@ -48,6 +49,7 @@ public class ConnDevBeans {
     @Autowired public RepositoryService repositoryService;
     @Autowired public CacheDispatcher cacheDispatcher;
     @Autowired public ConnectorInstallationService connectorService;
+    @Autowired public ConnectorExportService connectorExportService;
     @Autowired public ProvisioningService provisioningService;
     @Autowired public SystemObjectCache systemObjectCache;
     @Autowired public MidpointConfiguration configuration;

--- a/model/smart-impl/src/main/java/com/evolveum/midpoint/smart/impl/conndev/activity/ExportConnectorActivityHandler.java
+++ b/model/smart-impl/src/main/java/com/evolveum/midpoint/smart/impl/conndev/activity/ExportConnectorActivityHandler.java
@@ -1,0 +1,136 @@
+package com.evolveum.midpoint.smart.impl.conndev.activity;
+
+import com.evolveum.midpoint.prism.PrismContext;
+import com.evolveum.midpoint.prism.PrismObject;
+import com.evolveum.midpoint.repo.common.activity.definition.WorkDefinitionFactory;
+import com.evolveum.midpoint.repo.common.activity.run.AbstractActivityRun;
+import com.evolveum.midpoint.repo.common.activity.run.ActivityRunInstantiationContext;
+import com.evolveum.midpoint.repo.common.activity.run.ActivityRunResult;
+import com.evolveum.midpoint.repo.common.activity.run.LocalActivityRun;
+import com.evolveum.midpoint.repo.common.reports.ReportSupportUtil;
+import com.evolveum.midpoint.schema.result.OperationResult;
+import com.evolveum.midpoint.smart.impl.conndev.ConnectorDevelopmentBackend;
+import com.evolveum.midpoint.task.api.RunningTask;
+import com.evolveum.midpoint.util.MiscUtil;
+import com.evolveum.midpoint.util.exception.CommonException;
+import com.evolveum.midpoint.util.exception.ConfigurationException;
+import com.evolveum.midpoint.util.exception.ObjectNotFoundException;
+import com.evolveum.midpoint.util.exception.SystemException;
+import com.evolveum.midpoint.util.logging.Trace;
+import com.evolveum.midpoint.util.logging.TraceManager;
+import com.evolveum.midpoint.xml.ns._public.common.common_3.*;
+
+import org.jetbrains.annotations.NotNull;
+import org.springframework.stereotype.Component;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+@Component
+public class ExportConnectorActivityHandler
+        extends AbstractConnDevActivityHandler<ExportConnectorActivityHandler.WorkDefinition, ExportConnectorActivityHandler> {
+
+    private static final Trace LOGGER = TraceManager.getTrace(ExportConnectorActivityHandler.class);
+
+    private static final String ARCHETYPE_OID = SystemObjectsType.ARCHETYPE_UTILITY_TASK.value();
+    private static final String DEVELOPMENT_MODE_PROPERTY = "developmentMode";
+    private static final String CONFIGURATION_OVERRIDE_FILE = "configurationOverride.properties";
+
+    public ExportConnectorActivityHandler() {
+        super(
+                ConnDevExportConnectorWorkDefinitionType.COMPLEX_TYPE,
+                WorkDefinitionsType.F_EXPORT_CONNECTOR,
+                ConnDevExportConnectorWorkStateType.COMPLEX_TYPE,
+                ExportConnectorActivityHandler.WorkDefinition.class,
+                ExportConnectorActivityHandler.WorkDefinition::new
+                );
+    }
+
+    @Override
+    public AbstractActivityRun<ExportConnectorActivityHandler.WorkDefinition, ExportConnectorActivityHandler, ?> createActivityRun(
+            @NotNull ActivityRunInstantiationContext<ExportConnectorActivityHandler.WorkDefinition, ExportConnectorActivityHandler> context,
+            @NotNull OperationResult result) {
+        return new MyActivityRun(context);
+    }
+
+    public static class WorkDefinition extends AbstractWorkDefinition<ConnDevExportConnectorWorkDefinitionType> {
+
+        final String explicitVersion;
+
+        public WorkDefinition(WorkDefinitionFactory.@NotNull WorkDefinitionInfo info) throws ConfigurationException {
+            super(info);
+            explicitVersion = typedDefinition.getVersion();
+        }
+    }
+
+    public static class MyActivityRun
+            extends LocalActivityRun<
+            ExportConnectorActivityHandler.WorkDefinition,
+            ExportConnectorActivityHandler,
+            ConnDevExportConnectorWorkStateType> {
+
+        MyActivityRun(
+                ActivityRunInstantiationContext<ExportConnectorActivityHandler.WorkDefinition, ExportConnectorActivityHandler> context) {
+            super(context);
+            setInstanceReady();
+        }
+
+        @Override
+        protected @NotNull ActivityRunResult runLocally(OperationResult result) throws CommonException {
+            var task = getRunningTask();
+            var beans = ConnDevBeans.get();
+
+            var backend = ConnectorDevelopmentBackend.backendFor(getWorkDefinition().connectorDevelopmentOid, task, result);
+            var connDef = backend.developmentObject().getConnector();
+
+            var version = getWorkDefinition().explicitVersion != null
+                    ? getWorkDefinition().explicitVersion
+                    : connDef.getVersion();
+
+            // Fixes the manifest in the midPoint home bundle directory to the exported version.
+            // This is a local, in-place write; it does not create a new ConnId bundle URI, so no
+            // re-registration with the running ConnId framework happens (and none is needed for
+            // producing the export artifact).
+            beans.connectorService.editableConnectorFor(connDef.getDirectory())
+                    .renameBundle(connDef.getGroupId(), connDef.getArtifactId(), version);
+
+            var fileName = MiscUtil.fixFileName(connDef.getArtifactId() + "-connector-" + version + ".jar");
+            var targetFile = new File(ReportSupportUtil.getOrCreateExportDir(), fileName);
+            try {
+                beans.connectorExportService.packBundle(
+                        connDef.getDirectory(),
+                        targetFile,
+                        Map.of(CONFIGURATION_OVERRIDE_FILE, Map.of(DEVELOPMENT_MODE_PROPERTY, "false")));
+            } catch (IOException e) {
+                throw new SystemException("Couldn't pack connector bundle into " + targetFile, e);
+            }
+
+            var nodeRef = currentNodeRef(task, result);
+
+            var state = getActivityState();
+            state.setWorkStateItemRealValues(ConnDevExportConnectorWorkStateType.F_RESULT, new ConnDevExportConnectorResultType()
+                    .fileName(fileName)
+                    .nodeRef(nodeRef)
+                    .version(version)
+                    .connectorRef(connDef.getConnectorRef().clone()));
+            state.flushPendingTaskModifications(result);
+            return ActivityRunResult.success();
+        }
+
+        private ObjectReferenceType currentNodeRef(RunningTask task, OperationResult result)
+                throws CommonException {
+            var beans = ConnDevBeans.get();
+            var nodeId = task.getNode();
+            var query = PrismContext.get().queryFor(NodeType.class)
+                    .item(NodeType.F_NODE_IDENTIFIER).eq(nodeId)
+                    .build();
+            List<PrismObject<NodeType>> nodes = beans.modelService.searchObjects(NodeType.class, query, null, task, result);
+            if (nodes.isEmpty()) {
+                throw new ObjectNotFoundException("Could not find node where the connector export was stored", NodeType.class, nodeId);
+            }
+            return new ObjectReferenceType().oid(nodes.get(0).getOid()).type(NodeType.COMPLEX_TYPE);
+        }
+    }
+}

--- a/provisioning/ucf-api/src/main/java/com/evolveum/midpoint/provisioning/ucf/api/ConnectorExportService.java
+++ b/provisioning/ucf-api/src/main/java/com/evolveum/midpoint/provisioning/ucf/api/ConnectorExportService.java
@@ -1,0 +1,22 @@
+package com.evolveum.midpoint.provisioning.ucf.api;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Map;
+
+public interface ConnectorExportService {
+
+    /**
+     * Packs an exploded connector bundle directory into a connector bundle jar.
+     *
+     * The directory is identified by its name inside the connector scan directory, the same way
+     * as in {@link ConnectorInstallationService#editableConnectorFor(String)}. The jar is written
+     * to a temporary file first and then atomically renamed to {@code targetFile}.
+     *
+     * The {@code propertyOverrides} map keys are properties file names relative to the bundle root,
+     * values are properties to be set in that file. Overrides are applied inside the created jar
+     * only; the source directory is left untouched.
+     */
+    File packBundle(String directory, File targetFile, Map<String, Map<String, String>> propertyOverrides)
+            throws IOException;
+}

--- a/provisioning/ucf-impl-connid/src/main/java/com/evolveum/midpoint/provisioning/ucf/impl/connid/ConnectorExportServiceImpl.java
+++ b/provisioning/ucf-impl-connid/src/main/java/com/evolveum/midpoint/provisioning/ucf/impl/connid/ConnectorExportServiceImpl.java
@@ -1,0 +1,135 @@
+package com.evolveum.midpoint.provisioning.ucf.impl.connid;
+
+import com.evolveum.midpoint.common.configuration.api.MidpointConfiguration;
+import com.evolveum.midpoint.provisioning.ucf.api.ConnectorExportService;
+
+import jakarta.annotation.PostConstruct;
+import org.apache.commons.configuration2.Configuration;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.jar.JarEntry;
+import java.util.jar.JarOutputStream;
+import java.util.jar.Manifest;
+import java.util.stream.Stream;
+
+import static java.nio.file.StandardCopyOption.ATOMIC_MOVE;
+import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
+
+@Component
+public class ConnectorExportServiceImpl implements ConnectorExportService {
+
+    private static final String TMP_SUFFIX = ".tmp";
+    private static final String PREFERRED_DIRECTORY = "connid-connectors";
+    private static final String MANIFEST_PATH = "META-INF/MANIFEST.MF";
+
+    @Autowired private MidpointConfiguration configuration;
+
+    private File bundleDirectory;
+
+    @PostConstruct
+    public void init() {
+        Configuration config = configuration.getConfiguration(MidpointConfiguration.ICF_CONFIGURATION);
+        List<Object> dirs = config.getList("scanDirectory");
+
+        bundleDirectory = dirs.stream().filter(d -> d.toString().contains(PREFERRED_DIRECTORY))
+                .findFirst()
+                .map(Object::toString)
+                .map(File::new)
+                .orElse(null);
+
+        if (bundleDirectory == null && !dirs.isEmpty()) {
+            bundleDirectory = new File(dirs.iterator().next().toString());
+        }
+    }
+
+    @Override
+    public File packBundle(String directory, File targetFile, Map<String, Map<String, String>> propertyOverrides)
+            throws IOException {
+        if (directory.contains("/") || directory.contains("\\")) {
+            throw new IllegalArgumentException("Invalid directory name: " + directory);
+        }
+        var bundleDir = new File(bundleDirectory, directory);
+        if (!bundleDir.isDirectory()) {
+            throw new IllegalStateException("Directory " + directory + " does not exist");
+        }
+        var manifestFile = new File(bundleDir, MANIFEST_PATH);
+        if (!manifestFile.isFile()) {
+            throw new IllegalStateException(
+                    "Directory " + directory + " is not a connector bundle, " + MANIFEST_PATH + " is missing");
+        }
+
+        var tmpFile = new File(targetFile.getPath() + TMP_SUFFIX);
+        try {
+            Manifest manifest;
+            try (var manifestStream = new FileInputStream(manifestFile)) {
+                manifest = new Manifest(manifestStream);
+            }
+            try (var jar = new JarOutputStream(new FileOutputStream(tmpFile), manifest)) {
+                var remainingOverrides = new HashMap<>(propertyOverrides);
+                writeFileEntries(jar, bundleDir, remainingOverrides);
+                writeMissingOverriddenEntries(jar, remainingOverrides);
+            }
+            Files.move(tmpFile.toPath(), targetFile.toPath(), ATOMIC_MOVE, REPLACE_EXISTING);
+        } catch (IOException | RuntimeException e) {
+            tmpFile.delete();
+            throw e;
+        }
+        return targetFile;
+    }
+
+    private void writeFileEntries(JarOutputStream jar, File bundleDir, Map<String, Map<String, String>> remainingOverrides)
+            throws IOException {
+        Path root = bundleDir.toPath();
+        try (Stream<Path> files = Files.walk(root)) {
+            var regularFiles = files.filter(Files::isRegularFile).sorted().toList();
+            for (Path file : regularFiles) {
+                String entryName = root.relativize(file).toString().replace(File.separatorChar, '/');
+                if (MANIFEST_PATH.equals(entryName) || file.getFileName().toString().endsWith(TMP_SUFFIX)) {
+                    continue;
+                }
+                jar.putNextEntry(new JarEntry(entryName));
+                var overrides = remainingOverrides.remove(entryName);
+                if (overrides != null) {
+                    jar.write(overriddenProperties(file.toFile(), overrides));
+                } else {
+                    Files.copy(file, jar);
+                }
+                jar.closeEntry();
+            }
+        }
+    }
+
+    private void writeMissingOverriddenEntries(JarOutputStream jar, Map<String, Map<String, String>> remainingOverrides)
+            throws IOException {
+        for (var override : remainingOverrides.entrySet()) {
+            jar.putNextEntry(new JarEntry(override.getKey()));
+            jar.write(overriddenProperties(null, override.getValue()));
+            jar.closeEntry();
+        }
+    }
+
+    private byte[] overriddenProperties(File file, Map<String, String> overrides) throws IOException {
+        var props = new Properties();
+        if (file != null) {
+            try (var stream = new FileInputStream(file)) {
+                props.load(stream);
+            }
+        }
+        overrides.forEach(props::setProperty);
+        var out = new ByteArrayOutputStream();
+        props.store(out, null);
+        return out.toByteArray();
+    }
+}


### PR DESCRIPTION
Lets the connector generator wizard package the connector's exploded ConnId bundle directory into a downloadable jar, so it can be installed into another midPoint instance without going through the connector catalog.

- ConnectorExportService (ucf-api/ucf-impl-connid): packs an exploded bundle directory into a jar (manifest first, atomic write), applying property overrides (developmentMode=false) only inside the jar
- ExportConnectorActivityHandler: fixes the bundle manifest to the current/explicit version and packs it via ConnectorExportService; does not bump the version or re-link the dev environment, since ConnId's DirectoryScanningInfoManager caches by bundle URI and a same-directory manifest change would never be re-registered
- New submitExportConnector/getExportConnectorStatus API plus a cluster-aware getExportedConnectorFileStream download, reusing the existing CLUSTER_REPORT_FILE_PATH transport without depending on ReportDataType (its fileFormat only allows csv/html)
- GUI: EXPORT_CONNECTOR tile on the wizard summary triggers a waiting step (mirrors the connector-creation waiting step); the download is triggered from the summary panel's onBeforeRender via a result stashed on the details model, since a download behavior attached to the waiting step would be invalidated once that step is replaced by the summary panel in the same AJAX response