### PR TITLE
Add authorization checks for connector wizard

### DIFF
--- a/docs/security/authorization/admin-gui.adoc
+++ b/docs/security/authorization/admin-gui.adoc
@@ -93,6 +93,12 @@ The authorization is also check while deciding if previewButton should be shown.
 Also, covers 'Create report' button on the Campaign details page.
 |
 
+| http://midpoint.evolveum.com/xml/ns/public/security/authorization-ui-3#connectorWizard
+| Connector generator wizard - GUI pages, REST API and the backend service that generates and executes connector code.
+Involves generating and running arbitrary connector code, so it is not granted by any out-of-the-box role, including Superuser (which reaches it only via `#all`).
+Grant it explicitly, only to administrators who need to generate connectors.
+| Since 4.11
+
 |===
 
 == Self-service Actions

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/PageConnectorDevelopment.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/PageConnectorDevelopment.java
@@ -31,10 +31,7 @@ import org.apache.wicket.request.mapper.parameter.PageParameters;
         },
         encoder = OnePageParameterEncoder.class,
         action = {
-                @AuthorizationAction(actionUri = AuthorizationConstants.AUTZ_UI_CONNECTOR_DEVELOPMENTS_ALL_URL,
-                        label = "PageAdminConnectorDevelopments.auth.connectorDevelopmentsAll.label",
-                        description = "PageAdminConnectorDevelopments.auth.connectorDevelopmentsAll.description"),
-                @AuthorizationAction(actionUri = AuthorizationConstants.AUTZ_UI_CONNECTOR_DEVELOPMENT_URL,
+                @AuthorizationAction(actionUri = AuthorizationConstants.AUTZ_UI_CONNECTOR_WIZARD_URL,
                         label = "PageAdminConnectorDevelopments.auth.connectorGenerator.label",
                         description = "PageAdminConnectorDevelopments.auth.connectorGenerator.description")
         })

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/PageConnectorDevelopments.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/PageConnectorDevelopments.java
@@ -30,15 +30,9 @@ import java.util.List;
                 @Url(mountUrl = "/admin/connectorDevelopments")
         },
         action = {
-                @AuthorizationAction(actionUri = AuthorizationConstants.AUTZ_UI_CONNECTOR_DEVELOPMENTS_ALL_URL,
-                        label = "PageAdminConnectorDevelopments.auth.connectorDevelopmentsAll.label",
-                        description = "PageAdminConnectorDevelopments.auth.connectorDevelopmentsAll.description"),
-                @AuthorizationAction(actionUri = AuthorizationConstants.AUTZ_UI_CONNECTOR_DEVELOPMENTS_URL,
-                        label = "PageConnectorDevelopments.auth.connectorDevelopments.label",
-                        description = "PageConnectorDevelopments.auth.connectorDevelopments.description")})
-//                @AuthorizationAction(actionUri = AuthorizationConstants.AUTZ_UI_CONNECTOR_DEVELOPMENTS_VIEW_URL,
-//                        label = "PageConnectorDevelopments.auth.connectorDevelopments.view.label",
-//                        description = "PageConnectorDevelopments.auth.connectorDevelopments.view.description")})
+                @AuthorizationAction(actionUri = AuthorizationConstants.AUTZ_UI_CONNECTOR_WIZARD_URL,
+                        label = "PageAdminConnectorDevelopments.auth.connectorGenerator.label",
+                        description = "PageAdminConnectorDevelopments.auth.connectorGenerator.description")})
 @CollectionInstance(identifier = "allConnectorDevelopments", applicableForType = ConnectorDevelopmentType.class,
         display = @PanelDisplay(label = "PageAdmin.menu.top.connectorDevelopments.list", singularLabel = "ObjectType.connectorDevelopment", icon = GuiStyleConstants.CLASS_OBJECT_CONNECTOR_ICON))
 public class PageConnectorDevelopments extends PageAdmin {

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/component/wizard/scimrest/MultiWaitingConnectorStepPanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/component/wizard/scimrest/MultiWaitingConnectorStepPanel.java
@@ -43,8 +43,6 @@ import com.evolveum.midpoint.schema.result.OperationResult;
 import com.evolveum.midpoint.smart.api.info.StatusInfo;
 import com.evolveum.midpoint.task.api.Task;
 import com.evolveum.midpoint.util.exception.CommonException;
-import com.evolveum.midpoint.util.exception.ObjectNotFoundException;
-import com.evolveum.midpoint.util.exception.SchemaException;
 import com.evolveum.midpoint.util.logging.Trace;
 import com.evolveum.midpoint.util.logging.TraceManager;
 import com.evolveum.midpoint.web.component.util.VisibleBehaviour;
@@ -209,7 +207,7 @@ public abstract class MultiWaitingConnectorStepPanel extends AbstractWizardStepP
 
     protected abstract List<ItemName> getActivityTypes();
 
-    protected abstract StatusInfo<?> obtainResult(ItemName activityType, String token, Task task, OperationResult result) throws SchemaException, ObjectNotFoundException;
+    protected abstract StatusInfo<?> obtainResult(ItemName activityType, String token, Task task, OperationResult result) throws CommonException;
 
     protected abstract String triggerOperation(Task task, OperationResult result);
 
@@ -232,7 +230,7 @@ public abstract class MultiWaitingConnectorStepPanel extends AbstractWizardStepP
                     Task task = app.createSimpleTask(OP_DETERMINE_STATUS);
                     OperationResult result = task.getResult();
                     return obtainResult(activityType, token, task, result);
-                } catch (SchemaException|ObjectNotFoundException e) {
+                } catch (CommonException e) {
                     throw new RuntimeException(e);
                 }
             }

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/component/wizard/scimrest/ScriptConnectorStepPanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/component/wizard/scimrest/ScriptConnectorStepPanel.java
@@ -35,8 +35,6 @@ import com.evolveum.midpoint.smart.api.conndev.ConnectorDevelopmentArtifacts;
 import com.evolveum.midpoint.smart.api.info.StatusInfo;
 import com.evolveum.midpoint.task.api.Task;
 import com.evolveum.midpoint.util.exception.CommonException;
-import com.evolveum.midpoint.util.exception.ObjectNotFoundException;
-import com.evolveum.midpoint.util.exception.SchemaException;
 import com.evolveum.midpoint.web.component.AceEditor;
 import com.evolveum.midpoint.web.component.AjaxIconButton;
 import com.evolveum.midpoint.web.page.admin.reports.component.SimpleAceEditorPanel;
