### PR TITLE
Add initial support for SQL as connector generator integration type

### DIFF
--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/factory/panel/ConnDevIntegrationTypeGuiComponentFactory.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/factory/panel/ConnDevIntegrationTypeGuiComponentFactory.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (C) 2010-2026 Evolveum and contributors
+ *
+ * Licensed under the EUPL-1.2 or later.
+ */
+
+package com.evolveum.midpoint.gui.impl.factory.panel;
+
+import java.util.Arrays;
+import java.util.List;
+
+import jakarta.annotation.PostConstruct;
+import org.apache.wicket.model.Model;
+import org.springframework.stereotype.Component;
+
+import com.evolveum.midpoint.gui.api.factory.AbstractGuiComponentFactory;
+import com.evolveum.midpoint.gui.api.prism.ItemStatus;
+import com.evolveum.midpoint.gui.api.prism.wrapper.ItemWrapper;
+import com.evolveum.midpoint.gui.api.prism.wrapper.PrismPropertyWrapper;
+import com.evolveum.midpoint.gui.api.prism.wrapper.PrismValueWrapper;
+import com.evolveum.midpoint.gui.api.util.WebComponentUtil;
+import com.evolveum.midpoint.util.QNameUtil;
+import com.evolveum.midpoint.util.exception.SchemaException;
+import com.evolveum.midpoint.util.exception.SystemException;
+import com.evolveum.midpoint.web.component.input.DropDownChoicePanel;
+import com.evolveum.midpoint.xml.ns._public.common.common_3.ConnDevApplicationInfoType;
+import com.evolveum.midpoint.xml.ns._public.common.common_3.ConnDevIntegrationType;
+
+/**
+ * Restricts the {@code application/integrationType} dropdown so that a connector development
+ * can never be switched between {@link ConnDevIntegrationType#SQL} and REST/SCIM once created —
+ * the SQL backend is a structurally different template/backend family, so such a switch would
+ * leave the object in an inconsistent state. New (not yet persisted) objects still offer all values.
+ */
+@Component
+public class ConnDevIntegrationTypeGuiComponentFactory extends AbstractGuiComponentFactory<ConnDevIntegrationType> {
+
+    @PostConstruct
+    public void register() {
+        getRegistry().addToRegistry(this);
+    }
+
+    @Override
+    public <IW extends ItemWrapper<?, ?>, VW extends PrismValueWrapper<?>> boolean match(IW wrapper, VW valueWrapper) {
+        if (wrapper.getParentContainerValue(ConnDevApplicationInfoType.class) == null) {
+            return false;
+        }
+        return QNameUtil.match(wrapper.getItemName(), ConnDevApplicationInfoType.F_INTEGRATION_TYPE);
+    }
+
+    @Override
+    protected DropDownChoicePanel<ConnDevIntegrationType> getPanel(PrismPropertyPanelContext<ConnDevIntegrationType> panelCtx) {
+        PrismPropertyWrapper<ConnDevIntegrationType> wrapper = panelCtx.unwrapWrapperModel();
+
+        ConnDevIntegrationType oldType = null;
+        if (wrapper.findObjectStatus() != ItemStatus.ADDED) {
+            try {
+                var oldValue = wrapper.getValue().getOldValue();
+                oldType = oldValue != null ? oldValue.getRealValue() : null;
+            } catch (SchemaException e) {
+                throw new SystemException("Couldn't determine current value of " + wrapper.getItemName(), e);
+            }
+        }
+
+        List<ConnDevIntegrationType> choices;
+        if (oldType == null) {
+            // new connector development, nothing to restrict yet
+            choices = List.of(ConnDevIntegrationType.values());
+        } else if (oldType == ConnDevIntegrationType.SQL) {
+            choices = List.of(ConnDevIntegrationType.SQL);
+        } else {
+            choices = List.of(ConnDevIntegrationType.SCIM, ConnDevIntegrationType.REST);
+        }
+
+        DropDownChoicePanel<ConnDevIntegrationType> panel = WebComponentUtil.createEnumPanel(panelCtx.getComponentId(),
+                Model.ofList(choices), panelCtx.getRealValueModel(), panelCtx.getParentComponent(), false);
+        if (oldType == ConnDevIntegrationType.SQL) {
+            panel.setEnabled(false);
+        }
+        return panel;
+    }
+
+    @Override
+    public Integer getOrder() {
+        return 100;
+    }
+}

