### PR TITLE
Send apiType param to relevant Midpilot calls

### DIFF
--- a/model/smart-impl/src/main/java/com/evolveum/midpoint/smart/impl/conndev/ConnectorDevelopmentBackend.java
+++ b/model/smart-impl/src/main/java/com/evolveum/midpoint/smart/impl/conndev/ConnectorDevelopmentBackend.java
@@ -417,7 +417,7 @@ public abstract class ConnectorDevelopmentBackend {
         }
         body.set("preferredAuthorizations", authArray);
 
-        try (var job = client().postJob("codegen/{sessionId}/authorization", body, skipCache)) {
+        try (var job = client().postJob("codegen/{sessionId}/authorization", body, apiType(), skipCache)) {
             String content = job.waitAndProcess(SLEEP_TIME, canRun(), json -> json.get("code").asText());
             if (content == null || content.isBlank()) {
                 return null;
@@ -483,7 +483,7 @@ public abstract class ConnectorDevelopmentBackend {
     }
 
     private String generateRelation(ConnDevArtifactType artifactSpec, List<ConnDevRelationInfoType> relation, ObjectNode body, boolean skipCache) {
-        try(var job = client().postJob("codegen/{sessionId}/relations/" + artifactSpec.getObjectClass(), body, skipCache)) {
+        try(var job = client().postJob("codegen/{sessionId}/relations/" + artifactSpec.getObjectClass(), body, null, skipCache)) {
             return job.waitAndProcess(SLEEP_TIME, canRun(), json -> json.get("code").asText());
         } catch (IOException e) {
             throw new SystemException("Couldn't generate relation for objectClass " + artifactSpec.getObjectClass(), e);
@@ -491,7 +491,8 @@ public abstract class ConnectorDevelopmentBackend {
     }
 
     private String generateObjectClassScript(ConnDevArtifactType artifactSpec, String endpointSuffix, String scriptDescription, ObjectNode body, boolean skipCache) {
-        try(var job = client().postJob("codegen/{sessionId}/classes/"+ artifactSpec.getObjectClass() + "/" + endpointSuffix, body, skipCache)) {
+        var apiType = "connid".equals(endpointSuffix) ? null : apiType();
+        try(var job = client().postJob("codegen/{sessionId}/classes/"+ artifactSpec.getObjectClass() + "/" + endpointSuffix, body, apiType, skipCache)) {
             return job.waitAndProcess(SLEEP_TIME, canRun(), json -> json.get("code").asText());
         } catch (IOException e) {
             throw new SystemException("Couldn't generate " + scriptDescription + " for objectClass " + artifactSpec.getObjectClass(), e);
@@ -845,6 +846,12 @@ public abstract class ConnectorDevelopmentBackend {
         return beans.client(sessionId(), this::restoreSession, this::synchronizeSession, result);
     }
 
+    protected String apiType() {
+        var app = developmentObject().getApplication();
+        var integrationType = app != null ? app.getIntegrationType() : null;
+        return integrationType != null ? integrationType.value() : null;
+    }
+
     /**
      * Pushes each freshly built dev-shadow documentation to the connector-generation service via
      * {@code POST session/{sessionId}/documentation/{docId}} and pulls the processed result back into
@@ -912,7 +919,7 @@ public abstract class ConnectorDevelopmentBackend {
 
     public List<ConnDevBasicObjectClassInfoType> discoverObjectClassesUsingDocumentation(
             List<ConnDevBasicObjectClassInfoType> connectorDiscovered, boolean includeUnrelated, boolean skipCache) {
-        try (var job = client().postJob("digester/{sessionId}/classes", skipCache)) {
+        try (var job = client().postJob("digester/{sessionId}/classes", apiType(), skipCache)) {
             return job.waitAndProcess(SLEEP_TIME, canRun(), o -> {
                 var ret = new ArrayList<ConnDevBasicObjectClassInfoType>();
                 var jsonClasses = o.get("objectClasses");
@@ -930,7 +937,7 @@ public abstract class ConnectorDevelopmentBackend {
     }
 
     public List<ConnDevAttributeInfoType> discoverObjectClassAttributes(String objectClass, boolean skipCache) {
-        try (var job = client().postJob("digester/{sessionId}/classes/" + objectClass + "/attributes", skipCache)) {
+        try (var job = client().postJob("digester/{sessionId}/classes/" + objectClass + "/attributes", apiType(), skipCache)) {
             return job.waitAndProcess(SLEEP_TIME, canRun(), o -> {
                 var ret = new ArrayList<ConnDevAttributeInfoType>();
                 var jsonAttributes = (ObjectNode) o.get("attributes");

--- a/model/smart-impl/src/main/java/com/evolveum/midpoint/smart/impl/conndev/RestBackend.java
+++ b/model/smart-impl/src/main/java/com/evolveum/midpoint/smart/impl/conndev/RestBackend.java
@@ -32,7 +32,7 @@ public class RestBackend extends ConnectorDevelopmentBackend {
 
     @Override
     public ConnDevApplicationInfoType discoverBasicInformation(boolean skipCache) {
-        try(var job = client().postJob("digester/{sessionId}/metadata", skipCache)) {
+        try(var job = client().postJob("digester/{sessionId}/metadata", null, skipCache)) {
             return job.waitAndProcess(SLEEP_TIME, canRun(), o -> {
                 var ret = new ConnDevApplicationInfoType();
 
@@ -116,7 +116,7 @@ public class RestBackend extends ConnectorDevelopmentBackend {
 
     @Override
     public List<ConnDevAuthInfoType> discoverAuthorizationInformation(boolean skipCache) {
-        try(var job = client().postJob("digester/{sessionId}/auth", skipCache)) {
+        try(var job = client().postJob("digester/{sessionId}/auth", null, skipCache)) {
             return job.waitAndProcess(SLEEP_TIME, canRun(), json -> {
                 var ret = new ArrayList<ConnDevAuthInfoType>();
                 for (var jsonAuth : json.get("auth")) {
@@ -144,7 +144,7 @@ public class RestBackend extends ConnectorDevelopmentBackend {
         request.set("applicationVersion", JSON_FACTORY.textNode(
                 Objects.requireNonNullElse(developmentObject().getApplication().getVersion(), "latest")));
         request.set("llmGeneratedSearchQuery", JSON_FACTORY.booleanNode(false));
-        try(var jobSpec = client().postJob("discovery/{sessionId}/discovery", request, skipCache)) {
+        try(var jobSpec = client().postJob("discovery/{sessionId}/discovery", request, null, skipCache)) {
             return jobSpec.waitAndProcess(SLEEP_TIME, canRun(), result -> {
                 var results = jobSpec.getResult().get("candidateLinksEnriched");
 
@@ -187,7 +187,7 @@ public class RestBackend extends ConnectorDevelopmentBackend {
 
     @Override
     public List<ConnDevHttpEndpointType> discoverConnectivityEndpoints(boolean skipCache) {
-        try (var job = client().postJob("digester/{sessionId}/connectivity-endpoint", skipCache)) {
+        try (var job = client().postJob("digester/{sessionId}/connectivity-endpoint", null, skipCache)) {
             return job.waitAndProcess(SLEEP_TIME, canRun(), o -> {
                 var ret = new ArrayList<ConnDevHttpEndpointType>();
                 var jsonEndpoints = o.get("endpoints");
@@ -209,7 +209,7 @@ public class RestBackend extends ConnectorDevelopmentBackend {
 
     @Override
     public List<ConnDevHttpEndpointType> discoverObjectClassEndpoints(String objectClass, boolean skipCache) {
-        try(var job = client().postJob("digester/{sessionId}/classes/" + objectClass + "/endpoints", skipCache)) {
+        try(var job = client().postJob("digester/{sessionId}/classes/" + objectClass + "/endpoints", apiType(), skipCache)) {
             return job.waitAndProcess(SLEEP_TIME, canRun(), o -> {
                 var ret = new ArrayList<ConnDevHttpEndpointType>();
                 var jsonClasses = o.get("endpoints");
@@ -247,7 +247,7 @@ public class RestBackend extends ConnectorDevelopmentBackend {
 
     private void downloadUsingScrapper(Collection<ConnDevDocumentationSourceType> byScrapper, Collection<ProcessedDocumentation> documentations, boolean skipCache) {
         var request = scrapperRequest(byScrapper);
-        try(var job = client().postJob("scrape/{sessionId}/scrape", request, skipCache)) {
+        try(var job = client().postJob("scrape/{sessionId}/scrape", request, null, skipCache)) {
             var scrapped = job.waitAndProcess(SLEEP_TIME, canRun(), json -> {
                 var ret = new ArrayList<ProcessedDocumentation>();
 
@@ -328,7 +328,7 @@ public class RestBackend extends ConnectorDevelopmentBackend {
     @Override
     public List<ConnDevRelationInfoType> discoverRelationsUsingObjectClasses(List<ConnDevBasicObjectClassInfoType> discovered, boolean skipCache) {
         try {
-            try(var job = client().postJob("digester/{sessionId}/relations", skipCache)) {
+            try(var job = client().postJob("digester/{sessionId}/relations", null, skipCache)) {
                 return job.waitAndProcess(SLEEP_TIME, canRun(), json -> {
                     var ret = new ArrayList<ConnDevRelationInfoType>();
                     var jsonRelations = json.get("relations");

--- a/model/smart-impl/src/main/java/com/evolveum/midpoint/smart/impl/conndev/ServiceClient.java
+++ b/model/smart-impl/src/main/java/com/evolveum/midpoint/smart/impl/conndev/ServiceClient.java
@@ -20,10 +20,12 @@ import org.apache.hc.core5.http.ContentType;
 import org.apache.hc.core5.http.HttpEntity;
 import org.apache.hc.core5.http.HttpStatus;
 import org.apache.hc.core5.http.io.entity.StringEntity;
+import org.apache.hc.core5.net.URIBuilder;
 
 import javax.net.ssl.SSLContext;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
 import java.util.function.BooleanSupplier;
 
@@ -55,15 +57,15 @@ public class ServiceClient {
         this.sessionEndpoint = appendSession(this.apiBase + RELATIVE_SESSION_ENDPOINT);
     }
 
-    public Job postJob(String endpoint, boolean skipCache) throws IOException {
-        var job = new Job(apiBase+endpoint, skipCache);
+    public Job postJob(String endpoint, String apiType, boolean skipCache) throws IOException {
+        var job = new Job(apiBase+endpoint, apiType, skipCache);
         var request = job.postBuilder();
         job.startJob(request);
         return job;
     }
 
-    public Job postJob(String endpoint, ObjectNode body, boolean skipCache) throws IOException {
-        var job = new Job(apiBase+endpoint, skipCache);
+    public Job postJob(String endpoint, ObjectNode body, String apiType, boolean skipCache) throws IOException {
+        var job = new Job(apiBase+endpoint, apiType, skipCache);
         var request = job.postBuilder();
         request.setEntity(new StringEntity(body.toPrettyString(), ContentType.APPLICATION_JSON));
         job.startJob(request);
@@ -129,6 +131,7 @@ public class ServiceClient {
     public class Job implements AutoCloseable {
 
         private final String uri;
+        private final String apiType;
         private final boolean skipCache;
         private String jobId = null;
 
@@ -136,15 +139,13 @@ public class ServiceClient {
         private ObjectNode latestResult;
 
         public Job(String uri, boolean skipCache) {
-            this.uri = appendSession(uri);
-            this.skipCache =skipCache;
+            this(uri, null, skipCache);
         }
 
-        private String appendSkipCache(String uri) {
-            if (!skipCache) {
-                return uri;
-            }
-            return uri + ( !uri.contains("?") ? "?" : "&" ) + "skipCache=true";
+        public Job(String uri, String apiType, boolean skipCache) {
+            this.uri = appendSession(uri);
+            this.apiType = apiType;
+            this.skipCache =skipCache;
         }
 
         @Override
@@ -153,7 +154,18 @@ public class ServiceClient {
         }
 
         public HttpPost postBuilder() {
-            return new HttpPost(appendSkipCache(uri));
+            try {
+                var builder = new URIBuilder(uri);
+                if (skipCache) {
+                    builder.addParameter("skipCache", "true");
+                }
+                if (apiType != null) {
+                    builder.addParameter("apiType", apiType);
+                }
+                return new HttpPost(builder.build());
+            } catch (URISyntaxException e) {
+                throw new SystemException(e);
+            }
         }
 
         public void startJob(HttpPost request) throws IOException {


### PR DESCRIPTION
- Extend ServiceClient.postJob with a nullable apiType parameter; Job.postBuilder builds the query string via URIBuilder instead of manual string concatenation
- ConnectorDevelopmentBackend.apiType() derives rest/scim/sql from the connector development's integration type
- Wire it into the 5 digester/codegen calls that accept it (classes, endpoints, attributes, authorization, object class scripts except connid); the other 7 calls pass null since Midpilot doesn't accept apiType there

Task: 11890