@@ -107,7 +105,7 @@ public abstract class ScriptConnectorStepPanel extends AbstractWizardStepPanel<C
                 StatusInfo<ConnDevGenerateArtifactResultType> statusInfo;
                 try {
                     statusInfo = getDetailsModel().getServiceLocator().getConnectorService().getGenerateArtifactStatus(token, task, result);
-                } catch (SchemaException | ObjectNotFoundException e) {
+                } catch (CommonException e) {
                     throw new RuntimeException(e);
                 }
                 ConnDevGenerateArtifactResultType artifactResultType = statusInfo.getResult();

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/component/wizard/scimrest/ScriptsConnectorStepPanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/component/wizard/scimrest/ScriptsConnectorStepPanel.java
@@ -42,8 +42,6 @@ import com.evolveum.midpoint.smart.api.conndev.ConnectorDevelopmentArtifacts;
 import com.evolveum.midpoint.smart.api.info.StatusInfo;
 import com.evolveum.midpoint.task.api.Task;
 import com.evolveum.midpoint.util.exception.CommonException;
-import com.evolveum.midpoint.util.exception.ObjectNotFoundException;
-import com.evolveum.midpoint.util.exception.SchemaException;
 import com.evolveum.midpoint.web.component.AceEditor;
 import com.evolveum.midpoint.web.component.AjaxIconButton;
 import com.evolveum.midpoint.web.component.TabbedPanel;
@@ -116,7 +114,7 @@ public abstract class ScriptsConnectorStepPanel extends AbstractWizardStepPanel<
                     StatusInfo<ConnDevGenerateArtifactResultType> statusInfo;
                     try {
                         statusInfo = getDetailsModel().getServiceLocator().getConnectorService().getGenerateArtifactStatus(tokenEntry.getValue(), task, result);
-                    } catch (SchemaException | ObjectNotFoundException e) {
+                    } catch (CommonException e) {
                         throw new RuntimeException(e);
                     }
                     ConnDevGenerateArtifactResultType artifactResultType = statusInfo.getResult();

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/component/wizard/scimrest/WaitingConnectorExportingStepPanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/component/wizard/scimrest/WaitingConnectorExportingStepPanel.java
@@ -14,8 +14,7 @@ import com.evolveum.midpoint.prism.path.ItemName;
 import com.evolveum.midpoint.schema.result.OperationResult;
 import com.evolveum.midpoint.smart.api.info.StatusInfo;
 import com.evolveum.midpoint.task.api.Task;
-import com.evolveum.midpoint.util.exception.ObjectNotFoundException;
-import com.evolveum.midpoint.util.exception.SchemaException;
+import com.evolveum.midpoint.util.exception.CommonException;
 import com.evolveum.midpoint.web.application.PanelDisplay;
 import com.evolveum.midpoint.web.application.PanelInstance;
 import com.evolveum.midpoint.web.application.PanelType;
@@ -55,7 +54,7 @@ public class WaitingConnectorExportingStepPanel extends WaitingConnectorStepPane
     }
 
     @Override
-    protected StatusInfo<?> obtainResult(String token, Task task, OperationResult result) throws SchemaException, ObjectNotFoundException {
+    protected StatusInfo<?> obtainResult(String token, Task task, OperationResult result) throws CommonException {
         return getDetailsModel().getServiceLocator().getConnectorService().getExportConnectorStatus(token, task, result);
     }
 

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/component/wizard/scimrest/WaitingConnectorStepPanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/component/wizard/scimrest/WaitingConnectorStepPanel.java
@@ -32,8 +32,6 @@ import com.evolveum.midpoint.smart.api.conndev.ConnectorDevelopmentArtifacts;
 import com.evolveum.midpoint.smart.api.info.StatusInfo;
 import com.evolveum.midpoint.task.api.Task;
 import com.evolveum.midpoint.util.exception.CommonException;
-import com.evolveum.midpoint.util.exception.ObjectNotFoundException;
-import com.evolveum.midpoint.util.exception.SchemaException;
 import com.evolveum.midpoint.util.logging.Trace;
 import com.evolveum.midpoint.util.logging.TraceManager;
 import com.evolveum.midpoint.web.component.util.VisibleEnableBehaviour;
@@ -200,7 +198,7 @@ public abstract class WaitingConnectorStepPanel extends AbstractWizardStepPanel<
                             Task task = app.createSimpleTask(OP_DETERMINE_STATUS);
                             OperationResult result = task.getResult();
                             return obtainResult(tokenModel.getObject(), task, result);
-                        } catch (SchemaException|ObjectNotFoundException e) {
+                        } catch (CommonException e) {
                             throw new RuntimeException(e);
                         }
                     }
@@ -233,7 +231,7 @@ public abstract class WaitingConnectorStepPanel extends AbstractWizardStepPanel<
         return null;
     };
 
-    protected abstract StatusInfo<?> obtainResult(String token, Task task, OperationResult result) throws SchemaException, ObjectNotFoundException;
+    protected abstract StatusInfo<?> obtainResult(String token, Task task, OperationResult result) throws CommonException;
 
     protected abstract String getNewTaskToken(Task task, OperationResult result, boolean regenerate);
 

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/component/wizard/scimrest/WaitingObjectClassScriptConnectorStepPanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/component/wizard/scimrest/WaitingObjectClassScriptConnectorStepPanel.java
@@ -13,8 +13,7 @@ import com.evolveum.midpoint.prism.Containerable;
 import com.evolveum.midpoint.schema.result.OperationResult;
 import com.evolveum.midpoint.smart.api.info.StatusInfo;
 import com.evolveum.midpoint.task.api.Task;
-import com.evolveum.midpoint.util.exception.ObjectNotFoundException;
-import com.evolveum.midpoint.util.exception.SchemaException;
+import com.evolveum.midpoint.util.exception.CommonException;
 import com.evolveum.midpoint.xml.ns._public.common.common_3.ConnDevObjectClassInfoType;
 
 import org.apache.commons.lang3.StringUtils;
@@ -52,7 +51,7 @@ public abstract class WaitingObjectClassScriptConnectorStepPanel extends Waiting
     }
 
     @Override
