### PR TITLE
Connector Generator wizard: fix endpoint selection persistence and preferredEndpoints

### DIFF
--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/component/wizard/scimrest/objectclass/EndpointsConnectorStepPanel.html
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/component/wizard/scimrest/objectclass/EndpointsConnectorStepPanel.html
@@ -15,7 +15,7 @@
         <div class="d-flex flex-column" wicket:id="panel">
             <div class="d-flex flex-row w-100">
                 <div class="h-100 m-auto pe-3">
-                    <input wicket:id="radio" type="radio"/>
+                    <input wicket:id="radio" type="radio" onclick="event.stopPropagation()"/>
                 </div>
                 <div class="h-100 m-auto border rounded px-2">
                     <div wicket:id="operation"/>

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/component/wizard/scimrest/objectclass/EndpointsConnectorStepPanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/component/wizard/scimrest/objectclass/EndpointsConnectorStepPanel.java
@@ -11,6 +11,7 @@ import java.util.List;
 import java.util.Optional;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.wicket.ajax.AjaxEventBehavior;
 import org.apache.wicket.ajax.AjaxRequestTarget;
 import org.apache.wicket.ajax.form.AjaxFormChoiceComponentUpdatingBehavior;
 import org.apache.wicket.behavior.AttributeAppender;
@@ -83,12 +84,22 @@ public abstract class EndpointsConnectorStepPanel extends AbstractWizardStepPane
                             PrismContainerWrapper<ConnDevHttpEndpointType> endpointsContainer = objectClassContainer
                                     .get().findContainer(ConnDevObjectClassInfoType.F_ENDPOINT);
                             // Filter endpoints which contain any of the supported intents for the script.
-                            return endpointsContainer.getValues().stream()
+                            List<PrismContainerValueWrapper<ConnDevHttpEndpointType>> candidates = endpointsContainer.getValues().stream()
                                     .filter(value ->
                                             getEndpointIntents().stream().anyMatch(
                                                 i -> value.getRealValue().getSuggestedUse().contains(i))
                                     )
                                     .toList();
+
+                            // Pre-select the candidate matching the endpoint already confirmed for this
+                            // operation, so a previously saved selection shows up as selected again.
+                            getConfirmedEndpointName().ifPresent(confirmedName ->
+                                    candidates.stream()
+                                            .filter(candidate -> StringUtils.equals(candidate.getRealValue().getName(), confirmedName))
+                                            .findFirst()
+                                            .ifPresent(candidate -> candidate.setSelected(true)));
+
+                            return candidates;
                         } catch (SchemaException e) {
                             throw new RuntimeException(e);
                         }
@@ -99,6 +110,20 @@ public abstract class EndpointsConnectorStepPanel extends AbstractWizardStepPane
                 }
             }
         };
+    }
+
+    private Optional<String> getConfirmedEndpointName() {
+        try {
+            PrismContainerWrapper<ConnDevHttpEndpointType> container =
+                    objectClassModel.getObject().findContainer(ConnDevObjectClassInfoType.F_ENDPOINT);
+            return container.getValues().stream()
+                    .map(PrismContainerValueWrapper::getRealValue)
+                    .filter(value -> getEndpointIntents().stream().anyMatch(i -> value.getSuggestedUse().contains(i)))
+                    .map(ConnDevHttpEndpointType::getName)
+                    .findFirst();
+        } catch (SchemaException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     protected abstract Collection<ConnDevHttpEndpointIntentType> getEndpointIntents();
@@ -157,6 +182,15 @@ public abstract class EndpointsConnectorStepPanel extends AbstractWizardStepPane
                 Label uri = new Label(ID_URI, () -> listItem.getModelObject().getRealValue().getUri());
                 uri.setOutputMarkupId(true);
                 listItem.add(uri);
+
+                listItem.add(AttributeAppender.append("style", "cursor: pointer;"));
+                listItem.add(new AjaxEventBehavior("click") {
+                    @Override
+                    protected void onEvent(AjaxRequestTarget target) {
+                        radioGroupModel.setObject(listItem.getModelObject().getRealValue().getName());
+                        target.add(radioGroup);
+                    }
+                });
             }
         };
         panel.setOutputMarkupId(true);
@@ -191,46 +225,60 @@ public abstract class EndpointsConnectorStepPanel extends AbstractWizardStepPane
             PrismContainerWrapper<ConnDevHttpEndpointType> container =
                     objectClassModel.getObject().findContainer(ConnDevObjectClassInfoType.F_ENDPOINT);
 