--- a/infra/schema/src/main/resources/xml/ns/public/common/common-connector-dev-3.xsd
+++ b/infra/schema/src/main/resources/xml/ns/public/common/common-connector-dev-3.xsd
@@ -606,6 +606,16 @@
                     </xsd:appinfo>
                 </xsd:annotation>
             </xsd:enumeration>
+            <xsd:enumeration value="sql">
+                <xsd:annotation>
+                    <xsd:documentation>
+                        Integration using SQL database connectivity
+                    </xsd:documentation>
+                    <xsd:appinfo>
+                        <jaxb:typesafeEnumMember name="SQL"/>
+                    </xsd:appinfo>
+                </xsd:annotation>
+            </xsd:enumeration>
             <!-- Dummy integration is hidden, will be replaced by multitable
             <xsd:enumeration value="dummy">
                 <xsd:annotation>

--- a/infra/schema/src/main/resources/xml/ns/public/common/common-smart-integration-3.xsd
+++ b/infra/schema/src/main/resources/xml/ns/public/common/common-smart-integration-3.xsd
@@ -63,6 +63,13 @@
                     </xsd:documentation>
                 </xsd:annotation>
             </xsd:element>
+            <xsd:element name="connectorSqlFrameworkUrl" type="xsd:string" minOccurs="0">
+                <xsd:annotation>
+                    <xsd:documentation>
+                        A URL of the SQL connector framework template.
+                    </xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
             <xsd:element name="statisticsTtl" type="xsd:duration" minOccurs="0">
                 <xsd:annotation>
                     <xsd:documentation>

--- a/model/smart-api/src/main/java/com/evolveum/midpoint/smart/api/conndev/SupportedAuthorization.java
+++ b/model/smart-api/src/main/java/com/evolveum/midpoint/smart/api/conndev/SupportedAuthorization.java
@@ -167,6 +167,7 @@ public enum SupportedAuthorization {
         return (List) switch (integration) {
             case SCIM -> scimProperties;
             case REST -> restProperties;
+            case SQL -> List.of();
         };
     }
 

