### PR TITLE
Add SQL connector connection wizard flow

### DIFF
--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/component/wizard/withnavigation/AbstractWizardController.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/component/wizard/withnavigation/AbstractWizardController.java
@@ -67,6 +67,11 @@ public abstract class AbstractWizardController<AH extends AssignmentHolderType, 
         this.partItems = partItems;
     }
 
+    @Override
+    public void invalidateChildrenSteps(String parentStepId) {
+        partItems.forEach(partItem -> partItem.invalidateChildrenSteps(parentStepId));
+    }
+
     protected final ADM getObjectDetailsModel() {
         return helper.getDetailsModel();
     }

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/component/wizard/withnavigation/AbstractWizardPartItem.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/component/wizard/withnavigation/AbstractWizardPartItem.java
@@ -78,7 +78,7 @@ public abstract class AbstractWizardPartItem<AH extends AssignmentHolderType, AD
         this.parentSteps = createWizardSteps();
         getParentSteps().forEach(parentStep -> {
             parentStep.init(this.controller);
-            getChildrenSteps(parentStep).forEach(s -> s.init(this.controller));
+            getChildrenSteps(parentStep);
         });
 
         String stepId = this.controller.getStepIdFromParams(page);
@@ -144,6 +144,10 @@ public abstract class AbstractWizardPartItem<AH extends AssignmentHolderType, AD
         return parentSteps;
     }
 
+    public void invalidateChildrenSteps(String parentStepId) {
+        childrenSteps.remove(parentStepId);
+    }
+
     private List<WizardStep> getChildrenSteps(WizardParentStep parentStep) {
         if (!childrenSteps.containsKey(parentStep.getStepId())) {
             String defaultKey = parentStep.getDefaultStepId();
@@ -151,7 +155,9 @@ public abstract class AbstractWizardPartItem<AH extends AssignmentHolderType, AD
                 childrenSteps.put(parentStep.getStepId(), childrenSteps.get(defaultKey));
                 childrenSteps.remove(defaultKey);
             } else {
-                childrenSteps.put(parentStep.getStepId(), parentStep.createChildrenSteps());
+                List<WizardStep> newChildrenSteps = parentStep.createChildrenSteps();
+                newChildrenSteps.forEach(s -> s.init(this.controller));
+                childrenSteps.put(parentStep.getStepId(), newChildrenSteps);
             }
         }
         return childrenSteps.get(parentStep.getStepId());

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/component/wizard/withnavigation/WizardModelWithParentSteps.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/component/wizard/withnavigation/WizardModelWithParentSteps.java
@@ -111,6 +111,13 @@ public abstract class WizardModelWithParentSteps extends WizardModel implements 
 
     public abstract void showSummaryPanel();
 
+    /**
+     * Forces the cached children steps of the given parent step to be recomputed on next access
+     * (e.g. after a decision that {@link WizardParentStep#createChildrenSteps()} depends on, such
+     * as an integration type selection, has just been persisted).
+     */
+    public abstract void invalidateChildrenSteps(String parentStepId);
+
 //    public AbstractWizardController getWizardController() {
 //        return wizardController;
 //    }

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/component/wizard/ConnectorDevelopmentWizardUtil.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/component/wizard/ConnectorDevelopmentWizardUtil.java
@@ -628,6 +628,16 @@ public class ConnectorDevelopmentWizardUtil {
         }
     }
 