-    protected StatusInfo<?> obtainResult(String token, Task task, OperationResult result) throws SchemaException, ObjectNotFoundException {
+    protected StatusInfo<?> obtainResult(String token, Task task, OperationResult result) throws CommonException {
         return getDetailsModel().getServiceLocator().getConnectorService().getGenerateArtifactStatus(token, task, result);
     }
 

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/component/wizard/scimrest/basic/DocumentationConnectorStepPanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/component/wizard/scimrest/basic/DocumentationConnectorStepPanel.java
@@ -46,7 +46,6 @@ import com.evolveum.midpoint.schema.util.SmartMetadataUtil;
 import com.evolveum.midpoint.smart.api.info.StatusInfo;
 import com.evolveum.midpoint.task.api.Task;
 import com.evolveum.midpoint.util.exception.CommonException;
-import com.evolveum.midpoint.util.exception.ObjectNotFoundException;
 import com.evolveum.midpoint.util.exception.SchemaException;
 import com.evolveum.midpoint.util.logging.Trace;
 import com.evolveum.midpoint.util.logging.TraceManager;
@@ -128,7 +127,7 @@ public class DocumentationConnectorStepPanel extends AbstractWizardStepPanel<Con
                 try {
                     statusInfo =
                             getDetailsModel().getServiceLocator().getConnectorService().getDiscoverDocumentationStatus(token, task, result);
-                } catch (SchemaException | ObjectNotFoundException e) {
+                } catch (CommonException e) {
                     throw new RuntimeException(e);
                 }
                 ConnDevDiscoverDocumentationResultType documentationResultBean = statusInfo.getResult();

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/component/wizard/scimrest/basic/WaitingConnectorCreatingConnectorStepPanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/component/wizard/scimrest/basic/WaitingConnectorCreatingConnectorStepPanel.java
@@ -27,7 +27,7 @@ import com.evolveum.midpoint.prism.Containerable;
 import com.evolveum.midpoint.schema.result.OperationResult;
 import com.evolveum.midpoint.smart.api.info.StatusInfo;
 import com.evolveum.midpoint.task.api.Task;
-import com.evolveum.midpoint.util.exception.ObjectNotFoundException;
+import com.evolveum.midpoint.util.exception.CommonException;
 import com.evolveum.midpoint.util.exception.SchemaException;
 import com.evolveum.midpoint.web.application.PanelDisplay;
 import com.evolveum.midpoint.web.application.PanelInstance;
@@ -59,7 +59,7 @@ public class WaitingConnectorCreatingConnectorStepPanel extends WaitingConnector
     }
 
     @Override
-    protected StatusInfo<?> obtainResult(String token, Task task, OperationResult result) throws SchemaException, ObjectNotFoundException {
+    protected StatusInfo<?> obtainResult(String token, Task task, OperationResult result) throws CommonException {
         return getDetailsModel().getServiceLocator().getConnectorService().getCreateConnectorStatus(token, task, result);
     }
 

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/component/wizard/scimrest/basic/WaitingForDocumentationConnectorStepPanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/component/wizard/scimrest/basic/WaitingForDocumentationConnectorStepPanel.java
@@ -17,8 +17,7 @@ import com.evolveum.midpoint.prism.path.ItemName;
 import com.evolveum.midpoint.schema.result.OperationResult;
 import com.evolveum.midpoint.smart.api.info.StatusInfo;
 import com.evolveum.midpoint.task.api.Task;
-import com.evolveum.midpoint.util.exception.ObjectNotFoundException;
-import com.evolveum.midpoint.util.exception.SchemaException;
+import com.evolveum.midpoint.util.exception.CommonException;
 import com.evolveum.midpoint.web.application.PanelDisplay;
 import com.evolveum.midpoint.web.application.PanelInstance;
 import com.evolveum.midpoint.web.application.PanelType;
@@ -44,7 +43,7 @@ public class WaitingForDocumentationConnectorStepPanel extends WaitingConnectorS
     }
 
     @Override
-    protected StatusInfo<?> obtainResult(String token, Task task, OperationResult result) throws SchemaException, ObjectNotFoundException {
+    protected StatusInfo<?> obtainResult(String token, Task task, OperationResult result) throws CommonException {
         return getDetailsModel().getServiceLocator().getConnectorService().getDiscoverDocumentationStatus(token, task, result);
     }
 

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/component/wizard/scimrest/connection/WaitingAuthScriptsConnectorStepPanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/component/wizard/scimrest/connection/WaitingAuthScriptsConnectorStepPanel.java
@@ -16,8 +16,7 @@ import com.evolveum.midpoint.schema.result.OperationResult;
 import com.evolveum.midpoint.smart.api.conndev.ConnectorDevelopmentArtifacts;
 import com.evolveum.midpoint.smart.api.info.StatusInfo;
 import com.evolveum.midpoint.task.api.Task;
-import com.evolveum.midpoint.util.exception.ObjectNotFoundException;
-import com.evolveum.midpoint.util.exception.SchemaException;
+import com.evolveum.midpoint.util.exception.CommonException;
 import com.evolveum.midpoint.web.application.PanelDisplay;
 import com.evolveum.midpoint.web.application.PanelInstance;
 import com.evolveum.midpoint.web.application.PanelType;
@@ -47,7 +46,7 @@ public class WaitingAuthScriptsConnectorStepPanel extends WaitingScriptConnector
     }
 
     @Override
-    protected StatusInfo<?> obtainResult(String token, Task task, OperationResult result) throws SchemaException, ObjectNotFoundException {
+    protected StatusInfo<?> obtainResult(String token, Task task, OperationResult result) throws CommonException {
         return getDetailsModel().getServiceLocator().getConnectorService().getGenerateArtifactStatus(token, task, result);
     }
 

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/component/wizard/scimrest/connection/WaitingBasicInfoConnectorStepPanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/component/wizard/scimrest/connection/WaitingBasicInfoConnectorStepPanel.java
@@ -16,8 +16,7 @@ import com.evolveum.midpoint.prism.path.ItemPath;
 import com.evolveum.midpoint.schema.result.OperationResult;
 import com.evolveum.midpoint.smart.api.info.StatusInfo;
 import com.evolveum.midpoint.task.api.Task;
-import com.evolveum.midpoint.util.exception.ObjectNotFoundException;
-import com.evolveum.midpoint.util.exception.SchemaException;
+import com.evolveum.midpoint.util.exception.CommonException;
 import com.evolveum.midpoint.web.application.PanelDisplay;
 import com.evolveum.midpoint.web.application.PanelInstance;
 import com.evolveum.midpoint.web.application.PanelType;
@@ -47,7 +46,7 @@ public class WaitingBasicInfoConnectorStepPanel extends WaitingConnectorStepPane
     }
 
     @Override
