### PR TITLE
Add per-type wizard strategy for connector dev

### DIFF
--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/component/wizard/ConnectorDevelopmentWizardUtil.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/component/wizard/ConnectorDevelopmentWizardUtil.java
@@ -638,6 +638,21 @@ public class ConnectorDevelopmentWizardUtil {
         }
     }
 
+    /**
+     * Resolves the {@link ConnectorWizardStrategy} for this connector's integration type, so wizard
+     * step panels can delegate connector-type-specific decisions instead of branching themselves.
+     * Mirrors {@code ConnectorDevelopmentBackend.backendFor(...)} on the model layer.
+     */
+    public static ConnectorWizardStrategy wizardStrategyFor(ConnectorDevelopmentDetailsModel detailsModel) {
+        if (isSql(detailsModel)) {
+            return new SqlConnectorWizardStrategy();
+        }
+        if (isScim(detailsModel)) {
+            return new ScimConnectorWizardStrategy();
+        }
+        return new RestConnectorWizardStrategy();
+    }
+
     public static List<ItemName> getVisibleAuthorizationAttributes(
             ConnectorDevelopmentDetailsModel detailsModel, ConnDevAuthInfoType authType) {
         try {

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/component/wizard/ConnectorWizardStrategy.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/component/wizard/ConnectorWizardStrategy.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2010-2025 Evolveum and contributors
+ *
+ * Licensed under the EUPL-1.2 or later.
+ */
+
+package com.evolveum.midpoint.gui.impl.page.admin.connector.development.component.wizard;
+
+import java.util.List;
+
+import org.apache.wicket.model.IModel;
+
+import com.evolveum.midpoint.gui.api.component.wizard.WizardStep;
+import com.evolveum.midpoint.gui.api.prism.wrapper.PrismContainerValueWrapper;
+import com.evolveum.midpoint.gui.impl.component.wizard.WizardPanelHelper;
+import com.evolveum.midpoint.gui.impl.page.admin.connector.development.ConnectorDevelopmentDetailsModel;
+import com.evolveum.midpoint.prism.Containerable;
+import com.evolveum.midpoint.prism.path.ItemName;
+import com.evolveum.midpoint.xml.ns._public.common.common_3.ConnDevObjectClassInfoType;
+
+/**
+ * Connector-type-specific decisions used by the connector development wizard (REST, SCIM, SQL),
+ * so step panels delegate here instead of branching on the connector's integration type
+ * themselves. Resolved via {@link ConnectorDevelopmentWizardUtil#wizardStrategyFor(ConnectorDevelopmentDetailsModel)}.
+ * Each {@code *ObjectClassSteps} method returns the full children step list for the matching
+ * router panel, mirroring {@code ConnectorDevelopmentBackend}'s per-type abstract methods on the
+ * model layer.
+ */
+public interface ConnectorWizardStrategy {
+
+    List<WizardStep> connectionSteps(WizardPanelHelper<? extends Containerable, ConnectorDevelopmentDetailsModel> helper);
+
+    List<WizardStep> initObjectClassSteps(
+            WizardPanelHelper<? extends Containerable, ConnectorDevelopmentDetailsModel> helper,
+            IModel<PrismContainerValueWrapper<ConnDevObjectClassInfoType>> objectClassModel);
+
+    List<WizardStep> searchAllObjectClassSteps(
+            WizardPanelHelper<? extends Containerable, ConnectorDevelopmentDetailsModel> helper,
+            IModel<PrismContainerValueWrapper<ConnDevObjectClassInfoType>> objectClassModel);
+
+    List<WizardStep> searchByIdObjectClassSteps(
+            WizardPanelHelper<? extends Containerable, ConnectorDevelopmentDetailsModel> helper,
+            IModel<PrismContainerValueWrapper<ConnDevObjectClassInfoType>> objectClassModel);
+
+    List<WizardStep> searchFilterObjectClassSteps(
+            WizardPanelHelper<? extends Containerable, ConnectorDevelopmentDetailsModel> helper,
+            IModel<PrismContainerValueWrapper<ConnDevObjectClassInfoType>> objectClassModel);
+
+    List<WizardStep> createObjectClassSteps(
+            WizardPanelHelper<? extends Containerable, ConnectorDevelopmentDetailsModel> helper,
+            IModel<PrismContainerValueWrapper<ConnDevObjectClassInfoType>> objectClassModel);
+
+    List<WizardStep> updateObjectClassSteps(
+            WizardPanelHelper<? extends Containerable, ConnectorDevelopmentDetailsModel> helper,
+            IModel<PrismContainerValueWrapper<ConnDevObjectClassInfoType>> objectClassModel);
+
+    List<WizardStep> deleteObjectClassSteps(
+            WizardPanelHelper<? extends Containerable, ConnectorDevelopmentDetailsModel> helper,
+            IModel<PrismContainerValueWrapper<ConnDevObjectClassInfoType>> objectClassModel);
+
+    /** Config property holding the connection base URL for this connector type. */
+    ItemName connectionUrlFieldName();
+}

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/component/wizard/RestConnectorWizardStrategy.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/component/wizard/RestConnectorWizardStrategy.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright (C) 2010-2025 Evolveum and contributors
+ *
+ * Licensed under the EUPL-1.2 or later.
+ */
+
+package com.evolveum.midpoint.gui.impl.page.admin.connector.development.component.wizard;
+
+import java.util.List;
+
+import org.apache.wicket.model.IModel;
+
+import com.evolveum.midpoint.gui.api.component.wizard.WizardStep;
+import com.evolveum.midpoint.gui.api.prism.wrapper.PrismContainerValueWrapper;
+import com.evolveum.midpoint.gui.impl.component.wizard.WizardPanelHelper;
+import com.evolveum.midpoint.gui.impl.page.admin.connector.development.ConnectorDevelopmentDetailsModel;
+import com.evolveum.midpoint.gui.impl.page.admin.connector.development.component.wizard.scimrest.connection.AuthScriptsConnectorStepPanel;
+import com.evolveum.midpoint.gui.impl.page.admin.connector.development.component.wizard.scimrest.connection.BaseUrlConnectorStepPanel;
+import com.evolveum.midpoint.gui.impl.page.admin.connector.development.component.wizard.scimrest.connection.CredentialsConnectorStepPanel;
+import com.evolveum.midpoint.gui.impl.page.admin.connector.development.component.wizard.scimrest.connection.EndpointConnectorStepPanel;
+import com.evolveum.midpoint.gui.impl.page.admin.connector.development.component.wizard.scimrest.connection.FixConnectionConnectorStepPanel;
+import com.evolveum.midpoint.gui.impl.page.admin.connector.development.component.wizard.scimrest.connection.ResourceTestConnectorStepPanel;
+import com.evolveum.midpoint.gui.impl.page.admin.connector.development.component.wizard.scimrest.connection.SupportedAuthMethodConnectorStepPanel;
+import com.evolveum.midpoint.gui.impl.page.admin.connector.development.component.wizard.scimrest.connection.WaitingAuthScriptsConnectorStepPanel;
+import com.evolveum.midpoint.gui.impl.page.admin.connector.development.component.wizard.scimrest.connection.WaitingBasicInfoConnectorStepPanel;
+import com.evolveum.midpoint.gui.impl.page.admin.connector.development.component.wizard.scimrest.connection.WaitingConnectivityEndpointConnectorStepPanel;
+import com.evolveum.midpoint.gui.impl.page.admin.connector.development.component.wizard.scimrest.connection.WaitingSchemaConnectorStepPanel;
+import com.evolveum.midpoint.gui.impl.page.admin.connector.development.component.wizard.scimrest.objectclass.ObjectClassSelectConnectorStepPanel;
+import com.evolveum.midpoint.gui.impl.page.admin.connector.development.component.wizard.scimrest.objectclass.create.CreateEndpointsConnectorStepPanel;
+import com.evolveum.midpoint.gui.impl.page.admin.connector.development.component.wizard.scimrest.objectclass.create.CreateScriptConnectorStepPanel;
+import com.evolveum.midpoint.gui.impl.page.admin.connector.development.component.wizard.scimrest.objectclass.create.WaitingCreateConnectorStepPanel;
+import com.evolveum.midpoint.gui.impl.page.admin.connector.development.component.wizard.scimrest.objectclass.delete.DeleteEndpointsConnectorStepPanel;
+import com.evolveum.midpoint.gui.impl.page.admin.connector.development.component.wizard.scimrest.objectclass.delete.DeleteScriptConnectorStepPanel;
+import com.evolveum.midpoint.gui.impl.page.admin.connector.development.component.wizard.scimrest.objectclass.delete.WaitingDeleteConnectorStepPanel;
+import com.evolveum.midpoint.gui.impl.page.admin.connector.development.component.wizard.scimrest.objectclass.schema.SchemaScriptConnectorStepPanel;
+import com.evolveum.midpoint.gui.impl.page.admin.connector.development.component.wizard.scimrest.objectclass.schema.ShowSchemaConnectorStepPanel;
+import com.evolveum.midpoint.gui.impl.page.admin.connector.development.component.wizard.scimrest.objectclass.schema.WaitingConnIdSchemaConnectorStepPanel;
+import com.evolveum.midpoint.gui.impl.page.admin.connector.development.component.wizard.scimrest.objectclass.schema.WaitingNativeSchemaConnectorStepPanel;
+import com.evolveum.midpoint.gui.impl.page.admin.connector.development.component.wizard.scimrest.objectclass.schema.WaitingObjectClassDetailsConnectorStepPanel;
+import com.evolveum.midpoint.gui.impl.page.admin.connector.development.component.wizard.scimrest.objectclass.search.SearchAllEndpointsConnectorStepPanel;
+import com.evolveum.midpoint.gui.impl.page.admin.connector.development.component.wizard.scimrest.objectclass.search.SearchAllObjectsConnectorStepPanel;
+import com.evolveum.midpoint.gui.impl.page.admin.connector.development.component.wizard.scimrest.objectclass.search.SearchAllScriptConnectorStepPanel;
+import com.evolveum.midpoint.gui.impl.page.admin.connector.development.component.wizard.scimrest.objectclass.search.SearchByIdEndpointsConnectorStepPanel;
+import com.evolveum.midpoint.gui.impl.page.admin.connector.development.component.wizard.scimrest.objectclass.search.SearchByIdObjectConnectorStepPanel;
+import com.evolveum.midpoint.gui.impl.page.admin.connector.development.component.wizard.scimrest.objectclass.search.SearchByIdScriptConnectorStepPanel;
+import com.evolveum.midpoint.gui.impl.page.admin.connector.development.component.wizard.scimrest.objectclass.search.SearchFilterEndpointsConnectorStepPanel;
+import com.evolveum.midpoint.gui.impl.page.admin.connector.development.component.wizard.scimrest.objectclass.search.SearchFilterObjectsConnectorStepPanel;
+import com.evolveum.midpoint.gui.impl.page.admin.connector.development.component.wizard.scimrest.objectclass.search.SearchFilterScriptConnectorStepPanel;
+import com.evolveum.midpoint.gui.impl.page.admin.connector.development.component.wizard.scimrest.objectclass.search.WaitingSearchAllConnectorStepPanel;
+import com.evolveum.midpoint.gui.impl.page.admin.connector.development.component.wizard.scimrest.objectclass.search.WaitingSearchByIdConnectorStepPanel;
+import com.evolveum.midpoint.gui.impl.page.admin.connector.development.component.wizard.scimrest.objectclass.search.WaitingSearchFilterConnectorStepPanel;
+import com.evolveum.midpoint.gui.impl.page.admin.connector.development.component.wizard.scimrest.objectclass.update.UpdateEndpointsConnectorStepPanel;
+import com.evolveum.midpoint.gui.impl.page.admin.connector.development.component.wizard.scimrest.objectclass.update.UpdateScriptConnectorStepPanel;
+import com.evolveum.midpoint.gui.impl.page.admin.connector.development.component.wizard.scimrest.objectclass.update.WaitingUpdateConnectorStepPanel;
+import com.evolveum.midpoint.prism.Containerable;
+import com.evolveum.midpoint.prism.path.ItemName;
+import com.evolveum.midpoint.xml.ns._public.common.common_3.ConnDevObjectClassInfoType;
+
+/**
+ * Wizard strategy for classic (non-SCIM) REST connectors. SCIM is a specialization of REST
+ * ({@link ScimConnectorWizardStrategy} extends this), mirroring {@code ScimBackend extends RestBackend}.
+ */
+public class RestConnectorWizardStrategy implements ConnectorWizardStrategy {
+
+    @Override
+    public List<WizardStep> connectionSteps(WizardPanelHelper<? extends Containerable, ConnectorDevelopmentDetailsModel> helper) {
+        return List.of(
+                new WaitingBasicInfoConnectorStepPanel(helper),
+                new BaseUrlConnectorStepPanel(helper),
+                new SupportedAuthMethodConnectorStepPanel(helper),
+                new WaitingAuthScriptsConnectorStepPanel(helper),
+                new AuthScriptsConnectorStepPanel(helper),
+                new CredentialsConnectorStepPanel(helper),
+                new WaitingConnectivityEndpointConnectorStepPanel(helper),
+                new EndpointConnectorStepPanel(helper),
+                new FixConnectionConnectorStepPanel(helper),
+                new ResourceTestConnectorStepPanel(helper),
+                new WaitingSchemaConnectorStepPanel(helper));
+    }
+
+    @Override
+    public List<WizardStep> initObjectClassSteps(
+            WizardPanelHelper<? extends Containerable, ConnectorDevelopmentDetailsModel> helper,
+            IModel<PrismContainerValueWrapper<ConnDevObjectClassInfoType>> objectClassModel) {
+        return List.of(
+                new ObjectClassSelectConnectorStepPanel(helper, objectClassModel),
+                new WaitingObjectClassDetailsConnectorStepPanel(helper, objectClassModel),
+                new WaitingNativeSchemaConnectorStepPanel(helper, objectClassModel),
+                new WaitingConnIdSchemaConnectorStepPanel(helper, objectClassModel),
+                new SchemaScriptConnectorStepPanel(helper, objectClassModel),
+                new ShowSchemaConnectorStepPanel(helper, objectClassModel),
+                new SearchAllEndpointsConnectorStepPanel(helper, objectClassModel),
+                new WaitingSearchAllConnectorStepPanel(helper, objectClassModel),
+                new SearchAllScriptConnectorStepPanel(helper, objectClassModel),
+                new SearchAllObjectsConnectorStepPanel(helper, objectClassModel),
+                new SearchByIdEndpointsConnectorStepPanel(helper, objectClassModel),
+                new WaitingSearchByIdConnectorStepPanel(helper, objectClassModel),
+                new SearchByIdScriptConnectorStepPanel(helper, objectClassModel),
+                new SearchByIdObjectConnectorStepPanel(helper, objectClassModel));
+    }
+
+    @Override
+    public List<WizardStep> searchAllObjectClassSteps(
+            WizardPanelHelper<? extends Containerable, ConnectorDevelopmentDetailsModel> helper,
+            IModel<PrismContainerValueWrapper<ConnDevObjectClassInfoType>> objectClassModel) {
+        return List.of(
+                new SearchAllEndpointsConnectorStepPanel(helper, objectClassModel),
+                new WaitingSearchAllConnectorStepPanel(helper, objectClassModel),
+                new SearchAllScriptConnectorStepPanel(helper, objectClassModel),
+                new SearchAllObjectsConnectorStepPanel(helper, objectClassModel));
+    }
+
+    @Override
+    public List<WizardStep> searchByIdObjectClassSteps(
+            WizardPanelHelper<? extends Containerable, ConnectorDevelopmentDetailsModel> helper,
+            IModel<PrismContainerValueWrapper<ConnDevObjectClassInfoType>> objectClassModel) {
+        return List.of(
+                new SearchByIdEndpointsConnectorStepPanel(helper, objectClassModel),
+                new WaitingSearchByIdConnectorStepPanel(helper, objectClassModel),
+                new SearchByIdScriptConnectorStepPanel(helper, objectClassModel),
+                new SearchByIdObjectConnectorStepPanel(helper, objectClassModel));
+    }
+
+    @Override
+    public List<WizardStep> searchFilterObjectClassSteps(
+            WizardPanelHelper<? extends Containerable, ConnectorDevelopmentDetailsModel> helper,
+            IModel<PrismContainerValueWrapper<ConnDevObjectClassInfoType>> objectClassModel) {
+        return List.of(
+                new SearchFilterEndpointsConnectorStepPanel(helper, objectClassModel),
+                new WaitingSearchFilterConnectorStepPanel(helper, objectClassModel),
+                new SearchFilterScriptConnectorStepPanel(helper, objectClassModel),
+                new SearchFilterObjectsConnectorStepPanel(helper, objectClassModel));
+    }
+
+    @Override
+    public List<WizardStep> createObjectClassSteps(
+            WizardPanelHelper<? extends Containerable, ConnectorDevelopmentDetailsModel> helper,
+            IModel<PrismContainerValueWrapper<ConnDevObjectClassInfoType>> objectClassModel) {
+        return List.of(
+                new CreateEndpointsConnectorStepPanel(helper, objectClassModel),
+                new WaitingCreateConnectorStepPanel(helper, objectClassModel),
+                new CreateScriptConnectorStepPanel(helper, objectClassModel));
+    }
+
+    @Override
+    public List<WizardStep> updateObjectClassSteps(
+            WizardPanelHelper<? extends Containerable, ConnectorDevelopmentDetailsModel> helper,
+            IModel<PrismContainerValueWrapper<ConnDevObjectClassInfoType>> objectClassModel) {
+        return List.of(
+                new UpdateEndpointsConnectorStepPanel(helper, objectClassModel),
+                new WaitingUpdateConnectorStepPanel(helper, objectClassModel),
+                new UpdateScriptConnectorStepPanel(helper, objectClassModel));
+    }
+
+    @Override
+    public List<WizardStep> deleteObjectClassSteps(
+            WizardPanelHelper<? extends Containerable, ConnectorDevelopmentDetailsModel> helper,
+            IModel<PrismContainerValueWrapper<ConnDevObjectClassInfoType>> objectClassModel) {
+        return List.of(
+                new DeleteEndpointsConnectorStepPanel(helper, objectClassModel),
+                new WaitingDeleteConnectorStepPanel(helper, objectClassModel),
+                new DeleteScriptConnectorStepPanel(helper, objectClassModel));
+    }
+
+    @Override
+    public ItemName connectionUrlFieldName() {
+        return BaseUrlConnectorStepPanel.BASE_ADDRESS_ITEM_NAME;
+    }
+}

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/component/wizard/ScimConnectorWizardStrategy.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/component/wizard/ScimConnectorWizardStrategy.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (C) 2010-2025 Evolveum and contributors
+ *
+ * Licensed under the EUPL-1.2 or later.
+ */
+
+package com.evolveum.midpoint.gui.impl.page.admin.connector.development.component.wizard;
+
+import com.evolveum.midpoint.gui.impl.page.admin.connector.development.component.wizard.scimrest.connection.BaseUrlConnectorStepPanel;
+import com.evolveum.midpoint.prism.path.ItemName;
+
+/**
+ * SCIM is a specialization of REST for wizard purposes (same connection step list; only the
+ * base-URL config field differs) — mirrors {@code ScimBackend extends RestBackend}.
+ */
+public class ScimConnectorWizardStrategy extends RestConnectorWizardStrategy {
+
+    @Override
+    public ItemName connectionUrlFieldName() {
+        return BaseUrlConnectorStepPanel.SCIM_BASE_URL_ITEM_NAME;
+    }
+}

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/component/wizard/SqlConnectorWizardStrategy.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/component/wizard/SqlConnectorWizardStrategy.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright (C) 2010-2025 Evolveum and contributors
+ *
+ * Licensed under the EUPL-1.2 or later.
+ */
+
+package com.evolveum.midpoint.gui.impl.page.admin.connector.development.component.wizard;
+
+import java.util.List;
+
+import org.apache.wicket.model.IModel;
+
+import com.evolveum.midpoint.gui.api.component.wizard.WizardStep;
+import com.evolveum.midpoint.gui.api.prism.wrapper.PrismContainerValueWrapper;
+import com.evolveum.midpoint.gui.impl.component.wizard.WizardPanelHelper;
+import com.evolveum.midpoint.gui.impl.page.admin.connector.development.ConnectorDevelopmentDetailsModel;
+import com.evolveum.midpoint.gui.impl.page.admin.connector.development.component.wizard.scimrest.connection.ResourceTestConnectorStepPanel;
+import com.evolveum.midpoint.gui.impl.page.admin.connector.development.component.wizard.scimrest.connection.WaitingSchemaConnectorStepPanel;
+import com.evolveum.midpoint.gui.impl.page.admin.connector.development.component.wizard.scimrest.objectclass.ObjectClassSelectConnectorStepPanel;
+import com.evolveum.midpoint.gui.impl.page.admin.connector.development.component.wizard.scimrest.objectclass.create.CreateScriptConnectorStepPanel;
+import com.evolveum.midpoint.gui.impl.page.admin.connector.development.component.wizard.scimrest.objectclass.create.WaitingCreateConnectorStepPanel;
+import com.evolveum.midpoint.gui.impl.page.admin.connector.development.component.wizard.scimrest.objectclass.delete.DeleteScriptConnectorStepPanel;
+import com.evolveum.midpoint.gui.impl.page.admin.connector.development.component.wizard.scimrest.objectclass.delete.WaitingDeleteConnectorStepPanel;
+import com.evolveum.midpoint.gui.impl.page.admin.connector.development.component.wizard.scimrest.objectclass.schema.SchemaScriptConnectorStepPanel;
+import com.evolveum.midpoint.gui.impl.page.admin.connector.development.component.wizard.scimrest.objectclass.schema.ShowSchemaConnectorStepPanel;
+import com.evolveum.midpoint.gui.impl.page.admin.connector.development.component.wizard.scimrest.objectclass.schema.WaitingConnIdSchemaConnectorStepPanel;
+import com.evolveum.midpoint.gui.impl.page.admin.connector.development.component.wizard.scimrest.objectclass.schema.WaitingNativeSchemaConnectorStepPanel;
+import com.evolveum.midpoint.gui.impl.page.admin.connector.development.component.wizard.scimrest.objectclass.schema.WaitingObjectClassDetailsConnectorStepPanel;
+import com.evolveum.midpoint.gui.impl.page.admin.connector.development.component.wizard.scimrest.objectclass.search.SearchAllObjectsConnectorStepPanel;
+import com.evolveum.midpoint.gui.impl.page.admin.connector.development.component.wizard.scimrest.objectclass.search.SearchAllScriptConnectorStepPanel;
+import com.evolveum.midpoint.gui.impl.page.admin.connector.development.component.wizard.scimrest.objectclass.search.SearchByIdObjectConnectorStepPanel;
+import com.evolveum.midpoint.gui.impl.page.admin.connector.development.component.wizard.scimrest.objectclass.search.SearchByIdScriptConnectorStepPanel;
+import com.evolveum.midpoint.gui.impl.page.admin.connector.development.component.wizard.scimrest.objectclass.search.SearchFilterObjectsConnectorStepPanel;
+import com.evolveum.midpoint.gui.impl.page.admin.connector.development.component.wizard.scimrest.objectclass.search.SearchFilterScriptConnectorStepPanel;
+import com.evolveum.midpoint.gui.impl.page.admin.connector.development.component.wizard.scimrest.objectclass.search.WaitingSearchAllConnectorStepPanel;
+import com.evolveum.midpoint.gui.impl.page.admin.connector.development.component.wizard.scimrest.objectclass.search.WaitingSearchByIdConnectorStepPanel;
+import com.evolveum.midpoint.gui.impl.page.admin.connector.development.component.wizard.scimrest.objectclass.search.WaitingSearchFilterConnectorStepPanel;
+import com.evolveum.midpoint.gui.impl.page.admin.connector.development.component.wizard.scimrest.objectclass.update.UpdateScriptConnectorStepPanel;
+import com.evolveum.midpoint.gui.impl.page.admin.connector.development.component.wizard.scimrest.objectclass.update.WaitingUpdateConnectorStepPanel;
+import com.evolveum.midpoint.gui.impl.page.admin.connector.development.component.wizard.sql.connection.SqlConnectionParametersConnectorStepPanel;
+import com.evolveum.midpoint.prism.Containerable;
+import com.evolveum.midpoint.prism.path.ItemName;
+import com.evolveum.midpoint.xml.ns._public.common.common_3.ConnDevObjectClassInfoType;
+
+/**
+ * Wizard strategy for SQL connectors. No HTTP endpoint-selection steps (JDBC connectors have no
+ * concept of an HTTP endpoint) and a dedicated JDBC connection-parameters step instead of the
+ * HTTP auth/base-URL flow.
+ */
+public class SqlConnectorWizardStrategy implements ConnectorWizardStrategy {
+
+    private static final String NOT_APPLICABLE_TO_SQL = "This wizard step is HTTP-specific and does not apply to SQL connectors.";
+
+    @Override
+    public List<WizardStep> connectionSteps(WizardPanelHelper<? extends Containerable, ConnectorDevelopmentDetailsModel> helper) {
+        return List.of(
+                new SqlConnectionParametersConnectorStepPanel(helper),
+                new ResourceTestConnectorStepPanel(helper, SqlConnectionParametersConnectorStepPanel.PANEL_TYPE),
+                new WaitingSchemaConnectorStepPanel(helper));
+    }
+
+    @Override
+    public List<WizardStep> initObjectClassSteps(
+            WizardPanelHelper<? extends Containerable, ConnectorDevelopmentDetailsModel> helper,
+            IModel<PrismContainerValueWrapper<ConnDevObjectClassInfoType>> objectClassModel) {
+        return List.of(
+                new ObjectClassSelectConnectorStepPanel(helper, objectClassModel),
+                new WaitingObjectClassDetailsConnectorStepPanel(helper, objectClassModel),
+                new WaitingNativeSchemaConnectorStepPanel(helper, objectClassModel),
+                new WaitingConnIdSchemaConnectorStepPanel(helper, objectClassModel),
+                new SchemaScriptConnectorStepPanel(helper, objectClassModel),
+                new ShowSchemaConnectorStepPanel(helper, objectClassModel),
+                new WaitingSearchAllConnectorStepPanel(helper, objectClassModel),
+                new SearchAllScriptConnectorStepPanel(helper, objectClassModel),
+                new SearchAllObjectsConnectorStepPanel(helper, objectClassModel),
+                new WaitingSearchByIdConnectorStepPanel(helper, objectClassModel),
+                new SearchByIdScriptConnectorStepPanel(helper, objectClassModel),
+                new SearchByIdObjectConnectorStepPanel(helper, objectClassModel));
+    }
+
+    @Override
+    public List<WizardStep> searchAllObjectClassSteps(
+            WizardPanelHelper<? extends Containerable, ConnectorDevelopmentDetailsModel> helper,
+            IModel<PrismContainerValueWrapper<ConnDevObjectClassInfoType>> objectClassModel) {
+        return List.of(
+                new WaitingSearchAllConnectorStepPanel(helper, objectClassModel),
+                new SearchAllScriptConnectorStepPanel(helper, objectClassModel),
+                new SearchAllObjectsConnectorStepPanel(helper, objectClassModel));
+    }
+
+    @Override
+    public List<WizardStep> searchByIdObjectClassSteps(
+            WizardPanelHelper<? extends Containerable, ConnectorDevelopmentDetailsModel> helper,
+            IModel<PrismContainerValueWrapper<ConnDevObjectClassInfoType>> objectClassModel) {
+        return List.of(
+                new WaitingSearchByIdConnectorStepPanel(helper, objectClassModel),
+                new SearchByIdScriptConnectorStepPanel(helper, objectClassModel),
+                new SearchByIdObjectConnectorStepPanel(helper, objectClassModel));
+    }
+
+    @Override
+    public List<WizardStep> searchFilterObjectClassSteps(
+            WizardPanelHelper<? extends Containerable, ConnectorDevelopmentDetailsModel> helper,
+            IModel<PrismContainerValueWrapper<ConnDevObjectClassInfoType>> objectClassModel) {
+        return List.of(
+                new WaitingSearchFilterConnectorStepPanel(helper, objectClassModel),
+                new SearchFilterScriptConnectorStepPanel(helper, objectClassModel),
+                new SearchFilterObjectsConnectorStepPanel(helper, objectClassModel));
+    }
+
+    @Override
+    public List<WizardStep> createObjectClassSteps(
+            WizardPanelHelper<? extends Containerable, ConnectorDevelopmentDetailsModel> helper,
+            IModel<PrismContainerValueWrapper<ConnDevObjectClassInfoType>> objectClassModel) {
+        return List.of(
+                new WaitingCreateConnectorStepPanel(helper, objectClassModel),
+                new CreateScriptConnectorStepPanel(helper, objectClassModel));
+    }
+
+    @Override
+    public List<WizardStep> updateObjectClassSteps(
+            WizardPanelHelper<? extends Containerable, ConnectorDevelopmentDetailsModel> helper,
+            IModel<PrismContainerValueWrapper<ConnDevObjectClassInfoType>> objectClassModel) {
+        return List.of(
+                new WaitingUpdateConnectorStepPanel(helper, objectClassModel),
+                new UpdateScriptConnectorStepPanel(helper, objectClassModel));
+    }
+
+    @Override
+    public List<WizardStep> deleteObjectClassSteps(
+            WizardPanelHelper<? extends Containerable, ConnectorDevelopmentDetailsModel> helper,
+            IModel<PrismContainerValueWrapper<ConnDevObjectClassInfoType>> objectClassModel) {
+        return List.of(
+                new WaitingDeleteConnectorStepPanel(helper, objectClassModel),
+                new DeleteScriptConnectorStepPanel(helper, objectClassModel));
+    }
+
+    @Override
+    public ItemName connectionUrlFieldName() {
+        throw new UnsupportedOperationException(NOT_APPLICABLE_TO_SQL);
+    }
+}

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/component/wizard/scimrest/connection/BaseUrlConnectorStepPanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/component/wizard/scimrest/connection/BaseUrlConnectorStepPanel.java
@@ -6,8 +6,6 @@
  */
 package com.evolveum.midpoint.gui.impl.page.admin.connector.development.component.wizard.scimrest.connection;
 
-import java.util.List;
-
 import org.apache.commons.lang3.StringUtils;
 import org.apache.wicket.ajax.AjaxRequestTarget;
 import org.apache.wicket.behavior.AttributeAppender;
@@ -117,7 +115,7 @@ public class BaseUrlConnectorStepPanel extends AbstractFormWizardStepPanel<Conne
                     ItemPath.create(ConnectorDevelopmentType.F_APPLICATION, ConnDevApplicationInfoType.F_BASE_API_ENDPOINT))
                     .getValue().getRealValue();
             if (StringUtils.isNotEmpty(suggestedUrl)) {
-                ItemName urlField = isScim() ? SCIM_BASE_URL_ITEM_NAME : BASE_ADDRESS_ITEM_NAME;
+                ItemName urlField = urlFieldName();
                 PrismPropertyValueWrapper<String> fieldValue = (PrismPropertyValueWrapper<String>) getContainerFormModel().getObject().findProperty(urlField).getValue();
                 if (StringUtils.isEmpty(fieldValue.getRealValue())) {
                     fieldValue.setRealValue(suggestedUrl);
@@ -225,40 +223,20 @@ public class BaseUrlConnectorStepPanel extends AbstractFormWizardStepPanel<Conne
     }
 
     protected boolean checkMandatory(ItemWrapper wrapper) {
-        if (isScim()) {
-            if (QNameUtil.match(wrapper.getItemName(), SCIM_BASE_URL_ITEM_NAME)) {
-                return true;
-            }
-        } else {
-            if (QNameUtil.match(wrapper.getItemName(), BASE_ADDRESS_ITEM_NAME)) {
-                return true;
-            }
+        if (QNameUtil.match(wrapper.getItemName(), urlFieldName())) {
+            return true;
         }
         return wrapper.isMandatory();
     }
 
     @Override
     protected ItemVisibilityHandler getVisibilityHandler() {
-        return wrapper -> {
-            if (isScim()) {
-                if (scimItemNames().stream().anyMatch(name -> QNameUtil.match(wrapper.getItemName(), name))) {
-                    return ItemVisibility.AUTO;
-                }
-            } else {
-                if (QNameUtil.match(wrapper.getItemName(), BASE_ADDRESS_ITEM_NAME)) {
-                    return ItemVisibility.AUTO;
-                }
-            }
-            return ItemVisibility.HIDDEN;
-        };
+        return wrapper -> QNameUtil.match(wrapper.getItemName(), urlFieldName())
+                ? ItemVisibility.AUTO : ItemVisibility.HIDDEN;
     }
 
-    private List<ItemName> scimItemNames() {
-        return List.of(SCIM_BASE_URL_ITEM_NAME);
-    }
-
-    private boolean isScim() {
-        return ConnectorDevelopmentWizardUtil.isScim(getDetailsModel());
+    private ItemName urlFieldName() {
+        return ConnectorDevelopmentWizardUtil.wizardStrategyFor(getDetailsModel()).connectionUrlFieldName();
     }
 
     @Override
@@ -295,9 +273,8 @@ public class BaseUrlConnectorStepPanel extends AbstractFormWizardStepPanel<Conne
 
     @Override
     public boolean isCompleted() {
-        ItemName fieldToCheck = isScim() ? SCIM_BASE_URL_ITEM_NAME : BASE_ADDRESS_ITEM_NAME;
         return ConnectorDevelopmentWizardUtil.existTestingResourcePropertyValue(
-                getDetailsModel(), getPanelType(), fieldToCheck);
+                getDetailsModel(), getPanelType(), urlFieldName());
     }
     @Override
     protected String getSubTextContainerCssClass() {

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/component/wizard/scimrest/connection/ConnectionConnectorStepPanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/component/wizard/scimrest/connection/ConnectionConnectorStepPanel.java
@@ -21,7 +21,6 @@ import com.evolveum.midpoint.gui.impl.component.wizard.WizardPanelHelper;
 import com.evolveum.midpoint.gui.impl.component.wizard.withnavigation.WizardParentStep;
 import com.evolveum.midpoint.gui.impl.page.admin.connector.development.ConnectorDevelopmentDetailsModel;
 import com.evolveum.midpoint.gui.impl.page.admin.connector.development.component.wizard.ConnectorDevelopmentWizardUtil;
-import com.evolveum.midpoint.gui.impl.page.admin.connector.development.component.wizard.sql.connection.SqlConnectionParametersConnectorStepPanel;
 import com.evolveum.midpoint.gui.impl.prism.panel.ItemPanelSettings;
 import com.evolveum.midpoint.gui.impl.prism.panel.ItemPanelSettingsBuilder;
 import com.evolveum.midpoint.gui.impl.prism.panel.vertical.form.VerticalFormPanel;
@@ -174,24 +173,7 @@ public class ConnectionConnectorStepPanel extends AbstractFormWizardStepPanel<Co
 
     @Override
     public List<WizardStep> createChildrenSteps() {
-        if (ConnectorDevelopmentWizardUtil.isSql(getDetailsModel())) {
-            return List.of(
-                    new SqlConnectionParametersConnectorStepPanel(getHelper()),
-                    new ResourceTestConnectorStepPanel(getHelper(), SqlConnectionParametersConnectorStepPanel.PANEL_TYPE),
-                    new WaitingSchemaConnectorStepPanel(getHelper()));
-        }
-        return List.of(
-                new WaitingBasicInfoConnectorStepPanel(getHelper()),
-                new BaseUrlConnectorStepPanel(getHelper()),
-                new SupportedAuthMethodConnectorStepPanel(getHelper()),
-                new WaitingAuthScriptsConnectorStepPanel(getHelper()),
-                new AuthScriptsConnectorStepPanel(getHelper()),
-                new CredentialsConnectorStepPanel(getHelper()),
-                new WaitingConnectivityEndpointConnectorStepPanel(getHelper()),
-                new EndpointConnectorStepPanel(getHelper()),
-                new FixConnectionConnectorStepPanel(getHelper()),
-                new ResourceTestConnectorStepPanel(getHelper()),
-                new WaitingSchemaConnectorStepPanel(getHelper()));
+        return ConnectorDevelopmentWizardUtil.wizardStrategyFor(getDetailsModel()).connectionSteps(getHelper());
     }
 
     @Override

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/component/wizard/scimrest/connection/FixConnectionConnectorStepPanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/component/wizard/scimrest/connection/FixConnectionConnectorStepPanel.java
@@ -118,11 +118,8 @@ public class FixConnectionConnectorStepPanel extends AbstractWizardStepPanel<Con
         baseUrlModel = new LoadableModel<>(false) {
             @Override
             protected String load() {
-                ItemName urlField = ConnectorDevelopmentWizardUtil.isScim(getDetailsModel())
-                        ? BaseUrlConnectorStepPanel.SCIM_BASE_URL_ITEM_NAME
-                        : BaseUrlConnectorStepPanel.BASE_ADDRESS_ITEM_NAME;
                 Object val = ConnectorDevelopmentWizardUtil.getTestingResourcePropertyValue(
-                        getDetailsModel(), BaseUrlConnectorStepPanel.PANEL_TYPE, urlField);
+                        getDetailsModel(), BaseUrlConnectorStepPanel.PANEL_TYPE, urlFieldName());
                 return val instanceof String s ? s : "";
             }
         };
@@ -396,6 +393,10 @@ public class FixConnectionConnectorStepPanel extends AbstractWizardStepPanel<Con
         };
     }
 
+    private ItemName urlFieldName() {
+        return ConnectorDevelopmentWizardUtil.wizardStrategyFor(getDetailsModel()).connectionUrlFieldName();
+    }
+
     private IModel<? extends PrismContainerWrapper> getCredentialsFormModel() {
         try {
             PrismReferenceWrapper<Referencable> resource = getDetailsModel().getObjectWrapper().findReference(
@@ -435,10 +436,7 @@ public class FixConnectionConnectorStepPanel extends AbstractWizardStepPanel<Con
 
         try {
             if (StringUtils.isNotEmpty(baseUrl)) {
-                ItemName urlField = ConnectorDevelopmentWizardUtil.isScim(getDetailsModel())
-                        ? BaseUrlConnectorStepPanel.SCIM_BASE_URL_ITEM_NAME
-                        : BaseUrlConnectorStepPanel.BASE_ADDRESS_ITEM_NAME;
-                ConnectorDevelopmentWizardUtil.setTestingResourcePropertyValue(getDetailsModel(), PANEL_TYPE, urlField, baseUrl);
+                ConnectorDevelopmentWizardUtil.setTestingResourcePropertyValue(getDetailsModel(), PANEL_TYPE, urlFieldName(), baseUrl);
             }
             if (StringUtils.isNotEmpty(url)) {
                 ConnectorDevelopmentWizardUtil.setTestingResourcePropertyValue(

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/component/wizard/scimrest/objectclass/AbstractObjectClassConnectorStepPanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/component/wizard/scimrest/objectclass/AbstractObjectClassConnectorStepPanel.java
@@ -24,6 +24,7 @@ import com.evolveum.midpoint.gui.impl.component.wizard.WizardPanelHelper;
 import com.evolveum.midpoint.gui.impl.component.wizard.withnavigation.WizardParentStep;
 import com.evolveum.midpoint.gui.impl.page.admin.connector.development.ConnectorDevelopmentDetailsModel;
 import com.evolveum.midpoint.gui.impl.page.admin.connector.development.component.wizard.ConnectorDevelopmentWizardUtil;
+import com.evolveum.midpoint.gui.impl.page.admin.connector.development.component.wizard.ConnectorWizardStrategy;
 import com.evolveum.midpoint.gui.impl.prism.panel.ItemPanelSettings;
 import com.evolveum.midpoint.gui.impl.prism.panel.ItemPanelSettingsBuilder;
 import com.evolveum.midpoint.gui.impl.prism.panel.vertical.form.VerticalFormPanel;
@@ -279,8 +280,8 @@ public abstract class AbstractObjectClassConnectorStepPanel extends AbstractForm
         return objectClassModel;
     }
 
-    protected final boolean isSql() {
-        return ConnectorDevelopmentWizardUtil.isSql(getDetailsModel());
+    protected final ConnectorWizardStrategy wizardStrategy() {
+        return ConnectorDevelopmentWizardUtil.wizardStrategyFor(getDetailsModel());
     }
 
     @Override

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/component/wizard/scimrest/objectclass/InitObjectClassConnectorStepPanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/component/wizard/scimrest/objectclass/InitObjectClassConnectorStepPanel.java
@@ -10,17 +10,6 @@ import java.util.List;
 
 import com.evolveum.midpoint.gui.impl.component.wizard.WizardPanelHelper;
 import com.evolveum.midpoint.gui.impl.page.admin.connector.development.ConnectorDevelopmentDetailsModel;
-import com.evolveum.midpoint.gui.impl.page.admin.connector.development.component.wizard.scimrest.objectclass.schema.*;
-
-import com.evolveum.midpoint.gui.impl.page.admin.connector.development.component.wizard.scimrest.objectclass.search.SearchAllScriptConnectorStepPanel;
-
-import com.evolveum.midpoint.gui.impl.page.admin.connector.development.component.wizard.scimrest.objectclass.search.SearchAllEndpointsConnectorStepPanel;
-import com.evolveum.midpoint.gui.impl.page.admin.connector.development.component.wizard.scimrest.objectclass.search.SearchAllObjectsConnectorStepPanel;
-import com.evolveum.midpoint.gui.impl.page.admin.connector.development.component.wizard.scimrest.objectclass.search.WaitingSearchAllConnectorStepPanel;
-import com.evolveum.midpoint.gui.impl.page.admin.connector.development.component.wizard.scimrest.objectclass.search.SearchByIdEndpointsConnectorStepPanel;
-import com.evolveum.midpoint.gui.impl.page.admin.connector.development.component.wizard.scimrest.objectclass.search.WaitingSearchByIdConnectorStepPanel;
-import com.evolveum.midpoint.gui.impl.page.admin.connector.development.component.wizard.scimrest.objectclass.search.SearchByIdScriptConnectorStepPanel;
-import com.evolveum.midpoint.gui.impl.page.admin.connector.development.component.wizard.scimrest.objectclass.search.SearchByIdObjectConnectorStepPanel;
 import com.evolveum.midpoint.prism.Containerable;
 import com.evolveum.midpoint.xml.ns._public.common.common_3.ConnectorDevelopmentType;
 import com.evolveum.midpoint.xml.ns._public.common.common_3.OperationTypeType;
@@ -56,36 +45,7 @@ public class InitObjectClassConnectorStepPanel extends AbstractObjectClassConnec
 
     @Override
     public List<WizardStep> createChildrenSteps() {
-        if (isSql()) {
-            return List.of(
-                    new ObjectClassSelectConnectorStepPanel(getHelper(), getObjectClassModel()),
-                    new WaitingObjectClassDetailsConnectorStepPanel(getHelper(), getObjectClassModel()),
-                    new WaitingNativeSchemaConnectorStepPanel(getHelper(), getObjectClassModel()),
-                    new WaitingConnIdSchemaConnectorStepPanel(getHelper(), getObjectClassModel()),
-                    new SchemaScriptConnectorStepPanel(getHelper(), getObjectClassModel()),
-                    new ShowSchemaConnectorStepPanel(getHelper(), getObjectClassModel()),
-                    new WaitingSearchAllConnectorStepPanel(getHelper(), getObjectClassModel()),
-                    new SearchAllScriptConnectorStepPanel(getHelper(), getObjectClassModel()),
-                    new SearchAllObjectsConnectorStepPanel(getHelper(), getObjectClassModel()),
-                    new WaitingSearchByIdConnectorStepPanel(getHelper(), getObjectClassModel()),
-                    new SearchByIdScriptConnectorStepPanel(getHelper(), getObjectClassModel()),
-                    new SearchByIdObjectConnectorStepPanel(getHelper(), getObjectClassModel()));
-        }
-        return List.of(
-                new ObjectClassSelectConnectorStepPanel(getHelper(), getObjectClassModel()),
-                new WaitingObjectClassDetailsConnectorStepPanel(getHelper(), getObjectClassModel()),
-                new WaitingNativeSchemaConnectorStepPanel(getHelper(), getObjectClassModel()),
-                new WaitingConnIdSchemaConnectorStepPanel(getHelper(), getObjectClassModel()),
-                new SchemaScriptConnectorStepPanel(getHelper(), getObjectClassModel()),
-                new ShowSchemaConnectorStepPanel(getHelper(), getObjectClassModel()),
-                new SearchAllEndpointsConnectorStepPanel(getHelper(), getObjectClassModel()),
-                new WaitingSearchAllConnectorStepPanel(getHelper(), getObjectClassModel()),
-                new SearchAllScriptConnectorStepPanel(getHelper(), getObjectClassModel()),
-                new SearchAllObjectsConnectorStepPanel(getHelper(), getObjectClassModel()),
-                new SearchByIdEndpointsConnectorStepPanel(getHelper(), getObjectClassModel()),
-                new WaitingSearchByIdConnectorStepPanel(getHelper(), getObjectClassModel()),
-                new SearchByIdScriptConnectorStepPanel(getHelper(), getObjectClassModel()),
-                new SearchByIdObjectConnectorStepPanel(getHelper(), getObjectClassModel()));
+        return wizardStrategy().initObjectClassSteps(getHelper(), getObjectClassModel());
     }
 
     @Override

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/component/wizard/scimrest/objectclass/create/CreateObjectClassConnectorStepPanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/component/wizard/scimrest/objectclass/create/CreateObjectClassConnectorStepPanel.java
@@ -45,15 +45,7 @@ public class CreateObjectClassConnectorStepPanel extends AbstractObjectClassConn
 
     @Override
     public List<WizardStep> createChildrenSteps() {
-        if (isSql()) {
-            return List.of(
-                    new WaitingCreateConnectorStepPanel(getHelper(), getObjectClassModel()),
-                    new CreateScriptConnectorStepPanel(getHelper(), getObjectClassModel()));
-        }
-        return List.of(
-                new CreateEndpointsConnectorStepPanel(getHelper(), getObjectClassModel()),
-                new WaitingCreateConnectorStepPanel(getHelper(), getObjectClassModel()),
-                new CreateScriptConnectorStepPanel(getHelper(), getObjectClassModel()));
+        return wizardStrategy().createObjectClassSteps(getHelper(), getObjectClassModel());
     }
 
     @Override

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/component/wizard/scimrest/objectclass/delete/DeleteObjectClassConnectorStepPanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/component/wizard/scimrest/objectclass/delete/DeleteObjectClassConnectorStepPanel.java
@@ -45,15 +45,7 @@ public class DeleteObjectClassConnectorStepPanel extends AbstractObjectClassConn
 
     @Override
     public List<WizardStep> createChildrenSteps() {
-        if (isSql()) {
-            return List.of(
-                    new WaitingDeleteConnectorStepPanel(getHelper(), getObjectClassModel()),
-                    new DeleteScriptConnectorStepPanel(getHelper(), getObjectClassModel()));
-        }
-        return List.of(
-                new DeleteEndpointsConnectorStepPanel(getHelper(), getObjectClassModel()),
-                new WaitingDeleteConnectorStepPanel(getHelper(), getObjectClassModel()),
-                new DeleteScriptConnectorStepPanel(getHelper(), getObjectClassModel()));
+        return wizardStrategy().deleteObjectClassSteps(getHelper(), getObjectClassModel());
     }
 
     @Override

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/component/wizard/scimrest/objectclass/search/SearchAllObjectClassConnectorStepPanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/component/wizard/scimrest/objectclass/search/SearchAllObjectClassConnectorStepPanel.java
@@ -45,17 +45,7 @@ public class SearchAllObjectClassConnectorStepPanel extends AbstractObjectClassC
 
     @Override
     public List<WizardStep> createChildrenSteps() {
-        if (isSql()) {
-            return List.of(
-                    new WaitingSearchAllConnectorStepPanel(getHelper(), getObjectClassModel()),
-                    new SearchAllScriptConnectorStepPanel(getHelper(), getObjectClassModel()),
-                    new SearchAllObjectsConnectorStepPanel(getHelper(), getObjectClassModel()));
-        }
-        return List.of(
-                new SearchAllEndpointsConnectorStepPanel(getHelper(), getObjectClassModel()),
-                new WaitingSearchAllConnectorStepPanel(getHelper(), getObjectClassModel()),
-                new SearchAllScriptConnectorStepPanel(getHelper(), getObjectClassModel()),
-                new SearchAllObjectsConnectorStepPanel(getHelper(), getObjectClassModel()));
+        return wizardStrategy().searchAllObjectClassSteps(getHelper(), getObjectClassModel());
     }
 
     @Override

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/component/wizard/scimrest/objectclass/search/SearchByIdObjectClassConnectorStepPanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/component/wizard/scimrest/objectclass/search/SearchByIdObjectClassConnectorStepPanel.java
@@ -46,17 +46,7 @@ public class SearchByIdObjectClassConnectorStepPanel extends AbstractObjectClass
 
     @Override
     public List<WizardStep> createChildrenSteps() {
-        if (isSql()) {
-            return List.of(
-                    new WaitingSearchByIdConnectorStepPanel(getHelper(), getObjectClassModel()),
-                    new SearchByIdScriptConnectorStepPanel(getHelper(), getObjectClassModel()),
-                    new SearchByIdObjectConnectorStepPanel(getHelper(), getObjectClassModel()));
-        }
-        return List.of(
-                new SearchByIdEndpointsConnectorStepPanel(getHelper(), getObjectClassModel()),
-                new WaitingSearchByIdConnectorStepPanel(getHelper(), getObjectClassModel()),
-                new SearchByIdScriptConnectorStepPanel(getHelper(), getObjectClassModel()),
-                new SearchByIdObjectConnectorStepPanel(getHelper(), getObjectClassModel()));
+        return wizardStrategy().searchByIdObjectClassSteps(getHelper(), getObjectClassModel());
     }
 
     @Override

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/component/wizard/scimrest/objectclass/search/SearchFilterObjectClassConnectorStepPanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/component/wizard/scimrest/objectclass/search/SearchFilterObjectClassConnectorStepPanel.java
@@ -46,17 +46,7 @@ public class SearchFilterObjectClassConnectorStepPanel extends AbstractObjectCla
 
     @Override
     public List<WizardStep> createChildrenSteps() {
-        if (isSql()) {
-            return List.of(
-                    new WaitingSearchFilterConnectorStepPanel(getHelper(), getObjectClassModel()),
-                    new SearchFilterScriptConnectorStepPanel(getHelper(), getObjectClassModel()),
-                    new SearchFilterObjectsConnectorStepPanel(getHelper(), getObjectClassModel()));
-        }
-        return List.of(
-                new SearchFilterEndpointsConnectorStepPanel(getHelper(), getObjectClassModel()),
-                new WaitingSearchFilterConnectorStepPanel(getHelper(), getObjectClassModel()),
-                new SearchFilterScriptConnectorStepPanel(getHelper(), getObjectClassModel()),
-                new SearchFilterObjectsConnectorStepPanel(getHelper(), getObjectClassModel()));
+        return wizardStrategy().searchFilterObjectClassSteps(getHelper(), getObjectClassModel());
     }
 
     @Override

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/component/wizard/scimrest/objectclass/update/UpdateObjectClassConnectorStepPanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/component/wizard/scimrest/objectclass/update/UpdateObjectClassConnectorStepPanel.java
@@ -45,15 +45,7 @@ public class UpdateObjectClassConnectorStepPanel extends AbstractObjectClassConn
 
     @Override
     public List<WizardStep> createChildrenSteps() {
-        if (isSql()) {
-            return List.of(
-                    new WaitingUpdateConnectorStepPanel(getHelper(), getObjectClassModel()),
-                    new UpdateScriptConnectorStepPanel(getHelper(), getObjectClassModel()));
-        }
-        return List.of(
-                new UpdateEndpointsConnectorStepPanel(getHelper(), getObjectClassModel()),
-                new WaitingUpdateConnectorStepPanel(getHelper(), getObjectClassModel()),
-                new UpdateScriptConnectorStepPanel(getHelper(), getObjectClassModel()));
+        return wizardStrategy().updateObjectClassSteps(getHelper(), getObjectClassModel());
     }
 
     @Override


### PR DESCRIPTION
- Introduce ConnectorWizardStrategy (Rest/Scim/Sql implementations, Scim extends Rest) so step panels delegate connector-type decisions instead of branching themselves, mirroring ConnectorDevelopmentBackend
- Replace if(isSql())/if(isScim()) checks across 11 wizard step-panel classes with delegation to the strategy

Task: 11919