+    public static boolean isSql(ConnectorDevelopmentDetailsModel detailsModel) {
+        try {
+            PrismPropertyWrapper<ConnDevIntegrationType> integrationType = detailsModel.getObjectWrapper().findProperty(
+                    ItemPath.create(ConnectorDevelopmentType.F_CONNECTOR, ConnDevConnectorType.F_INTEGRATION_TYPE));
+            return ConnDevIntegrationType.SQL.equals(integrationType.getValue().getRealValue());
+        } catch (SchemaException e) {
+            return false;
+        }
+    }
+
     public static List<ItemName> getVisibleAuthorizationAttributes(
             ConnectorDevelopmentDetailsModel detailsModel, ConnDevAuthInfoType authType) {
         try {

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/component/wizard/scimrest/basic/ConnectorIdentificationConnectorStepPanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/component/wizard/scimrest/basic/ConnectorIdentificationConnectorStepPanel.java
@@ -18,8 +18,10 @@ import com.evolveum.midpoint.gui.api.prism.wrapper.PrismContainerWrapper;
 import com.evolveum.midpoint.gui.api.prism.wrapper.PrismPropertyWrapper;
 import com.evolveum.midpoint.gui.impl.component.wizard.AbstractFormWizardStepPanel;
 import com.evolveum.midpoint.gui.impl.component.wizard.WizardPanelHelper;
+import com.evolveum.midpoint.gui.impl.component.wizard.withnavigation.WizardModelWithParentSteps;
 import com.evolveum.midpoint.gui.impl.page.admin.connector.development.ConnectorDevelopmentDetailsModel;
 import com.evolveum.midpoint.gui.impl.page.admin.connector.development.component.wizard.ConnectorDevelopmentWizardUtil;
+import com.evolveum.midpoint.gui.impl.page.admin.connector.development.component.wizard.scimrest.connection.ConnectionConnectorStepPanel;
 import com.evolveum.midpoint.gui.impl.prism.panel.ItemPanelSettings;
 import com.evolveum.midpoint.gui.impl.prism.panel.ItemPanelSettingsBuilder;
 import com.evolveum.midpoint.gui.impl.prism.panel.vertical.form.VerticalFormPanel;
@@ -245,6 +247,9 @@ public class ConnectorIdentificationConnectorStepPanel extends AbstractFormWizar
         OperationResult result = getHelper().onSaveObjectPerformed(target);
         getDetailsModel().getConnectorDevelopmentOperation();
         if (result != null && !result.isError()) {
+            if (getWizard() instanceof WizardModelWithParentSteps wizardModel) {
+                wizardModel.invalidateChildrenSteps(ConnectionConnectorStepPanel.PANEL_TYPE);
+            }
             super.onNextPerformed(target);
         } else {
             target.add(getFeedback());

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/component/wizard/scimrest/connection/ConnectionConnectorStepPanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/component/wizard/scimrest/connection/ConnectionConnectorStepPanel.java
@@ -20,6 +20,8 @@ import com.evolveum.midpoint.gui.impl.component.wizard.AbstractFormWizardStepPan
 import com.evolveum.midpoint.gui.impl.component.wizard.WizardPanelHelper;
 import com.evolveum.midpoint.gui.impl.component.wizard.withnavigation.WizardParentStep;
 import com.evolveum.midpoint.gui.impl.page.admin.connector.development.ConnectorDevelopmentDetailsModel;
+import com.evolveum.midpoint.gui.impl.page.admin.connector.development.component.wizard.ConnectorDevelopmentWizardUtil;
+import com.evolveum.midpoint.gui.impl.page.admin.connector.development.component.wizard.sql.connection.SqlConnectionParametersConnectorStepPanel;
 import com.evolveum.midpoint.gui.impl.prism.panel.ItemPanelSettings;
 import com.evolveum.midpoint.gui.impl.prism.panel.ItemPanelSettingsBuilder;
 import com.evolveum.midpoint.gui.impl.prism.panel.vertical.form.VerticalFormPanel;
@@ -172,6 +174,11 @@ public class ConnectionConnectorStepPanel extends AbstractFormWizardStepPanel<Co
 
     @Override
     public List<WizardStep> createChildrenSteps() {
+        if (ConnectorDevelopmentWizardUtil.isSql(getDetailsModel())) {
+            return List.of(
+                    new SqlConnectionParametersConnectorStepPanel(getHelper()),
+                    new ResourceTestConnectorStepPanel(getHelper(), SqlConnectionParametersConnectorStepPanel.PANEL_TYPE));
+        }
         return List.of(
                 new WaitingBasicInfoConnectorStepPanel(getHelper()),
                 new BaseUrlConnectorStepPanel(getHelper()),

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/component/wizard/scimrest/connection/ResourceTestConnectorStepPanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/component/wizard/scimrest/connection/ResourceTestConnectorStepPanel.java
@@ -53,9 +53,17 @@ public class ResourceTestConnectorStepPanel extends AbstractWizardStepPanel<Conn
 
     private LoadableModel<String> resourceOidModel;
     private boolean nextButtonVisible = false;
+    private final String fixConnectionPanelType;
 
     public ResourceTestConnectorStepPanel(WizardPanelHelper<? extends Containerable, ConnectorDevelopmentDetailsModel> helper) {
+        this(helper, FixConnectionConnectorStepPanel.PANEL_TYPE);
+    }
+
+    public ResourceTestConnectorStepPanel(
+            WizardPanelHelper<? extends Containerable, ConnectorDevelopmentDetailsModel> helper,
+            String fixConnectionPanelType) {
         super(helper);
+        this.fixConnectionPanelType = fixConnectionPanelType;
     }
 
     @Override
@@ -110,8 +118,8 @@ public class ResourceTestConnectorStepPanel extends AbstractWizardStepPanel<Conn
             @Override
             protected void onFailureActionPerform(AjaxRequestTarget target) {
                 if (getWizard() instanceof WizardModelWithParentSteps wizardModel) {
-                    wizardModel.addOperationResult(PANEL_TYPE, FixConnectionConnectorStepPanel.PANEL_TYPE, getLastFailedResult());
-                    wizardModel.setActiveStepById(FixConnectionConnectorStepPanel.PANEL_TYPE);
+                    wizardModel.addOperationResult(PANEL_TYPE, fixConnectionPanelType, getLastFailedResult());
+                    wizardModel.setActiveStepById(fixConnectionPanelType);
                     wizardModel.fireActiveStepChanged(wizardModel.getActiveStep());
                     target.add(wizardModel.getPanel());
                 }

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/component/wizard/sql/connection/SqlConnectionParametersConnectorStepPanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/component/wizard/sql/connection/SqlConnectionParametersConnectorStepPanel.java
@@ -1,0 +1,254 @@
+/*
+ * Copyright (C) 2010-2026 Evolveum and contributors
+ *
+ * This work is dual-licensed under the Apache License 2.0
+ * and European Union Public License. See LICENSE file for details.
+ */
+package com.evolveum.midpoint.gui.impl.page.admin.connector.development.component.wizard.sql.connection;
+
+import java.util.List;
+
+import org.apache.wicket.ajax.AjaxRequestTarget;
+import org.apache.wicket.behavior.AttributeAppender;
+import org.apache.wicket.model.IModel;
+
+import com.evolveum.midpoint.gui.api.factory.wrapper.WrapperContext;
+import com.evolveum.midpoint.gui.api.prism.wrapper.ItemVisibilityHandler;
+import com.evolveum.midpoint.gui.api.prism.wrapper.ItemWrapper;
+import com.evolveum.midpoint.gui.api.prism.wrapper.PrismContainerWrapper;
+import com.evolveum.midpoint.gui.api.prism.wrapper.PrismPropertyWrapper;
+import com.evolveum.midpoint.gui.impl.component.wizard.AbstractFormWizardStepPanel;
+import com.evolveum.midpoint.gui.impl.component.wizard.WizardPanelHelper;
+import com.evolveum.midpoint.gui.impl.page.admin.ObjectDetailsModels;
+import com.evolveum.midpoint.gui.impl.page.admin.connector.development.ConnectorDevelopmentDetailsModel;
+import com.evolveum.midpoint.gui.impl.page.admin.connector.development.component.wizard.ConnectorDevelopmentWizardUtil;
+import com.evolveum.midpoint.gui.impl.prism.panel.ItemPanelSettings;
+import com.evolveum.midpoint.gui.impl.prism.panel.ItemPanelSettingsBuilder;
+import com.evolveum.midpoint.gui.impl.prism.panel.vertical.form.VerticalFormPanel;
+import com.evolveum.midpoint.gui.impl.prism.panel.vertical.form.VerticalFormPrismContainerPanel;
+import com.evolveum.midpoint.prism.Containerable;
+import com.evolveum.midpoint.prism.path.ItemName;
+import com.evolveum.midpoint.prism.path.ItemPath;
+import com.evolveum.midpoint.schema.constants.SchemaConstants;
+import com.evolveum.midpoint.schema.result.OperationResult;
+import com.evolveum.midpoint.util.QNameUtil;
+import com.evolveum.midpoint.util.exception.SchemaException;
+import com.evolveum.midpoint.web.application.PanelDisplay;
+import com.evolveum.midpoint.web.application.PanelInstance;
+import com.evolveum.midpoint.web.application.PanelType;
+import com.evolveum.midpoint.web.component.prism.ItemVisibility;
+import com.evolveum.midpoint.web.model.PrismContainerWrapperModel;
+import com.evolveum.midpoint.xml.ns._public.common.common_3.*;
+
+/**
+ * SQL connector "Connection" step: a single form collecting the JDBC connection
+ * parameters (jdbcUrl, username, password and the optional advanced pool/timeout
+ * settings) directly on the testing resource's connector configuration.
+ */
+@PanelType(name = "cdw-sql-connection-parameters")
+@PanelInstance(identifier = "cdw-sql-connection-parameters",
+        applicableForType = ConnectorDevelopmentType.class,
+        applicableForOperation = OperationTypeType.WIZARD,
+        display = @PanelDisplay(label = "PageConnectorDevelopment.wizard.step.sqlConnectionParameters", icon = "fa fa-wrench"),
+        containerPath = "empty")
+public class SqlConnectionParametersConnectorStepPanel extends AbstractFormWizardStepPanel<ConnectorDevelopmentDetailsModel> {
+
+    public static final String PANEL_TYPE = "cdw-sql-connection-parameters";
+
+    private static final ItemName JDBC_URL = ItemName.from("", "jdbcUrl");
+    private static final ItemName USERNAME = ItemName.from("", "username");
+    private static final ItemName PASSWORD = ItemName.from("", "password");
+    private static final ItemName POOL_SIZE = ItemName.from("", "poolSize");
+    private static final ItemName CONNECTION_TIMEOUT = ItemName.from("", "connectionTimeout");
+    private static final ItemName IDLE_TIMEOUT = ItemName.from("", "idleTimeout");
+    private static final ItemName VALIDATE_CONNECTION_ON_BORROW = ItemName.from("", "validateConnectionOnBorrow");
+    private static final ItemName AUTO_DISCOVER_SCHEMA = ItemName.from("", "autoDiscoverSchema");
+    private static final ItemName TEST_CONNECTION_QUERY = ItemName.from("", "testConnectionQuery");
+
+    private static final List<ItemName> REQUIRED_FIELDS = List.of(JDBC_URL, USERNAME, PASSWORD);
+    private static final List<ItemName> VISIBLE_FIELDS = List.of(
+            JDBC_URL, USERNAME, PASSWORD, POOL_SIZE, CONNECTION_TIMEOUT, IDLE_TIMEOUT,
+            VALIDATE_CONNECTION_ON_BORROW, AUTO_DISCOVER_SCHEMA, TEST_CONNECTION_QUERY);
+
+    private static final ItemName DEVELOPMENT_MODE_ITEM_NAME = ItemName.from("", "developmentMode");
+    private static final ItemPath CONNECTOR_CONFIGURATION_PROPERTIES = ItemPath.create("connectorConfiguration", SchemaConstants.ICF_CONFIGURATION_PROPERTIES_LOCAL_NAME);
+    private static final ItemPath PRODUCER_BUFFER_SIZE = ItemPath.create("connectorConfiguration", "producerBufferSize");
+
+    private PrismContainerWrapper<? extends Containerable> containerWrapper;
+
+    public SqlConnectionParametersConnectorStepPanel(WizardPanelHelper<? extends Containerable, ConnectorDevelopmentDetailsModel> helper) {
+        super(helper);
+    }
+
+    @Override
+    protected IModel<? extends PrismContainerWrapper> getContainerFormModel() {
+        try {
+            ObjectDetailsModels<ResourceType> objectDetailsModel =
+                    ConnectorDevelopmentWizardUtil.getTestingResourceModel(getDetailsModel(), getPanelType());
+
+            disableConnIdProducerProxy(objectDetailsModel);
+            enableConnectorDevelopmentMode(objectDetailsModel);
+            PrismPropertyWrapper<Object> stateProperty = objectDetailsModel.getObjectWrapper().findProperty(
+                    ItemPath.create(ResourceType.F_OPERATIONAL_STATE, OperationalStateType.F_LAST_AVAILABILITY_STATUS));
+            stateProperty.getValue().setRealValue(AvailabilityStatusType.DOWN);
+
+            return PrismContainerWrapperModel.fromContainerWrapper(objectDetailsModel.getObjectWrapperModel(), CONNECTOR_CONFIGURATION_PROPERTIES);
+        } catch (SchemaException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private void enableConnectorDevelopmentMode(ObjectDetailsModels<ResourceType> objectDetailsModel) throws SchemaException {
+        objectDetailsModel.getObjectWrapper().findProperty(CONNECTOR_CONFIGURATION_PROPERTIES.append(DEVELOPMENT_MODE_ITEM_NAME)).getValue().setRealValue(true);
+    }
+
+    private void disableConnIdProducerProxy(ObjectDetailsModels<ResourceType> objectDetailsModel) throws SchemaException {
+        objectDetailsModel.getObjectWrapper().findProperty(PRODUCER_BUFFER_SIZE).getValue().setRealValue(0);
+    }
+
+    @Override
+    protected void onBeforeRender() {
+        PrismContainerWrapper<?> wrapper = getContainerFormModel().getObject();
+
+        if (containerWrapper != null && containerWrapper != wrapper) {
+            initLayout();
+        }
+        containerWrapper = wrapper;
+
+        super.onBeforeRender();
+        ((VerticalFormPrismContainerPanel) getVerticalForm().getSingleContainerPanel().getContainer().get("1"))
+                .getContainer().add(AttributeAppender.remove("class"));
+    }
+
+    @Override
+    protected void initLayout() {
+        getTextLabel().add(AttributeAppender.replace("class", "mb-2 col-12 gen-step-title"));
+        getSubtextLabel().add(AttributeAppender.replace("class", "border-bottom pb-4 d-inline-block w-100"));
+        getButtonContainer().add(AttributeAppender.replace("class", "d-flex align-items-center flex-nowrap flex-row mt-4 gap-2 wizard-actions-strip col-12"));
+        getFeedback().add(AttributeAppender.replace("class", "col-12 feedbackContainer"));
+
+        ItemPanelSettings settings = new ItemPanelSettingsBuilder()
+                .visibilityHandler(getVisibilityHandler())
+                .mandatoryHandler(this::checkMandatory)
+                .build();
+        VerticalFormPanel panel = new VerticalFormPanel(ID_FORM, getContainerFormModel(), settings, getContainerConfiguration()) {
+            @Override
+            protected String getIcon() {
+                return SqlConnectionParametersConnectorStepPanel.this.getIcon();
+            }
+
+            @Override
+            protected IModel<?> getTitleModel() {
+                return getFormTitle();
+            }
+
+            @Override
+            protected WrapperContext createWrapperContext() {
+                return getDetailsModel().createWrapperContext();
+            }
+
+            @Override
+            protected boolean isShowEmptyButtonVisible() {
+                return false;
+            }
+
+            @Override
+            protected boolean isHeaderVisible(IModel model) {
+                return false;
+            }
+
+            @Override
+            protected String getCssClassForFormContainerOfValuePanel() {
+                return "";
+            }
+        };
+        panel.setOutputMarkupId(true);
+        panel.add(AttributeAppender.replace("class", "col-12"));
+        addOrReplace(panel);
+    }
+
+    protected String getPanelType() {
+        return PANEL_TYPE;
+    }
+
+    @Override
+    protected String getIcon() {
+        return "fa fa-wrench";
+    }
+
+    @Override
+    public IModel<String> getTitle() {
+        return createStringResource("PageConnectorDevelopment.wizard.step.sqlConnectionParameters");
+    }
+
+    @Override
+    protected IModel<?> getTextModel() {
+        return createStringResource("PageConnectorDevelopment.wizard.step.sqlConnectionParameters.text");
+    }
+
+    @Override
+    protected IModel<?> getSubTextModel() {
+        return createStringResource("PageConnectorDevelopment.wizard.step.sqlConnectionParameters.subText");
+    }
+
+    protected boolean checkMandatory(ItemWrapper wrapper) {
+        if (REQUIRED_FIELDS.stream().anyMatch(name -> QNameUtil.match(wrapper.getItemName(), name))) {
+            return true;
+        }
+        return wrapper.isMandatory();
+    }
+
+    @Override
+    protected ItemVisibilityHandler getVisibilityHandler() {
+        return wrapper -> {
+            if (VISIBLE_FIELDS.stream().anyMatch(name -> QNameUtil.match(wrapper.getItemName(), name))) {
+                return ItemVisibility.AUTO;
+            }
+            return ItemVisibility.HIDDEN;
+        };
+    }
+
+    @Override
+    public String getStepId() {
+        return PANEL_TYPE;
+    }
+
+    @Override
+    public String appendCssToWizard() {
+        return "col-12 col-xl-10 col-xxl-8";
+    }
+
+    @Override
+    protected boolean isSubmitVisible() {
+        return false;
+    }
+
+    @Override
+    protected IModel<String> getNextLabelModel() {
+        return null;
+    }
+
+    @Override
+    public boolean onNextPerformed(AjaxRequestTarget target) {
+        OperationResult result = getHelper().onSaveObjectPerformed(target);
+        getDetailsModel().getConnectorDevelopmentOperation();
+        if (result != null && !result.isError()) {
+            super.onNextPerformed(target);
+        } else {
+            target.add(getFeedback());
+        }
+        return false;
+    }
+
+    @Override
+    public boolean isCompleted() {
+        return REQUIRED_FIELDS.stream().allMatch(
+                fieldName -> ConnectorDevelopmentWizardUtil.existTestingResourcePropertyValue(
+                        getDetailsModel(), getPanelType(), fieldName));
+    }
+
+    @Override
+    protected String getSubTextContainerCssClass() {
+        return "text-secondary col-12 pb-4";
+    }
+}

--- a/model/smart-impl/src/main/java/com/evolveum/midpoint/smart/impl/conndev/SqlBackend.java
+++ b/model/smart-impl/src/main/java/com/evolveum/midpoint/smart/impl/conndev/SqlBackend.java
@@ -16,6 +16,7 @@ public class SqlBackend extends ConnectorDevelopmentBackend {
     private static final Trace LOGGER = TraceManager.getTrace(SqlBackend.class);
 
     private static final String NOT_YET_IMPLEMENTED = "SQL connector generation is not yet implemented.";
+    private static final String NOT_APPLICABLE_TO_SQL = "This operation is HTTP-specific and does not apply to SQL connectors.";
 
     public SqlBackend(ConnDevBeans beans, ConnectorDevelopmentType connDev, Task task, OperationResult result) {
         super(beans, connDev, task, result);
@@ -30,9 +31,9 @@ public class SqlBackend extends ConnectorDevelopmentBackend {
 
     @Override
     public List<ConnDevAuthInfoType> discoverAuthorizationInformation(boolean skipCache) {
-        // Not yet implemented: SQL discovery/generation logic is a separate follow-up task.
-        LOGGER.warn(NOT_YET_IMPLEMENTED);
-        return List.of();
+        // HTTP auth-scheme discovery does not apply to SQL: JDBC credentials are plain
+        // configuration properties, not a discovered auth scheme.
+        throw new UnsupportedOperationException(NOT_APPLICABLE_TO_SQL);
     }
 
     @Override
@@ -80,9 +81,9 @@ public class SqlBackend extends ConnectorDevelopmentBackend {
 
     @Override
     public List<ConnDevHttpEndpointType> discoverConnectivityEndpoints(boolean skipCache) {
-        // Not yet implemented: SQL discovery/generation logic is a separate follow-up task.
-        LOGGER.warn(NOT_YET_IMPLEMENTED);
-        return List.of();
+        // HTTP connectivity-endpoint discovery does not apply to SQL: the jdbcUrl is
+        // entered directly as a configuration property.
+        throw new UnsupportedOperationException(NOT_APPLICABLE_TO_SQL);
     }
 
     @Override


### PR DESCRIPTION
- SqlBackend: HTTP-specific discovery (auth scheme, connectivity endpoint) now throws instead of stubbing, since JDBC has no such concepts
- New SqlConnectionParametersConnectorStepPanel collects jdbcUrl/ username/password plus optional pool/timeout settings; wizard branches to it for SQL integration type
- ResourceTestConnectorStepPanel takes a parametrized fix-step target, so SQL failures return to the same params screen instead of a separate fix panel
- Wizard child-steps cache is now invalidated when integration type is saved, fixing premature caching of the REST/SCIM branch before the type was even chosen

Task: 11878