-    protected StatusInfo<?> obtainResult(String token, Task task, OperationResult result) throws SchemaException, ObjectNotFoundException {
+    protected StatusInfo<?> obtainResult(String token, Task task, OperationResult result) throws CommonException {
         return getDetailsModel().getServiceLocator().getConnectorService().getDiscoverBasicInformationStatus(token, task, result);
     }
 

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/component/wizard/scimrest/connection/WaitingConnectivityEndpointConnectorStepPanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/component/wizard/scimrest/connection/WaitingConnectivityEndpointConnectorStepPanel.java
@@ -16,8 +16,7 @@ import com.evolveum.midpoint.prism.path.ItemPath;
 import com.evolveum.midpoint.schema.result.OperationResult;
 import com.evolveum.midpoint.smart.api.info.StatusInfo;
 import com.evolveum.midpoint.task.api.Task;
-import com.evolveum.midpoint.util.exception.ObjectNotFoundException;
-import com.evolveum.midpoint.util.exception.SchemaException;
+import com.evolveum.midpoint.util.exception.CommonException;
 import com.evolveum.midpoint.web.application.PanelDisplay;
 import com.evolveum.midpoint.web.application.PanelInstance;
 import com.evolveum.midpoint.web.application.PanelType;
@@ -49,7 +48,7 @@ public class WaitingConnectivityEndpointConnectorStepPanel extends WaitingConnec
 
     @Override
     protected StatusInfo<?> obtainResult(String token, Task task, OperationResult result)
-            throws SchemaException, ObjectNotFoundException {
+            throws CommonException {
         return getDetailsModel().getServiceLocator().getConnectorService()
                 .getDiscoverConnectivityEndpointStatus(token, task, result);
     }

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/component/wizard/scimrest/connection/WaitingSchemaConnectorStepPanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/component/wizard/scimrest/connection/WaitingSchemaConnectorStepPanel.java
@@ -14,8 +14,7 @@ import com.evolveum.midpoint.prism.path.ItemName;
 import com.evolveum.midpoint.schema.result.OperationResult;
 import com.evolveum.midpoint.smart.api.info.StatusInfo;
 import com.evolveum.midpoint.task.api.Task;
-import com.evolveum.midpoint.util.exception.ObjectNotFoundException;
-import com.evolveum.midpoint.util.exception.SchemaException;
+import com.evolveum.midpoint.util.exception.CommonException;
 import com.evolveum.midpoint.web.application.PanelDisplay;
 import com.evolveum.midpoint.web.application.PanelInstance;
 import com.evolveum.midpoint.web.application.PanelType;
@@ -50,7 +49,7 @@ public class WaitingSchemaConnectorStepPanel extends WaitingConnectorStepPanel {
     }
 
     @Override
-    protected StatusInfo<?> obtainResult(String token, Task task, OperationResult result) throws SchemaException, ObjectNotFoundException {
+    protected StatusInfo<?> obtainResult(String token, Task task, OperationResult result) throws CommonException {
         return getDetailsModel().getServiceLocator().getConnectorService().getRefreshSchemaStatus(token, task, result);
     }
 

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/component/wizard/scimrest/objectclass/WaitingObjectClassInformationStepPanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/component/wizard/scimrest/objectclass/WaitingObjectClassInformationStepPanel.java
@@ -22,8 +22,7 @@ import com.evolveum.midpoint.prism.Containerable;
 import com.evolveum.midpoint.schema.result.OperationResult;
 import com.evolveum.midpoint.smart.api.info.StatusInfo;
 import com.evolveum.midpoint.task.api.Task;
-import com.evolveum.midpoint.util.exception.ObjectNotFoundException;
-import com.evolveum.midpoint.util.exception.SchemaException;
+import com.evolveum.midpoint.util.exception.CommonException;
 import com.evolveum.midpoint.web.application.PanelDisplay;
 import com.evolveum.midpoint.web.application.PanelInstance;
 import com.evolveum.midpoint.web.application.PanelType;
@@ -46,7 +45,7 @@ public class WaitingObjectClassInformationStepPanel extends WaitingConnectorStep
     }
 
     @Override
-    protected StatusInfo<?> obtainResult(String token, Task task, OperationResult result) throws SchemaException, ObjectNotFoundException {
+    protected StatusInfo<?> obtainResult(String token, Task task, OperationResult result) throws CommonException {
         return getDetailsModel().getServiceLocator().getConnectorService().getDiscoverObjectClassInformationStatus(token, task, result);
     }
 

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/component/wizard/scimrest/objectclass/schema/WaitingObjectClassDetailsConnectorStepPanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/component/wizard/scimrest/objectclass/schema/WaitingObjectClassDetailsConnectorStepPanel.java
@@ -24,8 +24,7 @@ import com.evolveum.midpoint.prism.Containerable;
 import com.evolveum.midpoint.schema.result.OperationResult;
 import com.evolveum.midpoint.smart.api.info.StatusInfo;
 import com.evolveum.midpoint.task.api.Task;
-import com.evolveum.midpoint.util.exception.ObjectNotFoundException;
-import com.evolveum.midpoint.util.exception.SchemaException;
+import com.evolveum.midpoint.util.exception.CommonException;
 import com.evolveum.midpoint.web.application.PanelDisplay;
 import com.evolveum.midpoint.web.application.PanelInstance;
 import com.evolveum.midpoint.web.application.PanelType;
@@ -64,7 +63,7 @@ public class WaitingObjectClassDetailsConnectorStepPanel extends MultiWaitingCon
 
     @Override
     protected StatusInfo<?> obtainResult(ItemName activityType, String token, Task task, OperationResult result)
-            throws SchemaException, ObjectNotFoundException {
+            throws CommonException {
         var service = getDetailsModel().getServiceLocator().getConnectorService();
         if (WorkDefinitionsType.F_DISCOVER_OBJECT_CLASS_ENDPOINTS.equals(activityType)) {
             return service.getDiscoverObjectClassEndpointsStatus(token, task, result);

--- a/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/component/wizard/scimrest/relation/WaitingRelationshipScriptConnectorStepPanel.java
+++ b/gui/admin-gui/src/main/java/com/evolveum/midpoint/gui/impl/page/admin/connector/development/component/wizard/scimrest/relation/WaitingRelationshipScriptConnectorStepPanel.java
@@ -30,7 +30,7 @@ import com.evolveum.midpoint.prism.Containerable;
 import com.evolveum.midpoint.schema.result.OperationResult;
 import com.evolveum.midpoint.smart.api.info.StatusInfo;
 import com.evolveum.midpoint.task.api.Task;
-import com.evolveum.midpoint.util.exception.ObjectNotFoundException;
+import com.evolveum.midpoint.util.exception.CommonException;
 import com.evolveum.midpoint.util.exception.SchemaException;
 import com.evolveum.midpoint.web.application.PanelDisplay;
 import com.evolveum.midpoint.web.application.PanelInstance;
@@ -62,7 +62,7 @@ public class WaitingRelationshipScriptConnectorStepPanel extends WaitingScriptCo
     }
 
     @Override
-    protected StatusInfo<?> obtainResult(String token, Task task, OperationResult result) throws SchemaException, ObjectNotFoundException {
+    protected StatusInfo<?> obtainResult(String token, Task task, OperationResult result) throws CommonException {
         return getDetailsModel().getServiceLocator().getConnectorService().getGenerateArtifactStatus(token, task, result);
     }
 

--- a/model/authentication-api/src/main/java/com/evolveum/midpoint/authentication/api/authorization/EndPointsUrlMapping.java
+++ b/model/authentication-api/src/main/java/com/evolveum/midpoint/authentication/api/authorization/EndPointsUrlMapping.java
@@ -203,10 +203,8 @@ public enum EndPointsUrlMapping {
                     "PageSimulationResults.authUri.simulationsAll.label", "PageSimulationResults.authUri.simulationsAll.description")),
 
     CONNECTOR_DEVELOPMENT_DETAILS("/admin/connectorGenerator/**",
-            new AuthorizationActionValue(AUTZ_UI_CONNECTOR_DEVELOPMENT_URL,
+            new AuthorizationActionValue(AUTZ_UI_CONNECTOR_WIZARD_URL,
                     "PageAdminConnectorDevelopments.auth.connectorGenerator.label", "PageAdminConnectorDevelopments.auth.connectorGenerator.description"),
-            new AuthorizationActionValue(AUTZ_UI_CONNECTOR_DEVELOPMENTS_ALL_URL,
-                    "PageAdminConnectorDevelopments.auth.connectorDevelopmentsAll.label", "PageAdminConnectorDevelopments.auth.connectorDevelopmentsAll.description"),
             new AuthorizationActionValue(AUTZ_GUI_ALL_URL,
                     "PageAdminConnectorDevelopments.authUri.guiAll.label", "PageAdminConnectorDevelopments.authUri.guiAll.description")),
 

--- a/model/rest-impl/src/main/java/com/evolveum/midpoint/rest/impl/ConnectorDevelopmentRestController.java
+++ b/model/rest-impl/src/main/java/com/evolveum/midpoint/rest/impl/ConnectorDevelopmentRestController.java
@@ -12,6 +12,8 @@ import com.evolveum.midpoint.model.api.util.ConnectorGeneratorConstants;
 import com.evolveum.midpoint.model.api.util.SmartIntegrationOperationExecutor;
 import com.evolveum.midpoint.prism.PrismObject;
 import com.evolveum.midpoint.schema.result.OperationResult;
+import com.evolveum.midpoint.security.api.AuthorizationConstants;
+import com.evolveum.midpoint.security.enforcer.api.SecurityEnforcer;
 import com.evolveum.midpoint.smart.api.conndev.ConnectorDevelopmentOperation;
 import com.evolveum.midpoint.smart.api.conndev.ConnectorDevelopmentService;
 import com.evolveum.midpoint.smart.api.info.StatusInfo;
@@ -58,10 +60,12 @@ public class ConnectorDevelopmentRestController extends AbstractRestController {
     public static final String OPERATION_DISCOVER_OBJECT_CLASS_ENDPOINTS = CLASS_DOT + "DiscoverObjectClassEndpoints";
     public static final String OPERATION_DISCOVER_CONNECTIVITY_ENDPOINTS = CLASS_DOT + "DiscoverConnectivityEndpoints";
     public static final String OPERATION_REFRESH_SCHEMA = CLASS_DOT + "RefreshSchema";
+    public static final String OPERATION_DOWNLOAD_CONNECTOR = CLASS_DOT + "DownloadConnector";
 
     @Autowired private ConnectorDevelopmentService connectorDevelopmentService;
     @Autowired private MidpointConfiguration configuration;
     @Autowired private ModelService modelService;
+    @Autowired private SecurityEnforcer securityEnforcer;
 
     @PostMapping(ConnectorGeneratorConstants.RPC_START_FROM_NEW)
     public ResponseEntity<?> startFromNew(
@@ -463,45 +467,56 @@ public class ConnectorDevelopmentRestController extends AbstractRestController {
     public ResponseEntity<?> downloadConnector(
             @RequestParam("name") @NotNull String name,
             HttpServletResponse response
-    ) throws IOException {
-        Configuration config = configuration.getConfiguration(MidpointConfiguration.ICF_CONFIGURATION);
-        List<Object> dirs = config.getList("scanDirectory");
+    ) {
+        var task = initRequest();
+        var result = createSubresult(task, OPERATION_DOWNLOAD_CONNECTOR);
 
-        File downloadDirectory = dirs.stream()
-                .filter(d -> d != null && d.toString().contains("connid-connectors"))
-                .findFirst()
-                .map(Object::toString)
-                .map(File::new)
-                .orElse(null);
+        try {
+            securityEnforcer.authorize(AuthorizationConstants.AUTZ_UI_CONNECTOR_WIZARD_URL, task, result);
 
-        if (downloadDirectory == null || !downloadDirectory.exists()) {
-            return ResponseEntity.internalServerError().body("Base connector directory configuration not found.");
+            Configuration config = configuration.getConfiguration(MidpointConfiguration.ICF_CONFIGURATION);
+            List<Object> dirs = config.getList("scanDirectory");
+
+            File downloadDirectory = dirs.stream()
+                    .filter(d -> d != null && d.toString().contains("connid-connectors"))
+                    .findFirst()
+                    .map(Object::toString)
+                    .map(File::new)
+                    .orElse(null);
+
+            if (downloadDirectory == null || !downloadDirectory.exists()) {
+                return ResponseEntity.internalServerError().body("Base connector directory configuration not found.");
+            }
+
+            File connectorDir = new File(downloadDirectory, name);
+
+            String canonicalBase = downloadDirectory.getCanonicalPath();
+            String canonicalTarget = connectorDir.getCanonicalPath();
+
+            if (!canonicalTarget.equals(canonicalBase + "/" + name)) {
+                return ResponseEntity.internalServerError().body("Invalid name or version format.");
+            }
+
+            if (!connectorDir.exists() || !connectorDir.isDirectory()) {
+                return ResponseEntity.internalServerError().body("Connector directory not found.");
+            }
+
+            response.setContentType("application/jar");
+            String cleanFileName = name.replaceAll("[^a-zA-Z0-9.-]", "_") + ".jar";
+
+            response.setHeader(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"" + cleanFileName + "\"");
+
+            try (JarOutputStream jarOutputStream = new JarOutputStream(response.getOutputStream())) {
+                jarDirectory(connectorDir, connectorDir, jarOutputStream);
+                jarOutputStream.flush();
+            }
+
+            return ResponseEntity.ok().build();
+        } catch (Exception e) {
+            return handleException(result, e);
+        } finally {
+            finishRequest(task, result);
         }
-
-        File connectorDir = new File(downloadDirectory, name);
-
-        String canonicalBase = downloadDirectory.getCanonicalPath();
-        String canonicalTarget = connectorDir.getCanonicalPath();
-
-        if (!canonicalTarget.equals(canonicalBase + "/" + name)) {
-            return ResponseEntity.internalServerError().body("Invalid name or version format.");
-        }
-
-        if (!connectorDir.exists() || !connectorDir.isDirectory()) {
-            return ResponseEntity.internalServerError().body("Connector directory not found.");
-        }
-
-        response.setContentType("application/jar");
-        String cleanFileName = name.replaceAll("[^a-zA-Z0-9.-]", "_") + ".jar";
-
-        response.setHeader(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"" + cleanFileName + "\"");
-
-        try (JarOutputStream jarOutputStream = new JarOutputStream(response.getOutputStream())) {
-            jarDirectory(connectorDir, connectorDir, jarOutputStream);
-            jarOutputStream.flush();
-        }
-
-        return ResponseEntity.ok().build();
     }
 
     private void jarDirectory(File rootDir, File currentFile, JarOutputStream jarOutputStream) throws IOException {
@@ -543,6 +558,8 @@ public class ConnectorDevelopmentRestController extends AbstractRestController {
             CommunicationException,
             ConfigurationException,
             ObjectNotFoundException, SubscriptionComplianceException {
+        securityEnforcer.authorize(AuthorizationConstants.AUTZ_UI_CONNECTOR_WIZARD_URL, task, result);
+
         PrismObject<ConnectorDevelopmentType> connectorDevelopmentType = modelService.getObject(
                 ConnectorDevelopmentType.class,
                 oid,

--- a/model/smart-api/src/main/java/com/evolveum/midpoint/smart/api/conndev/ConnectorDevelopmentService.java
+++ b/model/smart-api/src/main/java/com/evolveum/midpoint/smart/api/conndev/ConnectorDevelopmentService.java
@@ -18,29 +18,29 @@ public interface ConnectorDevelopmentService {
     ConnectorDevelopmentOperation continueFrom(ConnectorDevelopmentType type);
 
 
-    StatusInfo<ConnDevCreateConnectorResultType> getCreateConnectorStatus(String token, Task task, OperationResult result) throws SchemaException, ObjectNotFoundException;
+    StatusInfo<ConnDevCreateConnectorResultType> getCreateConnectorStatus(String token, Task task, OperationResult result) throws CommonException;
 
-    StatusInfo<ConnDevDiscoverGlobalInformationResultType> getDiscoverBasicInformationStatus(String token, Task task, OperationResult result) throws SchemaException, ObjectNotFoundException;
+    StatusInfo<ConnDevDiscoverGlobalInformationResultType> getDiscoverBasicInformationStatus(String token, Task task, OperationResult result) throws CommonException;
 
-    StatusInfo<ConnDevDiscoverDocumentationResultType> getDiscoverDocumentationStatus(String token, Task task, OperationResult result) throws SchemaException, ObjectNotFoundException;
+    StatusInfo<ConnDevDiscoverDocumentationResultType> getDiscoverDocumentationStatus(String token, Task task, OperationResult result) throws CommonException;
 
-    StatusInfo<ConnDevProcessDocumentationResultType> getProcessDocumentationStatus(String token, Task task, OperationResult result) throws SchemaException, ObjectNotFoundException;
+    StatusInfo<ConnDevProcessDocumentationResultType> getProcessDocumentationStatus(String token, Task task, OperationResult result) throws CommonException;
 
-    StatusInfo<ConnDevGenerateArtifactResultType> getGenerateArtifactStatus(String token, Task task, OperationResult result) throws SchemaException, ObjectNotFoundException;
+    StatusInfo<ConnDevGenerateArtifactResultType> getGenerateArtifactStatus(String token, Task task, OperationResult result) throws CommonException;
 
     StatusInfo<ConnDevFixObjectClassResultType> getFixObjectClassStatus(String token, Task task, OperationResult result) throws SchemaException, ObjectNotFoundException;
 
     StatusInfo<ConnDevDiscoverObjectClassInformationResultType> getDiscoverObjectClassInformationStatus(String token, Task task, OperationResult result) throws SchemaException, ObjectNotFoundException;
 
-    StatusInfo<ConnDevDiscoverObjectClassAttributesResultType> getDiscoverObjectClassAttributesStatus(String token, Task task, OperationResult result) throws SchemaException, ObjectNotFoundException;
+    StatusInfo<ConnDevDiscoverObjectClassAttributesResultType> getDiscoverObjectClassAttributesStatus(String token, Task task, OperationResult result) throws CommonException;
 
-    StatusInfo<ConnDevDiscoverObjectClassEndpointsResultType> getDiscoverObjectClassEndpointsStatus(String token, Task task, OperationResult result) throws SchemaException, ObjectNotFoundException;
+    StatusInfo<ConnDevDiscoverObjectClassEndpointsResultType> getDiscoverObjectClassEndpointsStatus(String token, Task task, OperationResult result) throws CommonException;
 
-    StatusInfo<ConnDevRefreshSchemaResultType> getRefreshSchemaStatus(String token, Task task, OperationResult result) throws SchemaException, ObjectNotFoundException;
+    StatusInfo<ConnDevRefreshSchemaResultType> getRefreshSchemaStatus(String token, Task task, OperationResult result) throws CommonException;
 
-    StatusInfo<ConnDevDiscoverConnectivityEndpointResultType> getDiscoverConnectivityEndpointStatus(String token, Task task, OperationResult result) throws SchemaException, ObjectNotFoundException;
+    StatusInfo<ConnDevDiscoverConnectivityEndpointResultType> getDiscoverConnectivityEndpointStatus(String token, Task task, OperationResult result) throws CommonException;
 
-    StatusInfo<ConnDevExportConnectorResultType> getExportConnectorStatus(String token, Task task, OperationResult result) throws SchemaException, ObjectNotFoundException;
+    StatusInfo<ConnDevExportConnectorResultType> getExportConnectorStatus(String token, Task task, OperationResult result) throws CommonException;
 
     /**
      * Cluster-aware download of an exported connector bundle jar, previously stored under

--- a/model/smart-impl/pom.xml
+++ b/model/smart-impl/pom.xml
@@ -65,11 +65,11 @@
             <artifactId>repo-common</artifactId>
             <version>${project.version}</version>
         </dependency>
-        <!--<dependency>-->
-        <!--    <groupId>com.evolveum.midpoint.repo</groupId>-->
-        <!--    <artifactId>security-enforcer-api</artifactId>-->
-        <!--    <version>${project.version}</version>-->
-        <!--</dependency>-->
+        <dependency>
+            <groupId>com.evolveum.midpoint.repo</groupId>
+            <artifactId>security-enforcer-api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
         <!--<dependency>-->
         <!--    <groupId>com.evolveum.midpoint.infra</groupId>-->
         <!--    <artifactId>common</artifactId>-->

--- a/model/smart-impl/src/main/java/com/evolveum/midpoint/smart/impl/conndev/ConnectorDevelopmentServiceImpl.java
+++ b/model/smart-impl/src/main/java/com/evolveum/midpoint/smart/impl/conndev/ConnectorDevelopmentServiceImpl.java
@@ -19,6 +19,8 @@ import com.evolveum.midpoint.schema.GetOperationOptionsBuilder;
 import com.evolveum.midpoint.schema.SelectorOptions;
 import com.evolveum.midpoint.schema.processor.BareResourceSchema;
 import com.evolveum.midpoint.schema.result.OperationResult;
+import com.evolveum.midpoint.security.api.AuthorizationConstants;
+import com.evolveum.midpoint.security.enforcer.api.SecurityEnforcer;
 import com.evolveum.midpoint.smart.api.conndev.ConnDevArtifactValidationResult;
 import com.evolveum.midpoint.smart.api.conndev.ConnectorDevelopmentArtifacts;
 import com.evolveum.midpoint.smart.api.conndev.ConnectorDevelopmentOperation;
@@ -60,6 +62,7 @@ public class ConnectorDevelopmentServiceImpl implements ConnectorDevelopmentServ
     @Autowired private TaskManager taskManager;
     @Autowired private ModelService modelService;
     @Autowired private ClusterExecutionHelper clusterExecutionHelper;
+    @Autowired private SecurityEnforcer securityEnforcer;
 
     private static ConnectorDevelopmentServiceImpl instance;
 
@@ -335,6 +338,8 @@ public class ConnectorDevelopmentServiceImpl implements ConnectorDevelopmentServ
 
     private String submitTask(String name, WorkDefinitionsType work, Task task, OperationResult result) {
         try {
+            securityEnforcer.authorize(AuthorizationConstants.AUTZ_UI_CONNECTOR_WIZARD_URL, task, result);
+
             var oid = modelInteractionService.submit(
                     new ActivityDefinitionType()
                             .work(work),
@@ -364,51 +369,54 @@ public class ConnectorDevelopmentServiceImpl implements ConnectorDevelopmentServ
                 .build();
     }
 
-    private @NotNull TaskType getTask(String oid, OperationResult result) throws ObjectNotFoundException, SchemaException {
+    private @NotNull TaskType getTask(String oid, Task task, OperationResult result)
+            throws ObjectNotFoundException, SchemaException, SecurityViolationException, ExpressionEvaluationException,
+            CommunicationException, ConfigurationException, SubscriptionComplianceException {
+        securityEnforcer.authorize(AuthorizationConstants.AUTZ_UI_CONNECTOR_WIZARD_URL, task, result);
         return taskManager
                 .getObject(TaskType.class, oid, taskRetrievalOptions(), result)
                 .asObjectable();
     }
 
     @Override
-    public StatusInfo<ConnDevCreateConnectorResultType> getCreateConnectorStatus(String token, Task task, OperationResult result) throws SchemaException, ObjectNotFoundException {
+    public StatusInfo<ConnDevCreateConnectorResultType> getCreateConnectorStatus(String token, Task task, OperationResult result) throws CommonException {
         return new StatusInfoImpl<>(
-                getTask(token,result),
+                getTask(token, task, result),
                 ConnDevCreateConnectorWorkStateType.F_RESULT,
                 ConnDevCreateConnectorResultType.class);
     }
 
     @Override
-    public StatusInfoImpl<ConnDevDiscoverGlobalInformationResultType> getDiscoverBasicInformationStatus(String token, Task testTask, OperationResult result) throws SchemaException, ObjectNotFoundException {
+    public StatusInfoImpl<ConnDevDiscoverGlobalInformationResultType> getDiscoverBasicInformationStatus(String token, Task task, OperationResult result) throws CommonException {
         return new StatusInfoImpl<>(
-                getTask(token,result),
+                getTask(token, task, result),
                 ConnDevCreateConnectorWorkStateType.F_RESULT,
                 ConnDevDiscoverGlobalInformationResultType.class
                 );
     }
 
     @Override
-    public StatusInfo<ConnDevDiscoverDocumentationResultType> getDiscoverDocumentationStatus(String token, Task task, OperationResult result) throws SchemaException, ObjectNotFoundException {
+    public StatusInfo<ConnDevDiscoverDocumentationResultType> getDiscoverDocumentationStatus(String token, Task task, OperationResult result) throws CommonException {
         return new StatusInfoImpl<>(
-                getTask(token,result),
+                getTask(token, task, result),
                 ConnDevCreateConnectorWorkStateType.F_RESULT,
                 ConnDevDiscoverDocumentationResultType.class
         );
     }
 
     @Override
-    public StatusInfo<ConnDevProcessDocumentationResultType> getProcessDocumentationStatus(String token, Task task, OperationResult result) throws SchemaException, ObjectNotFoundException {
+    public StatusInfo<ConnDevProcessDocumentationResultType> getProcessDocumentationStatus(String token, Task task, OperationResult result) throws CommonException {
         return new StatusInfoImpl<>(
-                getTask(token,result),
+                getTask(token, task, result),
                 ConnDevCreateConnectorWorkStateType.F_RESULT,
                 ConnDevProcessDocumentationResultType.class
         );
     }
 
     @Override
-    public StatusInfo<ConnDevGenerateArtifactResultType> getGenerateArtifactStatus(String token, Task task, OperationResult result) throws SchemaException, ObjectNotFoundException {
+    public StatusInfo<ConnDevGenerateArtifactResultType> getGenerateArtifactStatus(String token, Task task, OperationResult result) throws CommonException {
         return new StatusInfoImpl<>(
-                getTask(token,result),
+                getTask(token, task, result),
                 ConnDevCreateConnectorWorkStateType.F_RESULT,
                 ConnDevGenerateArtifactResultType.class
         );
@@ -426,52 +434,52 @@ public class ConnectorDevelopmentServiceImpl implements ConnectorDevelopmentServ
     @Override
     public StatusInfo<ConnDevDiscoverObjectClassInformationResultType> getDiscoverObjectClassInformationStatus(String token, Task task, OperationResult result) throws SchemaException, ObjectNotFoundException {
         return new StatusInfoImpl<>(
-                getTask(token,result),
+                getTask(token, task, result),
                 ConnDevCreateConnectorWorkStateType.F_RESULT,
                 ConnDevDiscoverObjectClassInformationResultType.class
         );
     }
 
     @Override
-    public StatusInfo<ConnDevDiscoverObjectClassAttributesResultType> getDiscoverObjectClassAttributesStatus(String token, Task task, OperationResult result) throws SchemaException, ObjectNotFoundException {
+    public StatusInfo<ConnDevDiscoverObjectClassAttributesResultType> getDiscoverObjectClassAttributesStatus(String token, Task task, OperationResult result) throws CommonException {
         return new StatusInfoImpl<>(
-                getTask(token, result),
+                getTask(token, task, result),
                 ConnDevCreateConnectorWorkStateType.F_RESULT,
                 ConnDevDiscoverObjectClassAttributesResultType.class
         );
     }
 
     @Override
-    public StatusInfo<ConnDevDiscoverObjectClassEndpointsResultType> getDiscoverObjectClassEndpointsStatus(String token, Task task, OperationResult result) throws SchemaException, ObjectNotFoundException {
+    public StatusInfo<ConnDevDiscoverObjectClassEndpointsResultType> getDiscoverObjectClassEndpointsStatus(String token, Task task, OperationResult result) throws CommonException {
         return new StatusInfoImpl<>(
-                getTask(token, result),
+                getTask(token, task, result),
                 ConnDevCreateConnectorWorkStateType.F_RESULT,
                 ConnDevDiscoverObjectClassEndpointsResultType.class
         );
     }
 
     @Override
-    public StatusInfo<ConnDevRefreshSchemaResultType> getRefreshSchemaStatus(String token, Task task, OperationResult result) throws SchemaException, ObjectNotFoundException {
+    public StatusInfo<ConnDevRefreshSchemaResultType> getRefreshSchemaStatus(String token, Task task, OperationResult result) throws CommonException {
         return new StatusInfoImpl<>(
-                getTask(token, result),
+                getTask(token, task, result),
                 ConnDevRefreshSchemaWorkStateType.F_RESULT,
                 ConnDevRefreshSchemaResultType.class
         );
     }
 
     @Override
-    public StatusInfo<ConnDevDiscoverConnectivityEndpointResultType> getDiscoverConnectivityEndpointStatus(String token, Task task, OperationResult result) throws SchemaException, ObjectNotFoundException {
+    public StatusInfo<ConnDevDiscoverConnectivityEndpointResultType> getDiscoverConnectivityEndpointStatus(String token, Task task, OperationResult result) throws CommonException {
         return new StatusInfoImpl<>(
-                getTask(token, result),
+                getTask(token, task, result),
                 ConnDevCreateConnectorWorkStateType.F_RESULT,
                 ConnDevDiscoverConnectivityEndpointResultType.class
         );
     }
 
     @Override
-    public StatusInfo<ConnDevExportConnectorResultType> getExportConnectorStatus(String token, Task task, OperationResult result) throws SchemaException, ObjectNotFoundException {
+    public StatusInfo<ConnDevExportConnectorResultType> getExportConnectorStatus(String token, Task task, OperationResult result) throws CommonException {
         return new StatusInfoImpl<>(
-                getTask(token, result),
+                getTask(token, task, result),
                 ConnDevExportConnectorWorkStateType.F_RESULT,
                 ConnDevExportConnectorResultType.class
         );

--- a/repo/security-api/src/main/java/com/evolveum/midpoint/security/api/AuthorizationConstants.java
+++ b/repo/security-api/src/main/java/com/evolveum/midpoint/security/api/AuthorizationConstants.java
@@ -216,15 +216,9 @@ public class AuthorizationConstants {
     public static final QName AUTZ_UI_APPLICATION_EDIT_QNAME = new QName(NS_AUTHORIZATION_UI, "applicationEdit");
     public static final String AUTZ_UI_APPLICATION_EDIT_URL = NS_AUTHORIZATION_UI + "#applicationEdit";
 
-    //connectors
-    public static final QName AUTZ_UI_CONNECTOR_DEVELOPMENTS_ALL_QNAME = new QName(NS_AUTHORIZATION_UI, "connectorDevelopmentsAll");
-    public static final String AUTZ_UI_CONNECTOR_DEVELOPMENTS_ALL_URL = NS_AUTHORIZATION_UI + "#connectorDevelopmentsAll";
-
-    public static final QName AUTZ_UI_CONNECTOR_DEVELOPMENTS_QNAME = new QName(NS_AUTHORIZATION_UI, "connectorDevelopments");
-    public static final String AUTZ_UI_CONNECTOR_DEVELOPMENTS_URL = NS_AUTHORIZATION_UI + "#connectorDevelopments";
-
-    public static final QName AUTZ_UI_CONNECTOR_DEVELOPMENT_QNAME = new QName(NS_AUTHORIZATION_UI, "connectorDevelopment");
-    public static final String AUTZ_UI_CONNECTOR_DEVELOPMENT_URL = NS_AUTHORIZATION_UI + "#connectorDevelopment";
+    // connector generator wizard
+    public static final QName AUTZ_UI_CONNECTOR_WIZARD_QNAME = new QName(NS_AUTHORIZATION_UI, "connectorWizard");
+    public static final String AUTZ_UI_CONNECTOR_WIZARD_URL = NS_AUTHORIZATION_UI + "#connectorWizard";
 
     //message template
     public static final QName AUTZ_UI_MESSAGE_TEMPLATE_QNAME = new QName(NS_AUTHORIZATION_UI, "messageTemplate");


### PR DESCRIPTION
Connector generator had no authorization check on its REST API and backend. Any account with REST access could use it to generate and run connector code. This adds a dedicated authorization for the wizard, checked in the backend, since that check cannot live in the REST/GUI URL mapping alone.

Task: 12090