### PR TITLE
Write connector.manifest as YAML instead of JSON

### DIFF
--- a/model/smart-impl/pom.xml
+++ b/model/smart-impl/pom.xml
@@ -327,6 +327,10 @@
             <artifactId>jackson-databind</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.fasterxml.jackson.dataformat</groupId>
+            <artifactId>jackson-dataformat-yaml</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
         </dependency>

--- a/model/smart-impl/src/main/java/com/evolveum/midpoint/smart/impl/conndev/ConnectorDevelopmentBackend.java
+++ b/model/smart-impl/src/main/java/com/evolveum/midpoint/smart/impl/conndev/ConnectorDevelopmentBackend.java
@@ -42,7 +42,8 @@ import java.util.function.BooleanSupplier;
 public abstract class ConnectorDevelopmentBackend {
 
     private static final JsonNodeFactory JSON_FACTORY = JsonNodeFactory.instance;
-    private static final String CONNECTOR_MANIFEST = "connector.manifest.json";
+    private static final String CONNECTOR_MANIFEST = "connector.manifest.yaml";
+    private static final String CONNECTOR_MANIFEST_JSON_LEGACY = "connector.manifest.json";
     private static final String CONFIGURATION_OVERRIDE = "configurationOverride.properties";
     private static final int MAX_SUGGESTED_CONNECTIVITY_ENDPOINTS = 5;
     private static final String CONNDEV_OBJECT_CLASS = "conndev_ObjectClass";
@@ -240,7 +241,7 @@ public abstract class ConnectorDevelopmentBackend {
         var manifest = new ConnectorManifestWriter(development).serialize();
 
         editableConnector().saveFile(CONNECTOR_MANIFEST, manifest);
-
+        editableConnector().deleteFileIfExists(CONNECTOR_MANIFEST_JSON_LEGACY);
     }
 
     private EditableConnector editableConnector() {

--- a/model/smart-impl/src/main/java/com/evolveum/midpoint/smart/impl/conndev/ConnectorManifestWriter.java
+++ b/model/smart-impl/src/main/java/com/evolveum/midpoint/smart/impl/conndev/ConnectorManifestWriter.java
@@ -4,15 +4,19 @@ import com.evolveum.midpoint.xml.ns._public.common.common_3.*;
 
 import com.evolveum.prism.xml.ns._public.types_3.PolyStringType;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
 
+import java.io.UncheckedIOException;
 import java.util.function.Function;
 
 public class ConnectorManifestWriter {
 
     private static final JsonNodeFactory FACTORY = JsonNodeFactory.instance;
+    private static final YAMLMapper YAML = new YAMLMapper();
     private final ObjectNode application;
     private final ObjectNode connector;
     private ObjectNode root;
@@ -107,8 +111,12 @@ public class ConnectorManifestWriter {
         }
     }
 
+    /** Serializes the manifest as YAML — connectors also accept JSON, but the wizard writes YAML. */
     public String serialize() {
-        return root.toPrettyString();
-
+        try {
+            return YAML.writeValueAsString(root);
+        } catch (JsonProcessingException e) {
+            throw new UncheckedIOException(e);
+        }
     }
 }

--- a/provisioning/ucf-api/src/main/java/com/evolveum/midpoint/provisioning/ucf/api/EditableConnector.java
+++ b/provisioning/ucf-api/src/main/java/com/evolveum/midpoint/provisioning/ucf/api/EditableConnector.java
@@ -8,6 +8,8 @@ public interface EditableConnector extends DownloadedConnector {
 
     void saveFile(String filename, String content) throws IOException;
 
+    void deleteFileIfExists(String filename) throws IOException;
+
     String readFile(String filename) throws IOException;
 
     void updateProperty(String filename, String key, String value) throws IOException;

--- a/provisioning/ucf-impl-connid/src/main/java/com/evolveum/midpoint/provisioning/ucf/impl/connid/ConnectorInstallationServiceImpl.java
+++ b/provisioning/ucf-impl-connid/src/main/java/com/evolveum/midpoint/provisioning/ucf/impl/connid/ConnectorInstallationServiceImpl.java
@@ -283,6 +283,12 @@ public class ConnectorInstallationServiceImpl implements ConnectorInstallationSe
         }
 
         @Override
+        public void deleteFileIfExists(String filename) throws IOException {
+            var file = newFile(connectorFile, filename);
+            Files.deleteIfExists(file.toPath());
+        }
+
+        @Override
         public String readFile(String filename) throws IOException {
             var file = newFile(connectorFile, filename);
             return Files.readString(file.toPath());


### PR DESCRIPTION
ConnectorManifestWriter now serializes the same ObjectNode tree via YAMLMapper instead of toPrettyString(); the manifest filename changes to connector.manifest.yaml accordingly. No consumer-side change needed — com.evolveum.polygon.conndev.spi.ConnectorManifest.load(anchor, baseName) already resolves .yaml/.yml/.json.