--- a/model/smart-impl/src/main/java/com/evolveum/midpoint/smart/impl/conndev/ConnectorDevelopmentBackend.java
+++ b/model/smart-impl/src/main/java/com/evolveum/midpoint/smart/impl/conndev/ConnectorDevelopmentBackend.java
@@ -98,6 +98,7 @@ public abstract class ConnectorDevelopmentBackend {
         return switch (integrationType) {
             case REST -> new RestBackend(beans, connDev, task, result);
             case SCIM -> new ScimBackend(beans, connDev, task, result);
+            case SQL -> new SqlBackend(beans, connDev, task, result);
             //case DUMMY -> new OfflineBackend(beans, connDev, task, result);
         };
 

--- a/model/smart-impl/src/main/java/com/evolveum/midpoint/smart/impl/conndev/ConnectorDevelopmentServiceImpl.java
+++ b/model/smart-impl/src/main/java/com/evolveum/midpoint/smart/impl/conndev/ConnectorDevelopmentServiceImpl.java
@@ -320,8 +320,12 @@ public class ConnectorDevelopmentServiceImpl implements ConnectorDevelopmentServ
     }
 
     private String connectorTemplateFor(ConnDevIntegrationType integrationType) {
-        // FIXME: Dispatch to IntegrationType specific handler
-        return ConnDevBeans.get().getFrameworkUrl(new OperationResult("Empty"));
+        var beans = ConnDevBeans.get();
+        var result = new OperationResult("Empty");
+        return switch (integrationType) {
+            case REST, SCIM -> beans.getFrameworkUrl(result);
+            case SQL -> beans.getSqlFrameworkUrl(result);
+        };
     }
 
     private static @NotNull Collection<SelectorOptions<GetOperationOptions>> taskRetrievalOptions() {

--- a/model/smart-impl/src/main/java/com/evolveum/midpoint/smart/impl/conndev/SqlBackend.java
+++ b/model/smart-impl/src/main/java/com/evolveum/midpoint/smart/impl/conndev/SqlBackend.java
@@ -1,0 +1,116 @@
+package com.evolveum.midpoint.smart.impl.conndev;
+
+import com.evolveum.midpoint.schema.result.OperationResult;
+import com.evolveum.midpoint.smart.impl.conndev.activity.ConnDevBeans;
+import com.evolveum.midpoint.task.api.Task;
+import com.evolveum.midpoint.util.exception.*;
+import com.evolveum.midpoint.util.logging.Trace;
+import com.evolveum.midpoint.util.logging.TraceManager;
+import com.evolveum.midpoint.xml.ns._public.common.common_3.*;
+
+import java.io.IOException;
+import java.util.List;
+
+public class SqlBackend extends ConnectorDevelopmentBackend {
+
+    private static final Trace LOGGER = TraceManager.getTrace(SqlBackend.class);
+
+    private static final String NOT_YET_IMPLEMENTED = "SQL connector generation is not yet implemented.";
+
+    public SqlBackend(ConnDevBeans beans, ConnectorDevelopmentType connDev, Task task, OperationResult result) {
+        super(beans, connDev, task, result);
+    }
+
+    @Override
+    public ConnDevApplicationInfoType discoverBasicInformation(boolean skipCache) {
+        // Not yet implemented: SQL discovery/generation logic is a separate follow-up task.
+        LOGGER.warn(NOT_YET_IMPLEMENTED);
+        return new ConnDevApplicationInfoType();
+    }
+
+    @Override
+    public List<ConnDevAuthInfoType> discoverAuthorizationInformation(boolean skipCache) {
+        // Not yet implemented: SQL discovery/generation logic is a separate follow-up task.
+        LOGGER.warn(NOT_YET_IMPLEMENTED);
+        return List.of();
+    }
+
+    @Override
+    public List<ConnDevDocumentationSourceType> discoverDocumentation(boolean skipCache) {
+        // Not yet implemented: SQL discovery/generation logic is a separate follow-up task.
+        LOGGER.warn(NOT_YET_IMPLEMENTED);
+        return List.of();
+    }
+
+    @Override
+    public ConnDevArtifactType generateArtifact(ConnDevGenerateArtifactDefinitionType artifactSpec, boolean skipCache) {
+        // Not yet implemented: SQL discovery/generation logic is a separate follow-up task.
+        LOGGER.warn(NOT_YET_IMPLEMENTED);
+        return new ConnDevArtifactType();
+    }
+
+    @Override
+    public ConnDevArtifactType generateObjectClassArtifact(ConnDevGenerateArtifactDefinitionType artifactSpec, boolean skipCache) {
+        // Not yet implemented: SQL discovery/generation logic is a separate follow-up task.
+        LOGGER.warn(NOT_YET_IMPLEMENTED);
+        return new ConnDevArtifactType();
+    }
+
+    @Override
+    public List<ConnDevBasicObjectClassInfoType> discoverObjectClassesUsingDocumentation(
+            List<ConnDevBasicObjectClassInfoType> connectorDiscovered, boolean includeUnrelated, boolean skipCache) {
+        // Not yet implemented: SQL discovery/generation logic is a separate follow-up task.
+        LOGGER.warn(NOT_YET_IMPLEMENTED);
+        return List.of();
+    }
+
+    @Override
+    public List<ConnDevHttpEndpointType> discoverObjectClassEndpoints(String objectClass, boolean skipCache) {
+        // Not yet implemented: SQL discovery/generation logic is a separate follow-up task.
+        LOGGER.warn(NOT_YET_IMPLEMENTED);
+        return List.of();
+    }
+
+    @Override
+    public List<ConnDevAttributeInfoType> discoverObjectClassAttributes(String objectClass, boolean skipCache) {
+        // Not yet implemented: SQL discovery/generation logic is a separate follow-up task.
+        LOGGER.warn(NOT_YET_IMPLEMENTED);
+        return List.of();
+    }
+
+    @Override
+    public List<ConnDevHttpEndpointType> discoverConnectivityEndpoints(boolean skipCache) {
+        // Not yet implemented: SQL discovery/generation logic is a separate follow-up task.
+        LOGGER.warn(NOT_YET_IMPLEMENTED);
+        return List.of();
+    }
+
+    @Override
+    public void processDocumentation(boolean skipCache) throws SchemaException, ExpressionEvaluationException,
+            CommunicationException, SecurityViolationException, ConfigurationException, ObjectNotFoundException,
+            PolicyViolationException, ObjectAlreadyExistsException, RestrictedObjectException {
+        // Not yet implemented: SQL discovery/generation logic is a separate follow-up task.
+        LOGGER.warn(NOT_YET_IMPLEMENTED);
+    }
+
+    @Override
+    public List<ConnDevRelationInfoType> discoverRelationsUsingObjectClasses(
+            List<ConnDevBasicObjectClassInfoType> discovered, boolean skipCache) {
+        // Not yet implemented: SQL discovery/generation logic is a separate follow-up task.
+        LOGGER.warn(NOT_YET_IMPLEMENTED);
+        return List.of();
+    }
+
+    @Override
+    protected void restoreSession(ServiceClient.RestorationClient client) throws IOException {
+        // Not yet implemented: SQL discovery/generation logic is a separate follow-up task.
+        LOGGER.warn(NOT_YET_IMPLEMENTED);
+    }
+
+    @Override
+    protected List<ProcessedDocumentation> synchronizeDocumentation(List<DevShadowDocument> documentation) throws CommonException {
+        // Not yet implemented: SQL discovery/generation logic is a separate follow-up task.
+        LOGGER.warn(NOT_YET_IMPLEMENTED);
+        return List.of();
+    }
+}

--- a/model/smart-impl/src/main/java/com/evolveum/midpoint/smart/impl/conndev/activity/ConnDevBeans.java
+++ b/model/smart-impl/src/main/java/com/evolveum/midpoint/smart/impl/conndev/activity/ConnDevBeans.java
@@ -112,6 +112,18 @@ public class ConnDevBeans {
         return null;
     }
 
+    public String getSqlFrameworkUrl(OperationResult result) {
+        try {
+            var systemConfiguration = systemObjectCache.getSystemConfigurationBean(result);
+            if (systemConfiguration != null && systemConfiguration.getSmartIntegration() != null) {
+                return systemConfiguration.getSmartIntegration().getConnectorSqlFrameworkUrl();
+            }
+        } catch (SchemaException e) {
+            throw new SystemException("Could not get system configuration.", e);
+        }
+        return null;
+    }
+
     public ServiceClient client(String sessionId, ServiceClient.SessionRestoration restoration, ServiceClient.SessionRestoration synchronization, OperationResult result) {
         var apiBase = getServiceUrl(result);
         if (apiBase == null) {


### PR DESCRIPTION
- Add SQL as a third selectable integration type in the connector development wizard, alongside REST/SCIM
- Introduce a new connectorSqlFrameworkUrl configuration key (analogous to connectorFrameworkUrl) pointing at the SQL connector template
- Dispatch the template URL per integration type when creating a connector
- Add a new SqlBackend, registered in the backend-selection switch; stub discovery/generation logic (WARN log + empty defaults) - core implementation is a follow-up task
- Add a GUI component that prevents switching an existing connector development between SQL and REST/SCIM once created