-            List<PrismContainerValueWrapper<ConnDevHttpEndpointType>> valuesToAdd = valuesModel.getObject()
-                    .stream().filter(PrismContainerValueWrapper::isSelected)
-                    .map(value -> {
+            List<PrismContainerValueWrapper<ConnDevHttpEndpointType>> valuesToRemove = container.getValues().stream()
+                    .filter(value -> value.getRealValue().getSuggestedUse().contains(getEndpointIntents()))
+                    .toList();
+
+            if (!valuesToRemove.isEmpty()) {
+                valuesToRemove.forEach(
+                        value -> {
+                            try {
+                                container.remove(value, getDetailsModel().getPageAssignmentHolder());
+                            } catch (SchemaException e) {
+                                throw new RuntimeException(e);
+                            }
+                        });
+
+                // Persist the removal on its own: adding the new value in the same delta as removing
+                // the old one risks the new value being assigned the CID that only becomes free once
+                // the removal is applied, colliding with it ("Attempt to add a container value with
+                // an id that already exists").
+                OperationResult removeResult = getHelper().onSaveObjectPerformed(target);
+                if (removeResult != null && removeResult.isError()) {
+                    target.add(getFeedback());
+                    return false;
+                }
+            }
+
+            PrismContainerWrapper<ConnDevHttpEndpointType> finalContainer =
+                    objectClassModel.getObject().findContainer(ConnDevObjectClassInfoType.F_ENDPOINT);
+            valuesModel.getObject().stream()
+                    .filter(PrismContainerValueWrapper::isSelected)
+                    .findFirst()
+                    .ifPresent(value -> {
                         try {
                             PrismContainerValue<ConnDevHttpEndpointType> clone =
                                     value.getRealValue().asPrismContainerValue().cloneComplex(CloneStrategy.REUSE);
                             clone.removeItem(ConnDevHttpEndpointType.F_SUGGESTED_USE);
-                            //clone.asContainerable().suggestedUse(getEndpointIntents());
+                            clone.asContainerable().getSuggestedUse().addAll(getEndpointIntents());
 
-                            return (PrismContainerValueWrapper<ConnDevHttpEndpointType>) WebPrismUtil.createNewValueWrapper(
-                                    container,
+                            // Attach the clone to the real container (not just its GUI wrapper list) so
+                            // it is part of the delta computed by onSaveObjectPerformed() below -
+                            // otherwise the selection only exists in the wrapper and is lost on reload.
+                            clone.setId(null);
+                            clone.setParent(finalContainer.getItem());
+                            finalContainer.getItem().add(clone);
+
+                            PrismContainerValueWrapper<ConnDevHttpEndpointType> newValueWrapper = WebPrismUtil.createNewValueWrapper(
+                                    finalContainer,
                                     clone,
                                     getPageBase(),
                                     getDetailsModel().createWrapperContext());
-                        } catch (SchemaException e) {
-                            throw new RuntimeException(e);
-                        }
-                    })
-                    .toList();
-
-            List<PrismContainerValueWrapper<ConnDevHttpEndpointType>> valuesToRemove = container.getValues().stream()
-                    .filter(value -> value.getRealValue().getSuggestedUse().contains(getEndpointIntents()))
-                    .toList();
-            valuesToRemove.forEach(
-                    value -> {
-                        try {
-                            container.remove(value, getDetailsModel().getPageAssignmentHolder());
+                            finalContainer.getValues().add(newValueWrapper);
                         } catch (SchemaException e) {
                             throw new RuntimeException(e);
                         }
                     });
-
-            valuesToAdd.forEach(value -> {
-//                try {
-//                    container.getItem().add(value.getRealValue().asPrismContainerValue());
-                    container.getValues().add(value);
-//                } catch (SchemaException e) {
-//                    throw new RuntimeException(e);
-//                }
-            });
 
         } catch (SchemaException e) {
             throw new RuntimeException(e);

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/component/wizard/scimrest/objectclass/ObjectClassSelectConnectorStepPanel.html
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/component/wizard/scimrest/objectclass/ObjectClassSelectConnectorStepPanel.html
@@ -36,7 +36,7 @@
         <div class="flex-fill p-1" wicket:id="panel">
             <div class="d-flex flex-row card shadow-sm p-2 h-100">
                 <div class="d-flex flex-column justify-content-center h-100 m-auto pe-3">
-                    <input wicket:id="radio" type="radio"/>
+                    <input wicket:id="radio" type="radio" onclick="event.stopPropagation()"/>
                 </div>
                 <div class="w-100 d-flex flex-column">
                     <div class="d-lex flex-row">

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/component/wizard/scimrest/objectclass/ObjectClassSelectConnectorStepPanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/component/wizard/scimrest/objectclass/ObjectClassSelectConnectorStepPanel.java
@@ -13,6 +13,7 @@ import java.util.Objects;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.wicket.ajax.AjaxEventBehavior;
 import org.apache.wicket.ajax.AjaxRequestTarget;
 import org.apache.wicket.ajax.form.AjaxFormChoiceComponentUpdatingBehavior;
 import org.apache.wicket.behavior.AttributeAppender;
@@ -248,6 +249,15 @@ public class ObjectClassSelectConnectorStepPanel extends AbstractWizardStepPanel
                 Label description = new Label(ID_DESCRIPTION, () -> listItem.getModelObject().getRealValue().getDescription());
                 description.setOutputMarkupId(true);
                 listItem.add(description);
+
+                listItem.add(AttributeAppender.append("style", "cursor: pointer;"));
+                listItem.add(new AjaxEventBehavior("click") {
+                    @Override
+                    protected void onEvent(AjaxRequestTarget target) {
+                        radioGroupModel.setObject(listItem.getModelObject().getRealValue().getName());
+                        target.add(radioGroup);
+                    }
+                });
             }
         };
         panel.setOutputMarkupId(true);

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/component/wizard/scimrest/relation/RelationshipSelectConnectorStepPanel.html
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/component/wizard/scimrest/relation/RelationshipSelectConnectorStepPanel.html
@@ -14,7 +14,7 @@
     <div class="col-12 gap-2 p-0" wicket:id="radioGroup">
         <div class="d-flex flex-column w-100 p-3 card shadow-sm mb-3" wicket:id="panel">
             <div class="d-flex flex-row w-100 border-bottom pb-2 gap-2">
-                <input wicket:id="radio" type="radio"/>
+                <input wicket:id="radio" type="radio" onclick="event.stopPropagation()"/>
                 <div class="fw-bold" wicket:id="name"/>
                 <div class="text-secondary ms-auto" wicket:id="description"/>
             </div>

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/component/wizard/scimrest/relation/RelationshipSelectConnectorStepPanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/component/wizard/scimrest/relation/RelationshipSelectConnectorStepPanel.java
@@ -11,6 +11,7 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Strings;
+import org.apache.wicket.ajax.AjaxEventBehavior;
 import org.apache.wicket.ajax.AjaxRequestTarget;
 import org.apache.wicket.ajax.form.AjaxFormChoiceComponentUpdatingBehavior;
 import org.apache.wicket.behavior.AttributeAppender;
@@ -165,6 +166,15 @@ public class RelationshipSelectConnectorStepPanel extends AbstractWizardStepPane
                 Label objectAttribute = new Label(ID_OBJECT_ATTRIBUTE, () -> listItem.getModelObject().getRealValue().getObjectAttribute());
                 objectAttribute.setOutputMarkupId(true);
                 listItem.add(objectAttribute);
+
+                listItem.add(AttributeAppender.append("style", "cursor: pointer;"));
+                listItem.add(new AjaxEventBehavior("click") {
+                    @Override
+                    protected void onEvent(AjaxRequestTarget target) {
+                        radioGroupModel.setObject(listItem.getModelObject().getRealValue().getName());
+                        target.add(radioGroup);
+                    }
+                });
             }
         };
         panel.setOutputMarkupId(true);

