### PR TITLE
MID-11768 Allow value expression to return null (GUI)

### DIFF
--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/component/input/expression/ExpressionPanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/component/input/expression/ExpressionPanel.java
@@ -96,7 +96,9 @@ public class ExpressionPanel extends BasePanel<ExpressionType> {
                 "ExpressionEvaluatorType.SHADOW_OWNER_REFERENCE_SEARCH.show.button"),
         PATH(ExpressionEvaluatorType.PATH,
                 PathExpressionPanel.class,
-                "ExpressionEvaluatorType.PATH.show.button");
+                "ExpressionEvaluatorType.PATH.show.button"),
+        NULL(ExpressionEvaluatorType.NULL,
+                null, null);
 
         private final ExpressionEvaluatorType type;
         private final Class<? extends EvaluatorExpressionPanel> evaluatorPanel;
@@ -167,7 +169,12 @@ public class ExpressionPanel extends BasePanel<ExpressionType> {
                 public void setObject(RecognizedEvaluator object) {
                     RecognizedEvaluator oldType = isLoaded() ? getObject() : null;
                     super.setObject(object);
-                    if (oldType != null && oldType != object && ExpressionPanel.this.getModelObject() != null) {
+
+                    // No subpanel writes the "null" evaluator into ExpressionType, so it updated on selection.
+                    if (object != null && object.equals(RecognizedEvaluator.NULL)) {
+                        ExpressionType currentExpression = ExpressionPanel.this.getOrCreateExpression();
+                        ExpressionUtil.addNullExpressionValue(currentExpression);
+                    } else if (oldType != null && oldType != object && ExpressionPanel.this.getModelObject() != null) {
                         ExpressionPanel.this.getModelObject().getExpressionEvaluator().clear();
                     }
                 }

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/component/input/expression/ExpressionPanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/component/input/expression/ExpressionPanel.java
@@ -96,7 +96,9 @@ public class ExpressionPanel extends BasePanel<ExpressionType> {
                 "ExpressionEvaluatorType.SHADOW_OWNER_REFERENCE_SEARCH.show.button"),
         PATH(ExpressionEvaluatorType.PATH,
                 PathExpressionPanel.class,
-                "ExpressionEvaluatorType.PATH.show.button");
+                "ExpressionEvaluatorType.PATH.show.button"),
+        NULL_EXPRESSION(ExpressionEvaluatorType.NULL_EXPRESSION,
+                null, null);
 
         private final ExpressionEvaluatorType type;
         private final Class<? extends EvaluatorExpressionPanel> evaluatorPanel;
@@ -167,7 +169,12 @@ public class ExpressionPanel extends BasePanel<ExpressionType> {
                 public void setObject(RecognizedEvaluator object) {
                     RecognizedEvaluator oldType = isLoaded() ? getObject() : null;
                     super.setObject(object);
-                    if (oldType != null && oldType != object && ExpressionPanel.this.getModelObject() != null) {
+
+                    // No subpanel writes the "null" evaluator into ExpressionType, so it updated on selection.
+                    if (object != null && object.equals(RecognizedEvaluator.NULL_EXPRESSION)) {
+                        ExpressionType currentExpression = ExpressionPanel.this.getOrCreateExpression();
+                        ExpressionUtil.addNullExpressionValue(currentExpression);
+                    } else if (oldType != null && oldType != object && ExpressionPanel.this.getModelObject() != null) {
                         ExpressionPanel.this.getModelObject().getExpressionEvaluator().clear();
                     }
                 }

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/resource/component/wizard/schemaHandling/objectType/attribute/mapping/preview/expression/PreviewExpressionPanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/resource/component/wizard/schemaHandling/objectType/attribute/mapping/preview/expression/PreviewExpressionPanel.java
@@ -54,7 +54,9 @@ public class PreviewExpressionPanel extends BasePanel<ExpressionType> {
         SHADOW_OWNER_REFERENCE_SEARCH(ExpressionEvaluatorType.SHADOW_OWNER_REFERENCE_SEARCH,
                 "ExpressionEvaluatorType.SHADOW_OWNER_REFERENCE_SEARCH"),
         PATH(ExpressionEvaluatorType.PATH,
-                "ExpressionEvaluatorType.PATH");
+                "ExpressionEvaluatorType.PATH"),
+        NULL(ExpressionEvaluatorType.NULL,
+                "ExpressionEvaluatorType.NULL");
 
         private final ExpressionEvaluatorType type;
         private final String translationKey;

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/resource/component/wizard/schemaHandling/objectType/attribute/mapping/preview/expression/PreviewExpressionPanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/resource/component/wizard/schemaHandling/objectType/attribute/mapping/preview/expression/PreviewExpressionPanel.java
@@ -54,7 +54,9 @@ public class PreviewExpressionPanel extends BasePanel<ExpressionType> {
         SHADOW_OWNER_REFERENCE_SEARCH(ExpressionEvaluatorType.SHADOW_OWNER_REFERENCE_SEARCH,
                 "ExpressionEvaluatorType.SHADOW_OWNER_REFERENCE_SEARCH"),
         PATH(ExpressionEvaluatorType.PATH,
-                "ExpressionEvaluatorType.PATH");
+                "ExpressionEvaluatorType.PATH"),
+        NULL_EXPRESSION(ExpressionEvaluatorType.NULL_EXPRESSION,
+                "ExpressionEvaluatorType.NULL_EXPRESSION");
 
         private final ExpressionEvaluatorType type;
         private final String translationKey;

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/util/ExpressionUtil.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/util/ExpressionUtil.java
@@ -55,7 +55,8 @@ public class ExpressionUtil {
         SCRIPT,
         GENERATE,
         ASSOCIATION_FROM_LINK,
-        SHADOW_OWNER_REFERENCE_SEARCH
+        SHADOW_OWNER_REFERENCE_SEARCH,
+        NULL
     }
 
     public enum Language {
@@ -108,6 +109,8 @@ public class ExpressionUtil {
     public static final String ELEMENT_ASSOCIATION_FROM_LINK_WITH_NS = "<associationFromLink";
     public static final String ELEMENT_SHADOW_OWNER_REFERENCE_SEARCH = "<shadowOwnerReferenceSearch/>";
     public static final String ELEMENT_SHADOW_OWNER_REFERENCE_SEARCH_WITH_NS = "<shadowOwnerReferenceSearch";
+    public static final String ELEMENT_NULL = "<null/>";
+    public static final String ELEMENT_NULL_WITH_NS = "<null";
 
     public static String getExpressionString(ExpressionEvaluatorType type, ObjectReferenceType policy) {
         if (ExpressionEvaluatorType.GENERATE.equals(type) && policy != null) {
@@ -174,6 +177,8 @@ public class ExpressionUtil {
             return ExpressionEvaluatorType.LITERAL;
         } else if (expression.contains(ELEMENT_ASSOCIATION_FROM_LINK) || expression.contains(ELEMENT_ASSOCIATION_FROM_LINK_WITH_NS)) {
             return ExpressionEvaluatorType.ASSOCIATION_FROM_LINK;
+        } else if (expression.contains(ELEMENT_NULL) || expression.contains(ELEMENT_NULL_WITH_NS)) {
+            return ExpressionEvaluatorType.NULL;
         }
 
         return null;
@@ -723,6 +728,23 @@ public class ExpressionUtil {
         AsIsExpressionEvaluatorType evaluator = new AsIsExpressionEvaluatorType();
         JAXBElement<AsIsExpressionEvaluatorType> element =
                 new JAXBElement<>(SchemaConstantsGenerated.C_AS_IS, AsIsExpressionEvaluatorType.class, evaluator);
+        expression.expressionEvaluator(element);
+    }
+
+    /**
+     * Makes the "null" evaluator the only evaluator of the expression.
+     * @param expression for which "null" evaluator should be set as sole evaluator.
+     */
+    public static void addNullExpressionValue(ExpressionType expression) {
+        if (expression == null) {
+            return;
+        }
+
+        expression.getExpressionEvaluator().clear();
+
+        NullExpressionEvaluatorType evaluator = new NullExpressionEvaluatorType();
+        JAXBElement<NullExpressionEvaluatorType> element =
+                new JAXBElement<>(SchemaConstantsGenerated.C_NULL, NullExpressionEvaluatorType.class, evaluator);
         expression.expressionEvaluator(element);
     }
 

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/util/ExpressionUtil.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/web/util/ExpressionUtil.java
@@ -55,7 +55,8 @@ public class ExpressionUtil {
         SCRIPT,
         GENERATE,
         ASSOCIATION_FROM_LINK,
-        SHADOW_OWNER_REFERENCE_SEARCH
+        SHADOW_OWNER_REFERENCE_SEARCH,
+        NULL_EXPRESSION
     }
 
     public enum Language {
@@ -108,6 +109,8 @@ public class ExpressionUtil {
     public static final String ELEMENT_ASSOCIATION_FROM_LINK_WITH_NS = "<associationFromLink";
     public static final String ELEMENT_SHADOW_OWNER_REFERENCE_SEARCH = "<shadowOwnerReferenceSearch/>";
     public static final String ELEMENT_SHADOW_OWNER_REFERENCE_SEARCH_WITH_NS = "<shadowOwnerReferenceSearch";
+    public static final String ELEMENT_NULL_EXPRESSION = "<null/>";
+    public static final String ELEMENT_NULL_EXPRESSION_WITH_NS = "<null";
 
     public static String getExpressionString(ExpressionEvaluatorType type, ObjectReferenceType policy) {
         if (ExpressionEvaluatorType.GENERATE.equals(type) && policy != null) {
@@ -174,6 +177,8 @@ public class ExpressionUtil {
             return ExpressionEvaluatorType.LITERAL;
         } else if (expression.contains(ELEMENT_ASSOCIATION_FROM_LINK) || expression.contains(ELEMENT_ASSOCIATION_FROM_LINK_WITH_NS)) {
             return ExpressionEvaluatorType.ASSOCIATION_FROM_LINK;
+        } else if (expression.contains(ELEMENT_NULL_EXPRESSION) || expression.contains(ELEMENT_NULL_EXPRESSION_WITH_NS)) {
+            return ExpressionEvaluatorType.NULL_EXPRESSION;
         }
 
         return null;
@@ -723,6 +728,23 @@ public class ExpressionUtil {
         AsIsExpressionEvaluatorType evaluator = new AsIsExpressionEvaluatorType();
         JAXBElement<AsIsExpressionEvaluatorType> element =
                 new JAXBElement<>(SchemaConstantsGenerated.C_AS_IS, AsIsExpressionEvaluatorType.class, evaluator);
+        expression.expressionEvaluator(element);
+    }
+
+    /**
+     * Makes the "null" evaluator the only evaluator of the expression.
+     * @param expression for which "null" evaluator should be set as sole evaluator.
+     */
+    public static void addNullExpressionValue(ExpressionType expression) {
+        if (expression == null) {
+            return;
+        }
+
+        expression.getExpressionEvaluator().clear();
+
+        NullExpressionEvaluatorType evaluator = new NullExpressionEvaluatorType();
+        JAXBElement<NullExpressionEvaluatorType> element =
+                new JAXBElement<>(SchemaConstantsGenerated.C_NULL, NullExpressionEvaluatorType.class, evaluator);
         expression.expressionEvaluator(element);
     }
 


### PR DESCRIPTION
- null evaluator has no configuration, so it is written into the expression on selection instead of by a panel. Recognized also in mapping preview.