--- a/model/smart-impl/src/main/java/com/evolveum/midpoint/smart/impl/conndev/RestBackend.java
+++ b/model/smart-impl/src/main/java/com/evolveum/midpoint/smart/impl/conndev/RestBackend.java
@@ -246,7 +246,7 @@ public class RestBackend extends ConnectorDevelopmentBackend {
                     "native-schema", "native schema script", body, skipCache);
             case CONNID_SCHEMA_DEFINITION -> generateObjectClassScript(artifactSpec,
                     "connid", "ConnID mapping script", body, skipCache);
-            case SEARCH_ALL_DEFINITION -> generateSearchAll(artifactSpec, input.getEndpoint(), body, skipCache);
+            case SEARCH_ALL_DEFINITION -> generateSearchAll(artifactSpec, body, skipCache);
             case SEARCH_BY_ID_DEFINITION -> generateObjectClassScript(artifactSpec,
                     "search/" + ConnDevJsonMapper.toServiceIntent(artifactSpec.getIntent()),
                     "search by ID script", body, skipCache);
@@ -272,6 +272,14 @@ public class RestBackend extends ConnectorDevelopmentBackend {
         var errors = JSON_FACTORY.arrayNode();
         input.getMidpointError().forEach(errors::add);
         body.set("midpointErrors", errors);
+        var preferredEndpoints = JSON_FACTORY.arrayNode();
+        for (var endpoint : input.getEndpoint()) {
+            var jsonEndpoint = JSON_FACTORY.objectNode();
+            jsonEndpoint.set("method", JSON_FACTORY.textNode(ConnDevJsonMapper.toValue(endpoint.getOperation())));
+            jsonEndpoint.set("path", JSON_FACTORY.textNode(endpoint.getUri()));
+            preferredEndpoints.add(jsonEndpoint);
+        }
+        body.set("preferredEndpoints", preferredEndpoints);
         return body;
     }
 
@@ -286,8 +294,7 @@ public class RestBackend extends ConnectorDevelopmentBackend {
 
 
 
-    private String generateSearchAll(ConnDevArtifactType artifactSpec, List<ConnDevHttpEndpointType> endpoints, ObjectNode body, boolean skipCache) {
-        // TODO: In future when endpoints are editable ensure synchronization of endpoints
+    private String generateSearchAll(ConnDevArtifactType artifactSpec, ObjectNode body, boolean skipCache) {
         return generateObjectClassScript(artifactSpec, "search/" + ConnDevJsonMapper.toServiceIntent(artifactSpec.getIntent()),
                 "search script", body, skipCache);
     }


### PR DESCRIPTION
- Send `preferredEndpoints` (user-confirmed endpoints) to the codegen repair request, previously silently dropped.
- Fix endpoint selection in the object class Endpoints step not persisting (wrapper-only add, CID collision on remove+add, missing pre-select of the already-confirmed endpoint).
- Make object class / relationship selection tiles clickable anywhere, not just the small radio button.